### PR TITLE
feat: integrate Claude Agent SDK as primary execution engine

### DIFF
--- a/docs/reviews/capability-review-2026-05-27.md
+++ b/docs/reviews/capability-review-2026-05-27.md
@@ -1,0 +1,54 @@
+# Spark Agent 全能 Code Agent 能力评审报告
+
+日期: 2026-05-27
+评审者: Claude Code Agent
+
+## 总体评估
+
+总评分：58/100（骨架完整但核心执行深度不足）
+
+~40k 行 TypeScript，5 个包 + 1 个 Electron 桌面应用。支持 Claude/OpenAI 双模型内核，
+具备文件操作、Shell 命令、MCP 工具、权限审批、会话管理、规则合成等基础能力。
+
+## 核心能力评分
+
+| 维度 | 评分 | 关键差距 |
+|------|------|----------|
+| Agent Loop | 65 | 串行单工具、无 checkpoint、粗糙 token 估算 |
+| Model Adapters | 72 | 无 Claude Agent SDK 集成、无 fallback/retry |
+| Tool System | 60 | 编辑工具原始、无代码索引、无沙箱 |
+| Context Management | 45 | Context Governor 未实现、无 RAG |
+| Permission & Security | 70 | 无文件系统沙箱、无网络隔离 |
+| Multi-Agent | 15 | 几乎完全未实现 |
+| Workflow | 10 | 纯 UI 装饰 |
+| MCP Integration | 55 | 无工具分组、无 resource/prompt 支持 |
+| UI/UX | 55 | 无代码编辑器、无终端、无虚拟列表 |
+| Testing & Quality | 60 | 无 CI/CD、UI 测试几乎为零 |
+
+## 核心改进建议
+
+### P0 — 已执行
+1. **集成 Claude Agent SDK** → 已实现 ClaudeSDKExecutor
+2. **CI/CD Pipeline** → 待创建 GitHub Actions
+3. **文件编辑工具升级** → SDK 原生 Edit 工具
+
+### P1 — 高优先级
+- Context Governor MVP
+- Checkpoint / 会话分支
+- 代码索引与语义检索
+- Self-Correction 机制
+- Model Fallback & Retry
+
+### P2 — 中优先级
+- Monaco Editor 集成
+- 终端 PTY 集成
+- 虚拟列表
+- Multi-Agent 编排基础
+- Workflow 执行引擎
+
+## 竞品对比结论
+
+与 Claude Code CLI 的核心差距在于 agent 执行质量（工具精度、上下文智能、自修复）。
+集成 Claude Agent SDK 是缩短差距的最快路径。
+
+**核心建议：聚焦深度，克制广度。**

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -22,6 +22,9 @@
     "openai": "^6.39.0",
     "zod": "^3.23.0"
   },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.152"
+  },
   "devDependencies": {
     "typescript": "^5.5.0",
     "vitest": "^2.0.0"

--- a/packages/agent-runtime/src/__tests__/services/session.service.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/session.service.test.ts
@@ -48,6 +48,13 @@ vi.mock('../../services/mcp-server.service.js', () => ({
   })),
 }))
 
+// SDK not available in test environment — forces fallback to direct API path
+vi.mock('../../sdk/index.js', () => ({
+  ClaudeSDKExecutor: vi.fn(),
+  isSDKAvailable: vi.fn(async () => false),
+  SDKNotAvailableError: class extends Error { constructor() { super('SDK not available') } },
+}))
+
 import {
   SessionRepository,
   EventRepository,
@@ -271,6 +278,8 @@ describe('SessionService.sendTurn', () => {
     expect(typeof result.turnId).toBe('string')
     expect(loop.onEvent).toHaveBeenCalled()
     expect(loop.executeTurn).toHaveBeenCalled()
+    // Default adapter for anthropic is 'claude-sdk', but SDK is unavailable in tests,
+    // so it falls back to direct API using 'claude' adapter type
     expect(createAdapter).toHaveBeenCalledWith('claude', 'chat')
   })
 
@@ -416,6 +425,8 @@ describe('SessionService.sendTurn', () => {
     const svc = new SessionService(mockDb, vi.fn())
     await svc.sendTurn({ sessionId: 'sess-1', message: 'hello' })
 
+    // Default adapter for anthropic is 'claude-sdk', but SDK is unavailable in tests,
+    // so it falls back to direct API using 'claude' adapter type
     expect(createAdapter).toHaveBeenCalledWith('claude', 'chat')
   })
 

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -39,3 +39,8 @@ export { buildSkillSystemPrompt } from './skills/types.js'
 export { BUILTIN_SKILLS, getBuiltinSkill } from './skills/builtin/index.js'
 export { McpClient, McpToolBridge } from './mcp/index.js'
 export type { McpServerInfo, McpToolDefinition, McpToolResult, McpConnectionStatus, McpTransportConfig, StdioTransportConfig, SseTransportConfig } from './mcp/index.js'
+
+// Claude Agent SDK integration
+export { ClaudeSDKExecutor, isSDKAvailable, SDKNotAvailableError } from './sdk/index.js'
+export { mapPermissionMode, mergeToolPermissions } from './sdk/index.js'
+export type { SDKExecutorConfig, SDKMcpServerConfig, SDKPermissionConfig, SparkPermissionMode } from './sdk/index.js'

--- a/packages/agent-runtime/src/sdk/claude-sdk-executor.ts
+++ b/packages/agent-runtime/src/sdk/claude-sdk-executor.ts
@@ -1,0 +1,235 @@
+/**
+ * Claude Agent SDK Executor
+ *
+ * Wraps @anthropic-ai/claude-agent-sdk to provide a full agent execution
+ * engine that leverages Claude Code's battle-tested tools (Read, Edit, Bash,
+ * Grep, Glob), agent loop, checkpoint system, and MCP integration.
+ *
+ * This executor REPLACES our own AgentLoop + ToolRegistry when selected,
+ * delegating all tool execution, permission handling, and agent reasoning
+ * to the SDK. Spark's role becomes:
+ *   - Session & UI management
+ *   - System prompt composition (rules + skills + context)
+ *   - MCP server configuration passthrough
+ *   - Permission mode mapping
+ *   - Event stream translation (SDK messages → Spark AgentEvent)
+ *   - Usage tracking & cost recording
+ *
+ * The SDK's query() returns an AsyncGenerator<SDKMessage>. We iterate it,
+ * map each message to Spark AgentEvents, and emit them through our event
+ * system so the existing UI renders correctly.
+ *
+ * When the SDK is unavailable (not installed), the executor throws
+ * SDKNotAvailableError so SessionService can fall back to direct API.
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { AgentEvent } from '@spark/protocol'
+import { AgentEventEmitter } from '../core/event-emitter.js'
+import { mapSDKMessageToEvents } from './event-mapper.js'
+import { mapPermissionMode, mergeToolPermissions, mapReasoningEffort } from './permission-mapper.js'
+import type { SDKExecutorConfig, SDKMessage, SDKQueryFunction, SDKQueryOptions } from './types.js'
+
+type SDKModule = { query: SDKQueryFunction }
+
+let sdkModule: SDKModule | null = null
+let sdkLoadAttempted = false
+
+async function loadSDK(): Promise<SDKModule | null> {
+  if (sdkLoadAttempted) return sdkModule
+  sdkLoadAttempted = true
+  try {
+    sdkModule = await import('@anthropic-ai/claude-agent-sdk') as SDKModule
+    return sdkModule
+  } catch {
+    sdkModule = null
+    return null
+  }
+}
+
+export async function isSDKAvailable(): Promise<boolean> {
+  const sdk = await loadSDK()
+  return sdk != null
+}
+
+export function resetSDKLoadState(): void {
+  sdkLoadAttempted = false
+  sdkModule = null
+}
+
+export class ClaudeSDKExecutor {
+  private emitter = new AgentEventEmitter()
+  private abortController: AbortController | null = null
+
+  onEvent(listener: (event: AgentEvent) => void): void {
+    this.emitter.on(listener)
+  }
+
+  offEvent(listener: (event: AgentEvent) => void): void {
+    this.emitter.off(listener)
+  }
+
+  cancel(): void {
+    this.abortController?.abort()
+  }
+
+  async executeTurn(
+    sessionId: string,
+    turnId: string,
+    userMessage: string,
+    config: SDKExecutorConfig,
+  ): Promise<void> {
+    const sdk = await loadSDK()
+    if (sdk == null) {
+      throw new SDKNotAvailableError()
+    }
+
+    this.abortController = new AbortController()
+    const ctx = { sessionId, turnId }
+    const makeBase = () => ({
+      id: randomUUID(),
+      sessionId,
+      turnId,
+      timestamp: new Date().toISOString(),
+      seq: 0,
+    })
+
+    // Emit user message
+    this.emitter.emit({
+      ...makeBase(),
+      type: 'user_message',
+      content: userMessage,
+    })
+
+    this.emitter.emit({
+      ...makeBase(),
+      type: 'agent_status',
+      status: 'thinking',
+    })
+
+    // Build permission config
+    const permConfig = mapPermissionMode(config.permissionMode)
+    const mergedPerms = mergeToolPermissions(
+      permConfig,
+      config.allowedTools,
+      config.disallowedTools,
+    )
+
+    // Build composite system prompt
+    const systemPrompt = buildCompositeSystemPrompt(config)
+
+    // Build SDK options
+    const options: SDKQueryOptions = {
+      abortController: this.abortController,
+      model: config.model,
+      cwd: config.workspaceRootPath,
+      env: {
+        ...process.env,
+        ANTHROPIC_API_KEY: config.apiKey,
+        ...(config.apiEndpoint != null ? { ANTHROPIC_BASE_URL: config.apiEndpoint } : {}),
+      },
+
+      // Use Claude Code's built-in system prompt as base, append our customizations
+      systemPrompt: systemPrompt != null
+        ? { type: 'preset', preset: 'claude_code', append: systemPrompt }
+        : { type: 'preset', preset: 'claude_code' },
+
+      permissionMode: mergedPerms.permissionMode,
+      ...(mergedPerms.allowedTools.length > 0 ? { allowedTools: mergedPerms.allowedTools } : {}),
+      ...(mergedPerms.disallowedTools.length > 0 ? { disallowedTools: mergedPerms.disallowedTools } : {}),
+      ...(config.mcpServers != null ? { mcpServers: config.mcpServers } : {}),
+
+      maxTurns: config.maxTurnCount ?? 25,
+      ...(config.maxBudgetUsd != null ? { maxBudgetUsd: config.maxBudgetUsd } : {}),
+      effort: mapReasoningEffort(config.reasoningEffort),
+
+      includePartialMessages: true,
+      enableFileCheckpointing: config.enableCheckpoints ?? false,
+
+      // Map Spark approval callback to SDK permission callback
+      ...(config.approvalCallback != null ? {
+        canUseTool: async (
+          toolName: string,
+          input: Record<string, unknown>,
+        ): Promise<{ behavior: 'allow' } | { behavior: 'deny'; message: string }> => {
+          try {
+            const allowed = await config.approvalCallback!(sessionId, toolName, input)
+            return allowed
+              ? { behavior: 'allow' }
+              : { behavior: 'deny', message: 'User denied tool execution' }
+          } catch {
+            return { behavior: 'deny', message: 'Permission check failed' }
+          }
+        },
+      } : {}),
+    }
+
+    try {
+      const queryResult = sdk.query({ prompt: userMessage, options })
+
+      for await (const message of queryResult) {
+        if (this.abortController.signal.aborted) break
+
+        const events = mapSDKMessageToEvents(message, ctx)
+        for (const event of events) {
+          this.emitter.emit(event)
+        }
+      }
+    } catch (err) {
+      if (this.abortController.signal.aborted) {
+        this.emitter.emit({
+          ...makeBase(),
+          type: 'agent_error',
+          code: 'ABORTED',
+          message: 'Turn cancelled by user',
+          retryable: false,
+        })
+        this.emitter.emit({
+          ...makeBase(),
+          type: 'agent_status',
+          status: 'cancelled',
+        })
+      } else {
+        this.emitter.emit({
+          ...makeBase(),
+          type: 'agent_error',
+          code: 'SDK_ERROR',
+          message: err instanceof Error ? err.message : String(err),
+          retryable: true,
+          rawError: err instanceof Error ? `${err.name}: ${err.message}` : String(err),
+        })
+        this.emitter.emit({
+          ...makeBase(),
+          type: 'agent_status',
+          status: 'error',
+        })
+      }
+    }
+  }
+}
+
+function buildCompositeSystemPrompt(config: SDKExecutorConfig): string | undefined {
+  const sections: string[] = []
+
+  if (config.skillSystemPrompt?.trim()) {
+    sections.push(config.skillSystemPrompt)
+  }
+
+  if (config.systemPrompt?.trim()) {
+    sections.push(config.systemPrompt)
+  }
+
+  if (sections.length === 0) return undefined
+  return sections.join('\n\n')
+}
+
+export class SDKNotAvailableError extends Error {
+  constructor() {
+    super(
+      'Claude Agent SDK (@anthropic-ai/claude-agent-sdk) is not installed or failed to load. '
+      + 'Install it with: pnpm add @anthropic-ai/claude-agent-sdk\n'
+      + 'Falling back to direct Anthropic API adapter.',
+    )
+    this.name = 'SDKNotAvailableError'
+  }
+}

--- a/packages/agent-runtime/src/sdk/event-mapper.ts
+++ b/packages/agent-runtime/src/sdk/event-mapper.ts
@@ -1,0 +1,308 @@
+/**
+ * Maps Claude Agent SDK messages → Spark AgentEvent stream.
+ *
+ * The SDK delivers messages via an AsyncGenerator. Each message has a `type`
+ * field indicating what it represents. We convert these to Spark's granular
+ * event types so the existing UI timeline renders correctly.
+ *
+ * Message flow (with streaming):
+ *   system(init) → stream_event(content_block_delta)... → assistant(complete)
+ *   → tool execution → user(tool_result) → ... → result(success/error)
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { AgentEvent } from '@spark/protocol'
+import type {
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKResultMessage,
+  SDKSystemMessage,
+  SDKStreamEvent,
+  SDKContentBlock,
+} from './types.js'
+
+interface EventContext {
+  sessionId: string
+  turnId: string
+}
+
+function baseEvent(ctx: EventContext) {
+  return {
+    id: randomUUID(),
+    sessionId: ctx.sessionId,
+    turnId: ctx.turnId,
+    timestamp: new Date().toISOString(),
+    seq: 0,
+  }
+}
+
+/**
+ * Convert a single SDK message into a sequence of AgentEvents.
+ * Called once for each message yielded by the SDK's AsyncGenerator.
+ */
+export function mapSDKMessageToEvents(
+  message: SDKMessage,
+  ctx: EventContext,
+): AgentEvent[] {
+  switch (message.type) {
+    case 'system':
+      return mapSystemMessage(message as SDKSystemMessage, ctx)
+    case 'assistant':
+      return mapAssistantMessage(message as SDKAssistantMessage, ctx)
+    case 'stream_event':
+      return mapStreamEvent(message as SDKStreamEvent, ctx)
+    case 'result':
+      return mapResultMessage(message as SDKResultMessage, ctx)
+    default:
+      return []
+  }
+}
+
+function mapSystemMessage(msg: SDKSystemMessage, ctx: EventContext): AgentEvent[] {
+  if (msg.subtype !== 'init') return []
+  return [{
+    ...baseEvent(ctx),
+    type: 'agent_status',
+    status: 'thinking',
+    message: `Initialized with model ${msg.model}, ${msg.tools.length} tools, ${msg.mcp_servers.length} MCP servers`,
+  }]
+}
+
+function mapAssistantMessage(msg: SDKAssistantMessage, ctx: EventContext): AgentEvent[] {
+  const events: AgentEvent[] = []
+  const content = msg.message.content
+
+  for (const block of content) {
+    events.push(...mapContentBlock(block, ctx))
+  }
+
+  // Emit usage if available
+  if (msg.message.usage) {
+    const cacheHit = msg.message.usage.cache_read_input_tokens
+    events.push({
+      ...baseEvent(ctx),
+      type: 'usage_update',
+      provider: 'claude',
+      model: msg.message.model ?? '',
+      inputTokens: msg.message.usage.input_tokens,
+      outputTokens: msg.message.usage.output_tokens,
+      ...(cacheHit != null ? { cacheHitTokens: cacheHit } : {}),
+    })
+  }
+
+  return events
+}
+
+function mapStreamEvent(msg: SDKStreamEvent, ctx: EventContext): AgentEvent[] {
+  const event = msg.event
+  if (event == null) return []
+
+  switch (event.type) {
+    case 'content_block_delta': {
+      const delta = event.delta
+      if (delta == null) return []
+
+      if (delta.type === 'text_delta' && delta.text != null) {
+        return [{
+          ...baseEvent(ctx),
+          type: 'assistant_message',
+          mode: 'delta',
+          content: delta.text,
+          provider: 'claude',
+          isFinal: false,
+        }]
+      }
+
+      if (delta.type === 'thinking_delta' && delta.thinking != null) {
+        return [{
+          ...baseEvent(ctx),
+          type: 'agent_thinking',
+          mode: 'delta',
+          content: delta.thinking,
+        }]
+      }
+
+      return []
+    }
+
+    case 'content_block_start': {
+      const block = event.content_block
+      if (block == null) return []
+
+      if (block.type === 'tool_use' && block.id != null && block.name != null) {
+        return [{
+          ...baseEvent(ctx),
+          type: 'agent_status',
+          status: 'calling_tool',
+          message: `Calling ${mapSDKToolName(block.name)}`,
+        }]
+      }
+      return []
+    }
+
+    case 'message_start': {
+      const usage = event.message?.usage
+      if (usage) {
+        return [{
+          ...baseEvent(ctx),
+          type: 'usage_update',
+          provider: 'claude',
+          model: '',
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens,
+        }]
+      }
+      return []
+    }
+
+    default:
+      return []
+  }
+}
+
+function mapResultMessage(msg: SDKResultMessage, ctx: EventContext): AgentEvent[] {
+  const events: AgentEvent[] = []
+
+  // Final usage update
+  events.push({
+    ...baseEvent(ctx),
+    type: 'usage_update',
+    provider: 'claude',
+    model: '',
+    inputTokens: msg.usage.input_tokens,
+    outputTokens: msg.usage.output_tokens,
+    cacheHitTokens: msg.usage.cache_read_input_tokens,
+    estimatedCostUsd: msg.total_cost_usd,
+  })
+
+  if (msg.subtype === 'success') {
+    if (msg.result != null && msg.result.length > 0) {
+      events.push({
+        ...baseEvent(ctx),
+        type: 'assistant_message',
+        mode: 'complete',
+        content: msg.result,
+        provider: 'claude',
+        isFinal: true,
+      })
+    }
+    events.push({
+      ...baseEvent(ctx),
+      type: 'agent_status',
+      status: 'completed',
+    })
+  } else {
+    const errorMsg = msg.errors?.join('; ') ?? `Turn ended: ${msg.subtype}`
+    events.push({
+      ...baseEvent(ctx),
+      type: 'agent_error',
+      code: msg.subtype.toUpperCase(),
+      message: errorMsg,
+      retryable: msg.subtype !== 'error_max_budget_usd',
+    })
+    events.push({
+      ...baseEvent(ctx),
+      type: 'agent_status',
+      status: 'error',
+    })
+  }
+
+  return events
+}
+
+function mapContentBlock(block: SDKContentBlock, ctx: EventContext): AgentEvent[] {
+  switch (block.type) {
+    case 'text':
+      return [{
+        ...baseEvent(ctx),
+        type: 'assistant_message',
+        mode: 'complete',
+        content: block.text,
+        provider: 'claude',
+        isFinal: false,
+      }]
+
+    case 'thinking':
+      return [{
+        ...baseEvent(ctx),
+        type: 'agent_thinking',
+        mode: 'complete',
+        content: block.thinking,
+      }]
+
+    case 'tool_use':
+      return [{
+        ...baseEvent(ctx),
+        type: 'tool_call',
+        toolCallId: block.id,
+        toolName: mapSDKToolName(block.name),
+        toolInput: normalizeToolInput(block.input),
+        source: isSDKMcpTool(block.name) ? 'mcp' : 'builtin',
+        ...(isSDKMcpTool(block.name) ? { mcpServerId: extractMcpServerId(block.name) } : {}),
+      }]
+
+    case 'tool_result': {
+      const isError = block.is_error === true
+      const content = typeof block.content === 'string'
+        ? block.content
+        : flattenContentBlocks(block.content)
+      return [{
+        ...baseEvent(ctx),
+        type: 'tool_result',
+        toolCallId: block.tool_use_id,
+        toolName: 'unknown',
+        status: isError ? 'error' : 'success',
+        ...(isError ? { error: content } : { output: content }),
+      }]
+    }
+
+    default:
+      return []
+  }
+}
+
+/**
+ * The SDK uses tool names like "Read", "Edit", "Bash", "mcp__server__tool".
+ * Map them to Spark's display naming for the UI.
+ */
+function mapSDKToolName(sdkName: string): string {
+  const mapping: Record<string, string> = {
+    'Read': 'read_file',
+    'Write': 'write_file',
+    'Edit': 'edit_file',
+    'MultiEdit': 'multi_edit',
+    'Bash': 'bash',
+    'Glob': 'search_files',
+    'Grep': 'grep',
+    'TodoRead': 'todo_read',
+    'TodoWrite': 'todo_write',
+    'WebFetch': 'web_fetch',
+    'WebSearch': 'web_search',
+    'Agent': 'subagent',
+  }
+  return mapping[sdkName] ?? sdkName
+}
+
+function isSDKMcpTool(name: string): boolean {
+  return name.startsWith('mcp__')
+}
+
+function extractMcpServerId(name: string): string {
+  const parts = name.split('__')
+  return parts[1] ?? 'unknown'
+}
+
+function normalizeToolInput(input: unknown): Record<string, unknown> {
+  if (input == null) return {}
+  if (typeof input === 'object' && !Array.isArray(input)) return input as Record<string, unknown>
+  return { value: input }
+}
+
+function flattenContentBlocks(blocks: SDKContentBlock[]): string {
+  return blocks
+    .map((b) => {
+      if (b.type === 'text') return b.text
+      return JSON.stringify(b)
+    })
+    .join('\n')
+}

--- a/packages/agent-runtime/src/sdk/index.ts
+++ b/packages/agent-runtime/src/sdk/index.ts
@@ -1,0 +1,18 @@
+export { ClaudeSDKExecutor, isSDKAvailable, resetSDKLoadState, SDKNotAvailableError } from './claude-sdk-executor.js'
+export { mapPermissionMode, mergeToolPermissions, mapReasoningEffort } from './permission-mapper.js'
+export type { SDKPermissionConfig } from './permission-mapper.js'
+export { mapSDKMessageToEvents } from './event-mapper.js'
+export type {
+  SDKExecutorConfig,
+  SDKMcpServerConfig,
+  SDKMessage,
+  SDKAssistantMessage,
+  SDKResultMessage,
+  SDKSystemMessage,
+  SDKStreamEvent,
+  SDKContentBlock,
+  SDKQueryOptions,
+  SDKPermissionMode,
+  SDKEffort,
+  SparkPermissionMode,
+} from './types.js'

--- a/packages/agent-runtime/src/sdk/permission-mapper.ts
+++ b/packages/agent-runtime/src/sdk/permission-mapper.ts
@@ -1,0 +1,103 @@
+/**
+ * Maps Spark permission modes ↔ Claude Agent SDK permission modes.
+ *
+ * Spark has 8 permission modes (claude-* and codex-*).
+ * The Claude Agent SDK supports: default, acceptEdits, bypassPermissions, plan, dontAsk, auto.
+ *
+ * This module converts between the two systems and also builds the
+ * allowedTools / disallowedTools arrays the SDK expects.
+ */
+
+import type { SparkPermissionMode, SDKPermissionMode } from './types.js'
+
+export interface SDKPermissionConfig {
+  permissionMode: SDKPermissionMode
+  allowedTools: string[]
+  disallowedTools: string[]
+}
+
+const ALWAYS_DENIED_PATTERNS = [
+  'Bash(rm -rf /:*)',
+  'Bash(:(){ :|:& };::*)',
+  'Bash(mkfs:*)',
+  'Bash(dd if=/dev/zero:*)',
+]
+
+export function mapPermissionMode(sparkMode: SparkPermissionMode): SDKPermissionConfig {
+  switch (sparkMode) {
+    case 'claude-plan':
+      return {
+        permissionMode: 'plan',
+        allowedTools: [],
+        disallowedTools: ALWAYS_DENIED_PATTERNS,
+      }
+
+    case 'claude-ask':
+    case 'codex-default':
+      return {
+        permissionMode: 'default',
+        allowedTools: [],
+        disallowedTools: ALWAYS_DENIED_PATTERNS,
+      }
+
+    case 'claude-auto-edits':
+    case 'codex-auto-review':
+      return {
+        permissionMode: 'acceptEdits',
+        allowedTools: [],
+        disallowedTools: ALWAYS_DENIED_PATTERNS,
+      }
+
+    case 'claude-auto':
+      return {
+        permissionMode: 'auto',
+        allowedTools: [],
+        disallowedTools: ALWAYS_DENIED_PATTERNS,
+      }
+
+    case 'claude-bypass':
+    case 'codex-full-access':
+      return {
+        permissionMode: 'bypassPermissions',
+        allowedTools: [],
+        disallowedTools: ALWAYS_DENIED_PATTERNS,
+      }
+
+    default:
+      return {
+        permissionMode: 'default',
+        allowedTools: [],
+        disallowedTools: ALWAYS_DENIED_PATTERNS,
+      }
+  }
+}
+
+export function mergeToolPermissions(
+  base: SDKPermissionConfig,
+  extraAllowed?: string[],
+  extraDisallowed?: string[],
+): SDKPermissionConfig {
+  const allowed = base.allowedTools.slice()
+  const disallowed = base.disallowedTools.slice()
+
+  if (extraAllowed) {
+    for (const tool of extraAllowed) {
+      if (!allowed.includes(tool)) allowed.push(tool)
+    }
+  }
+  if (extraDisallowed) {
+    for (const tool of extraDisallowed) {
+      if (!disallowed.includes(tool)) disallowed.push(tool)
+    }
+  }
+
+  return { ...base, allowedTools: allowed, disallowedTools: disallowed }
+}
+
+/**
+ * Map Spark reasoning effort levels to SDK effort levels.
+ */
+export function mapReasoningEffort(effort?: 'low' | 'medium' | 'high' | 'xhigh'): 'low' | 'medium' | 'high' | 'xhigh' | 'max' | undefined {
+  if (effort === 'xhigh') return 'max'
+  return effort
+}

--- a/packages/agent-runtime/src/sdk/types.ts
+++ b/packages/agent-runtime/src/sdk/types.ts
@@ -1,0 +1,204 @@
+/**
+ * Types for Claude Agent SDK (@anthropic-ai/claude-agent-sdk) integration.
+ *
+ * These mirror the SDK's public API surface so we can type-check our executor
+ * without hard-coupling to the SDK package at compile time.
+ * When the SDK is not installed the executor gracefully falls back.
+ *
+ * Source: https://code.claude.com/docs/en/agent-sdk/typescript
+ * Package: @anthropic-ai/claude-agent-sdk ^0.3.152
+ */
+
+// ── SDK Message Types ───────────────────────────────────────────────────────
+
+export interface SDKAssistantMessage {
+  type: 'assistant'
+  uuid: string
+  session_id: string
+  message: {
+    role: 'assistant'
+    content: SDKContentBlock[]
+    model?: string
+    usage?: { input_tokens: number; output_tokens: number; cache_read_input_tokens?: number; cache_creation_input_tokens?: number }
+  }
+  parent_tool_use_id: string | null
+  error?: string
+}
+
+export interface SDKResultMessage {
+  type: 'result'
+  subtype: 'success' | 'error_max_turns' | 'error_during_execution' | 'error_max_budget_usd'
+  uuid: string
+  session_id: string
+  duration_ms: number
+  duration_api_ms: number
+  is_error: boolean
+  num_turns: number
+  result?: string
+  total_cost_usd: number
+  usage: {
+    input_tokens: number
+    output_tokens: number
+    cache_read_input_tokens: number
+    cache_creation_input_tokens: number
+  }
+  modelUsage?: Record<string, {
+    inputTokens: number
+    outputTokens: number
+    cacheReadInputTokens: number
+    cacheCreationInputTokens: number
+    costUSD: number
+  }>
+  errors?: string[]
+}
+
+export interface SDKSystemMessage {
+  type: 'system'
+  subtype: 'init'
+  uuid: string
+  session_id: string
+  tools: string[]
+  model: string
+  permissionMode: string
+  mcp_servers: Array<{ name: string; status: string }>
+  cwd: string
+  skills: string[]
+}
+
+export interface SDKStreamEvent {
+  type: 'stream_event'
+  event: {
+    type: string
+    delta?: { type: string; text?: string; thinking?: string; partial_json?: string }
+    content_block?: { type: string; id?: string; name?: string; text?: string; thinking?: string }
+    index?: number
+    message?: { usage?: { input_tokens: number; output_tokens: number } }
+    usage?: { output_tokens: number }
+  }
+  parent_tool_use_id: string | null
+  uuid: string
+  session_id: string
+}
+
+export interface SDKUserMessage {
+  type: 'user'
+  uuid: string
+  session_id: string
+  message: {
+    role: 'user'
+    content: string | SDKContentBlock[]
+  }
+}
+
+export type SDKContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; content: string | SDKContentBlock[]; is_error?: boolean }
+  | { type: 'thinking'; thinking: string }
+
+export type SDKMessage =
+  | SDKAssistantMessage
+  | SDKResultMessage
+  | SDKSystemMessage
+  | SDKStreamEvent
+  | SDKUserMessage
+  | { type: string; [key: string]: unknown }
+
+// ── SDK Query API ───────────────────────────────────────────────────────────
+
+export interface SDKMcpServerConfig {
+  type?: 'stdio' | 'sse' | 'http'
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  cwd?: string
+  url?: string
+  headers?: Record<string, string>
+}
+
+export type SDKPermissionMode =
+  | 'default'
+  | 'acceptEdits'
+  | 'bypassPermissions'
+  | 'plan'
+  | 'dontAsk'
+  | 'auto'
+
+export type SDKEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+
+export interface SDKQueryOptions {
+  abortController?: AbortController | undefined
+  cwd?: string | undefined
+  env?: Record<string, string | undefined> | undefined
+  model?: string | undefined
+  effort?: SDKEffort | undefined
+  permissionMode?: SDKPermissionMode | undefined
+  allowedTools?: string[] | undefined
+  disallowedTools?: string[] | undefined
+  mcpServers?: Record<string, SDKMcpServerConfig> | undefined
+  systemPrompt?: string | { type: 'preset'; preset: 'claude_code'; append?: string | undefined } | undefined
+  maxTurns?: number | undefined
+  maxBudgetUsd?: number | undefined
+  sessionId?: string | undefined
+  continue?: boolean | undefined
+  includePartialMessages?: boolean | undefined
+  enableFileCheckpointing?: boolean | undefined
+  canUseTool?: ((
+    toolName: string,
+    input: Record<string, unknown>,
+    options: { signal: AbortSignal },
+  ) => Promise<{ behavior: 'allow' } | { behavior: 'deny'; message: string }>) | undefined
+  agents?: Record<string, {
+    description: string
+    prompt: string
+    tools?: string[] | undefined
+    model?: string | undefined
+    maxTurns?: number | undefined
+  }> | undefined
+}
+
+/**
+ * The Query object returned by the SDK's query() function.
+ * It is an AsyncGenerator<SDKMessage> with additional control methods.
+ */
+export interface SDKQuery extends AsyncGenerator<SDKMessage, void> {
+  interrupt(): Promise<void>
+  close(): void
+}
+
+export interface SDKQueryFunction {
+  (params: { prompt: string; options?: SDKQueryOptions }): SDKQuery
+}
+
+// ── Spark ↔ SDK Permission Mode Mapping ─────────────────────────────────────
+
+export type SparkPermissionMode =
+  | 'claude-ask'
+  | 'claude-auto-edits'
+  | 'claude-plan'
+  | 'claude-auto'
+  | 'claude-bypass'
+  | 'codex-default'
+  | 'codex-auto-review'
+  | 'codex-full-access'
+
+// ── Executor Configuration ──────────────────────────────────────────────────
+
+export interface SDKExecutorConfig {
+  apiKey: string
+  model: string
+  apiEndpoint?: string | undefined
+  systemPrompt?: string | undefined
+  skillSystemPrompt?: string | undefined
+  permissionMode: SparkPermissionMode
+  maxTurnCount?: number | undefined
+  maxTokens?: number | undefined
+  maxBudgetUsd?: number | undefined
+  workspaceRootPath: string
+  reasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh' | undefined
+  mcpServers?: Record<string, SDKMcpServerConfig> | undefined
+  allowedTools?: string[] | undefined
+  disallowedTools?: string[] | undefined
+  enableCheckpoints?: boolean | undefined
+  approvalCallback?: ((sessionId: string, toolName: string, toolInput: Record<string, unknown>) => Promise<boolean>) | undefined
+}

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -19,12 +19,17 @@ import * as keystore from '@spark/shared/keystore'
 import { createAdapter } from './adapter-factory.js'
 import { McpService } from './mcp-server.service.js'
 import { RuntimeCompositionService } from './runtime-composition.service.js'
+import { ClaudeSDKExecutor, SDKNotAvailableError } from '../sdk/index.js'
+import type { SDKExecutorConfig, SDKMcpServerConfig } from '../sdk/index.js'
+import { createLogger } from '@spark/shared'
+
+const log = createLogger('session.service')
 
 export type SessionEventHandler = (event: AgentEvent) => void
 export type ApprovalHandler = (sessionId: string, toolName: string, toolInput: Record<string, unknown>) => Promise<boolean>
 /** session 被取消时调用：用于拒绝该 session 下所有挂起的 approval 请求，避免 agent 永久挂起 */
 export type ApprovalCancelHandler = (sessionId: string) => void
-type AgentAdapterKind = 'claude' | 'codex'
+type AgentAdapterKind = 'claude' | 'claude-sdk' | 'codex'
 type PendingTurn = { turnId: string; message: string }
 
 const DEFAULT_SESSION_TITLES = new Set(['New Session', '新会话', 'Workspace Session', '未命名会话'])
@@ -354,9 +359,6 @@ export class SessionService {
     const agentAdapter = getAgentAdapterFromSession(session.agent_adapter, session.chat_mode, provider.provider_type)
     const storedPermissionMode = getPermissionModeFromSession(session.permission_mode, agentAdapter)
     const permissionMode = this.getEffectivePermissionMode(sessionId, agentAdapter, storedPermissionMode)
-    // 仅 codex(=openai-family) adapter + provider 配置了 codexApiKind: 'responses' 时才走 Responses API
-    const apiKind: 'chat' | 'responses' = agentAdapter === 'codex' && config.codexApiKind === 'responses' ? 'responses' : 'chat'
-    const adapter = createAdapter(agentAdapter, apiKind)
 
     // Workspace root path for tools
     let workspaceRootPath = process.cwd()
@@ -379,15 +381,6 @@ export class SessionService {
       .filter((r) => r.enabled === 1)
       .map((r) => r.content)
 
-    const tools = new ToolRegistry()
-
-    // Register MCP tools from connected servers
-    try {
-      this.mcpService.registerToToolRegistry(tools)
-    } catch {
-      // MCP tool registration failure is non-fatal
-    }
-
     // Build explicit skill prompt if skillId is provided; available skills are composed below.
     let explicitSkillPrompt: string | undefined
     const skillRepo = new SkillRepository(this.db)
@@ -405,6 +398,54 @@ export class SessionService {
       },
       explicitSkillPrompt,
     )
+
+    // Initialize seq counter from existing event count
+    if (!this.seqCounters.has(sessionId)) {
+      this.seqCounters.set(sessionId, existingEventCount)
+    }
+
+    // ── SDK Execution Path ─────────────────────────────────────────────────
+    // When adapter is 'claude-sdk', use the Claude Agent SDK for execution.
+    // This delegates the entire agent loop, tools, and permissions to the SDK,
+    // giving us Claude Code's battle-tested Read/Edit/Bash/Grep capabilities.
+    // Falls back to direct API path if SDK is not installed.
+    if (agentAdapter === 'claude-sdk') {
+      const sdkConfig: SDKExecutorConfig = {
+        apiKey,
+        model,
+        workspaceRootPath,
+        permissionMode,
+        ...(config.apiEndpoint != null ? { apiEndpoint: config.apiEndpoint } : {}),
+        ...(runtimeContext.systemPrompt != null ? { systemPrompt: runtimeContext.systemPrompt } : {}),
+        ...(runtimeContext.skillSystemPrompt != null ? { skillSystemPrompt: runtimeContext.skillSystemPrompt } : {}),
+        maxTurnCount: this.iterationOverrides.get(sessionId) ?? 25,
+        ...(config.maxTokens != null ? { maxTokens: config.maxTokens } : {}),
+        ...(session.reasoning_effort != null ? { reasoningEffort: session.reasoning_effort as 'low' | 'medium' | 'high' | 'xhigh' } : {}),
+        enableCheckpoints: true,
+        ...(this.onApproval != null ? { approvalCallback: this.onApproval } : {}),
+      }
+      const sdkStarted = await this.tryStartSDKTurn(
+        sessionId, turnId, message, eventRepo, sessionRepo, sdkConfig,
+      )
+      if (sdkStarted) return
+      // SDK not available — fall through to direct API path
+      log.warn(`Claude Agent SDK not available for session ${sessionId}, falling back to direct API`)
+    }
+
+    // ── Direct API Execution Path ──────────────────────────────────────────
+    // Uses our own AgentLoop + ToolRegistry with the direct API adapters.
+    const apiKind: 'chat' | 'responses' = agentAdapter === 'codex' && config.codexApiKind === 'responses' ? 'responses' : 'chat'
+    const effectiveAdapterType = agentAdapter === 'claude-sdk' ? 'claude' : agentAdapter
+    const adapter = createAdapter(effectiveAdapterType, apiKind)
+
+    const tools = new ToolRegistry()
+
+    // Register MCP tools from connected servers
+    try {
+      this.mcpService.registerToToolRegistry(tools)
+    } catch {
+      // MCP tool registration failure is non-fatal
+    }
 
     const agentConfig: AgentConfig = {
       adapter,
@@ -427,30 +468,10 @@ export class SessionService {
       ...(this.onApproval != null ? { approvalCallback: this.onApproval } : {}),
     }
 
-    // Initialize seq counter from existing event count
-    if (!this.seqCounters.has(sessionId)) {
-      this.seqCounters.set(sessionId, existingEventCount)
-    }
-
     const loop = new AgentLoop()
 
     loop.onEvent((event) => {
-      const seq = this.seqCounters.get(sessionId) ?? 0
-      this.seqCounters.set(sessionId, seq + 1)
-      const sequenced = { ...event, seq }
-      this.onEvent(sequenced)
-      // Persist (fire-and-forget, sync SQLite call)
-      try {
-        eventRepo.insert({
-          id: sequenced.id,
-          sessionId,
-          turnId,
-          eventType: sequenced.type,
-          eventJson: JSON.stringify(sequenced),
-        })
-      } catch {
-        // Non-fatal: persistence failure should not crash the stream
-      }
+      this.emitAndPersist(sessionId, turnId, event, eventRepo)
     })
 
     this.activeLoops.set(sessionId, loop)
@@ -471,6 +492,112 @@ export class SessionService {
           this.startNextQueuedTurn(sessionId)
         }
       })
+  }
+
+  /**
+   * Attempt to run the turn through the Claude Agent SDK.
+   * Returns true if successfully started, false if SDK is unavailable.
+   */
+  private async tryStartSDKTurn(
+    sessionId: string,
+    turnId: string,
+    message: string,
+    eventRepo: EventRepository,
+    sessionRepo: SessionRepository,
+    config: SDKExecutorConfig,
+  ): Promise<boolean> {
+    try {
+      const { isSDKAvailable: checkSDK } = await import('../sdk/index.js')
+      if (!(await checkSDK())) return false
+    } catch {
+      return false
+    }
+
+    // Build MCP server config from our McpService for the SDK
+    const mcpServers = this.buildMcpServersForSDK()
+
+    const executor = new ClaudeSDKExecutor()
+
+    executor.onEvent((event) => {
+      this.emitAndPersist(sessionId, turnId, event, eventRepo)
+    })
+
+    this.activeLoops.set(sessionId, executor as unknown as AgentLoop)
+    sessionRepo.updateStatus(sessionId, 'running')
+
+    const sdkConfig: SDKExecutorConfig = {
+      ...config,
+      ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
+    }
+
+    // Fire-and-forget
+    executor
+      .executeTurn(sessionId, turnId, message, sdkConfig)
+      .then(() => {
+        sessionRepo.updateStatus(sessionId, 'idle')
+      })
+      .catch(() => {
+        sessionRepo.updateStatus(sessionId, 'error')
+      })
+      .finally(() => {
+        if (this.activeLoops.get(sessionId) === (executor as unknown as AgentLoop)) {
+          this.activeLoops.delete(sessionId)
+          this.startNextQueuedTurn(sessionId)
+        }
+      })
+
+    return true
+  }
+
+  /**
+   * Build MCP server configs in the SDK's expected format from our McpService.
+   */
+  private buildMcpServersForSDK(): Record<string, SDKMcpServerConfig> {
+    const result: Record<string, SDKMcpServerConfig> = {}
+    const servers = this.mcpService.listServers()
+
+    for (const server of servers) {
+      if (!server.enabled) continue
+      try {
+        const cfg = JSON.parse(server.configJson) as Record<string, unknown>
+        if (cfg.type === 'sse' && typeof cfg.url === 'string') {
+          result[server.name] = {
+            type: 'sse',
+            url: cfg.url,
+            ...(cfg.headers != null ? { headers: cfg.headers as Record<string, string> } : {}),
+          }
+        } else {
+          result[server.name] = {
+            type: 'stdio',
+            command: String(cfg.command ?? 'npx'),
+            args: Array.isArray(cfg.args) ? cfg.args.map(String) : [],
+            ...(cfg.env != null ? { env: cfg.env as Record<string, string> } : {}),
+            ...(typeof cfg.cwd === 'string' ? { cwd: cfg.cwd } : {}),
+          }
+        }
+      } catch {
+        // Skip servers with invalid config
+      }
+    }
+    return result
+  }
+
+  private emitAndPersist(sessionId: string, turnId: string, event: AgentEvent, eventRepo: EventRepository): void {
+    const seq = this.seqCounters.get(sessionId) ?? 0
+    this.seqCounters.set(sessionId, seq + 1)
+    const sequenced = { ...event, seq }
+    this.onEvent(sequenced)
+    try {
+      eventRepo.insert({
+        id: sequenced.id,
+        sessionId,
+        turnId,
+        eventType: sequenced.type,
+        eventJson: JSON.stringify(sequenced),
+      })
+    } catch {
+      // Non-fatal: persistence failure should not crash the stream
+    }
   }
 
   private enqueueTurn(sessionId: string, turn: PendingTurn): void {
@@ -772,9 +899,11 @@ function truncateTitle(title: string): string {
 }
 
 function getAgentAdapterFromSession(value: string | null | undefined, legacyChatMode: string | null | undefined, providerType: string | null): AgentAdapterKind {
-  if (value === 'claude' || value === 'codex') return value
-  if (legacyChatMode === 'claude' || legacyChatMode === 'codex') return legacyChatMode
-  return providerType === 'anthropic' ? 'claude' : 'codex'
+  if (value === 'claude' || value === 'claude-sdk' || value === 'codex') return value
+  if (legacyChatMode === 'claude' || legacyChatMode === 'claude-sdk' || legacyChatMode === 'codex') return legacyChatMode
+  // Default: Anthropic providers use claude-sdk (with fallback to direct API),
+  // others use codex (OpenAI-compatible).
+  return providerType === 'anthropic' ? 'claude-sdk' : 'codex'
 }
 
 function getPermissionModeFromSession(value: string | null | undefined, adapter: AgentAdapterKind): SessionPermissionMode {
@@ -794,8 +923,12 @@ function getPermissionModeFromSession(value: string | null | undefined, adapter:
 }
 
 function defaultMaxIterations(adapter: AgentAdapterKind): number {
-  // Claude 模型擅长长链思考、能稳定推进 ≥150 轮；Codex/GPT 系列建议保守一些。
-  return adapter === 'claude' ? 150 : 100
+  // claude-sdk: SDK manages its own iteration limits internally
+  if (adapter === 'claude-sdk') return 25
+  // claude direct API: supports long chains
+  if (adapter === 'claude') return 150
+  // codex/openai: conservative
+  return 100
 }
 
 function getChatModeFromSession(value: string | null | undefined): 'agent' | 'ask' | 'edit' | 'review' {

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -20,7 +20,7 @@ import type { AgentEvent, SessionId } from '../events/index.js'
 
 export type SessionChatMode = 'agent' | 'ask' | 'edit' | 'review'
 export type SessionReasoningEffort = 'low' | 'medium' | 'high' | 'xhigh'
-export type SessionAgentAdapter = 'claude' | 'codex'
+export type SessionAgentAdapter = 'claude' | 'claude-sdk' | 'codex'
 export type SessionPermissionMode =
   | 'claude-ask'
   | 'claude-auto-edits'

--- a/packages/protocol/src/schemas/index.ts
+++ b/packages/protocol/src/schemas/index.ts
@@ -21,7 +21,7 @@ export const RuntimeConfigScopeSchema = z.enum(['system', 'agent', 'project', 's
 export const LocalSkillSourceSchema = z.enum(['claude', 'codex', 'agents', 'custom'])
 export const SessionChatModeSchema = z.enum(['agent', 'ask', 'edit', 'review'])
 export const SessionReasoningEffortSchema = z.enum(['low', 'medium', 'high', 'xhigh'])
-export const SessionAgentAdapterSchema = z.enum(['claude', 'codex'])
+export const SessionAgentAdapterSchema = z.enum(['claude', 'claude-sdk', 'codex'])
 export const SessionPermissionModeSchema = z.enum([
   'claude-ask',
   'claude-auto-edits',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,10 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@25.9.1)(jsdom@29.1.1)(lightningcss@1.32.0)
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: ^0.3.152
+        version: 0.3.152(@anthropic-ai/sdk@0.98.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)
 
   packages/protocol:
     dependencies:
@@ -271,6 +275,58 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.152':
+    resolution: {integrity: sha512-e4ZXNd/WRq4Ww0SSqttrubgR5NJ/7c8qkj+ePsTwOamKcPra2E1cIOqAcQqitJNJjPMW7e7NVkiFjsCkowng+A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.152':
+    resolution: {integrity: sha512-7wyPOruUPwKcEIj7Moc6NeTSEZ6ltVwU9MQoWV7dzaFGq06YGoFoW9jJfPWSyA2H6v/Yx2sx7ta8vijP1VIBRQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.152':
+    resolution: {integrity: sha512-CRlC+hVMVpdD3K3qan/bX420WPrieqfDnd/aPe2dGt2KT8ylTyDftsjSaWdlP8T5kwv+apkAkk6G0QHPhBJB4A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.152':
+    resolution: {integrity: sha512-B1Vf1grD3o3bqnKx2TuUYJBdc5xDdMc1sTuikZTHkM2nejCAsmTJ3mZ3BuD3Ns2D7jyOQWeyXW05aEw4M0SEVw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.152':
+    resolution: {integrity: sha512-c2wy9c9v3JWJT2g77B5QOgptkfQp+veDTo7TnexRA0he+kDlkLId2voD3iw1vk9VDVF5eSuQNCk6cMDbMu6LRg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.152':
+    resolution: {integrity: sha512-S/YwxAInbtdLElx1H7gM5hDYeV9UiJtTh4eS8oQmjkPXu2Gddx6muek085FBFIlGypjvuXUHB7Nw5vtZtYHwGg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.152':
+    resolution: {integrity: sha512-CNpXWfvyQt6fj6f7HaPtdaOKv+U7hevDnEEo816m5EbIDRgT0XkAN1p+EiuvEIiDzEwJ0/usgIzDlNcIUfTMrg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.152':
+    resolution: {integrity: sha512-DsPwmrLf6caR164BRS5vH1cpBKYY9X5DkmjxI36Ou6FC3Tm2tLBYPh94ZBUIMyMzxARpQeRD6+QWEGNgwtR92w==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.3.152':
+    resolution: {integrity: sha512-SiDI8shtKtiKuf6ogkYj7+DumSVk+q9vY6facyY4mKPUQz1XPxSUISSzIavg/U7DC0RiiZ1Y8WwU4LDf0lsPgA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@anthropic-ai/sdk': '>=0.93.0'
+      '@modelcontextprotocol/sdk': ^1.29.0
+      zod: ^4.0.0
 
   '@anthropic-ai/sdk@0.98.0':
     resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
@@ -666,6 +722,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -713,6 +775,16 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1540,6 +1612,10 @@ packages:
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1554,6 +1630,14 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -1561,6 +1645,9 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1666,6 +1753,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -1709,6 +1800,10 @@ packages:
   builder-util@24.13.1:
     resolution: {integrity: sha512-NhbCSIntruNDTOVI9fdXz0dihaqX2YuE1D6zZMrwiErzH4ELZHE6mdiB40wEgZNprDia+FghRFgKoAqMZRRjSA==}
 
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1723,6 +1818,10 @@ packages:
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
   caniuse-lite@1.0.30001793:
@@ -1801,8 +1900,28 @@ packages:
   config-file-ts@0.2.6:
     resolution: {integrity: sha512-6boGVaglwblBgJqGyxm4+xCmEGcWgnWHSWHY5jad58awQhB6gftq0G8HbzU39YqCIYHMLAiL1yjwiZ36m/CL8w==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -1813,6 +1932,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -1884,6 +2007,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1919,6 +2046,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -1963,6 +2093,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -2012,6 +2146,9 @@ packages:
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -2073,6 +2210,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
@@ -2080,6 +2229,16 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -2101,6 +2260,9 @@ packages:
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -2124,6 +2286,10 @@ packages:
   filelist@1.0.6:
     resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2142,6 +2308,14 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2262,6 +2436,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2272,6 +2450,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -2292,6 +2474,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -2319,6 +2505,14 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
@@ -2337,6 +2531,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
@@ -2363,6 +2560,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2394,6 +2594,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2572,13 +2778,29 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -2649,6 +2871,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
@@ -2671,9 +2897,21 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2712,6 +2950,10 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2727,6 +2969,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2744,6 +2989,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -2789,6 +3038,10 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -2796,9 +3049,21 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2905,6 +3170,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -2945,12 +3214,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2959,6 +3239,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -3008,6 +3304,10 @@ packages:
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -3113,6 +3413,10 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -3147,6 +3451,10 @@ packages:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript-eslint@8.60.0:
     resolution: {integrity: sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3176,6 +3484,10 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -3211,6 +3523,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -3358,6 +3674,11 @@ packages:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -3370,6 +3691,46 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.152':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.3.152(@anthropic-ai/sdk@0.98.0(zod@3.25.76))(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.98.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.152
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.152
+    optional: true
 
   '@anthropic-ai/sdk@0.98.0(zod@3.25.76)':
     dependencies:
@@ -3731,6 +4092,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@hono/node-server@1.19.14(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+    optional: true
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3787,6 +4153,29 @@ snapshots:
       tmp-promise: 3.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.23)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.23
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4577,6 +4966,12 @@ snapshots:
 
   '@xmldom/xmldom@0.9.10': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+    optional: true
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4589,6 +4984,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+    optional: true
+
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
       ajv: 6.15.0
@@ -4599,6 +4999,14 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+    optional: true
 
   ansi-regex@5.0.1: {}
 
@@ -4737,6 +5145,21 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   boolean@3.2.0:
     optional: true
 
@@ -4807,6 +5230,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bytes@3.1.2:
+    optional: true
+
   cac@6.7.14: {}
 
   cacheable-lookup@5.0.4: {}
@@ -4825,6 +5251,12 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+    optional: true
 
   caniuse-lite@1.0.30001793: {}
 
@@ -4901,7 +5333,22 @@ snapshots:
       glob: 10.5.0
       typescript: 5.9.3
 
+  content-disposition@1.1.0:
+    optional: true
+
+  content-type@1.0.5:
+    optional: true
+
+  content-type@2.0.0:
+    optional: true
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2:
+    optional: true
+
+  cookie@0.7.2:
+    optional: true
 
   cookie@1.1.1: {}
 
@@ -4909,6 +5356,12 @@ snapshots:
     optional: true
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -4976,6 +5429,9 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0:
+    optional: true
+
   detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
@@ -5025,6 +5481,9 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1:
+    optional: true
 
   ejs@3.1.10:
     dependencies:
@@ -5108,6 +5567,9 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  encodeurl@2.0.0:
+    optional: true
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -5170,6 +5632,9 @@ snapshots:
       '@esbuild/win32-x64': 0.21.5
 
   escalade@3.2.0: {}
+
+  escape-html@1.0.3:
+    optional: true
 
   escape-string-regexp@4.0.0: {}
 
@@ -5258,9 +5723,60 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1:
+    optional: true
+
+  eventsource-parser@3.0.8:
+    optional: true
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+    optional: true
+
   expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+    optional: true
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   extract-zip@2.0.1:
     dependencies:
@@ -5283,6 +5799,9 @@ snapshots:
 
   fast-sha256@1.3.0: {}
 
+  fast-uri@3.1.2:
+    optional: true
+
   fd-slicer@1.1.0:
     dependencies:
       pend: 1.2.0
@@ -5300,6 +5819,18 @@ snapshots:
   filelist@1.0.6:
     dependencies:
       minimatch: 5.1.9
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   find-up@5.0.0:
     dependencies:
@@ -5325,6 +5856,12 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.3
       mime-types: 2.1.35
+
+  forwarded@0.2.0:
+    optional: true
+
+  fresh@2.0.0:
+    optional: true
 
   fs-constants@1.0.0: {}
 
@@ -5470,6 +6007,9 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.23:
+    optional: true
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -5481,6 +6021,15 @@ snapshots:
       - '@noble/hashes'
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+    optional: true
 
   http-proxy-agent@5.0.0:
     dependencies:
@@ -5512,6 +6061,11 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -5529,6 +6083,12 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ip-address@10.2.0:
+    optional: true
+
+  ipaddr.js@1.9.1:
+    optional: true
+
   is-ci@3.0.1:
     dependencies:
       ci-info: 3.9.0
@@ -5542,6 +6102,9 @@ snapshots:
       is-extglob: 2.1.1
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0:
+    optional: true
 
   isarray@1.0.0: {}
 
@@ -5564,6 +6127,9 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.7.0: {}
+
+  jose@6.2.3:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -5607,6 +6173,12 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0:
+    optional: true
+
+  json-schema-typed@8.0.2:
+    optional: true
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -5747,11 +6319,25 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0:
+    optional: true
+
+  merge-descriptors@2.0.0:
+    optional: true
+
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0:
+    optional: true
 
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+    optional: true
 
   mime@2.6.0: {}
 
@@ -5802,6 +6388,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@1.0.0:
+    optional: true
+
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.1
@@ -5817,7 +6406,18 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
+  object-assign@4.1.1:
+    optional: true
+
+  object-inspect@1.13.4:
+    optional: true
+
   object-keys@1.1.1:
+    optional: true
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
     optional: true
 
   once@1.4.0:
@@ -5853,6 +6453,9 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseurl@1.3.3:
+    optional: true
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -5864,6 +6467,9 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2:
+    optional: true
+
   pathe@1.1.2: {}
 
   pathval@2.0.1: {}
@@ -5873,6 +6479,9 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pkce-challenge@5.0.1:
+    optional: true
 
   playwright-core@1.60.0: {}
 
@@ -5922,6 +6531,12 @@ snapshots:
       err-code: 2.0.3
       retry: 0.12.0
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    optional: true
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -5929,7 +6544,23 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.0
+    optional: true
+
   quick-lru@5.1.1: {}
+
+  range-parser@1.2.1:
+    optional: true
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+    optional: true
 
   rc@1.2.8:
     dependencies:
@@ -6070,6 +6701,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -6097,18 +6739,80 @@ snapshots:
 
   semver@7.8.1: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0:
+    optional: true
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+    optional: true
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+    optional: true
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+    optional: true
 
   siginfo@2.0.0: {}
 
@@ -6156,6 +6860,9 @@ snapshots:
       fast-sha256: 1.3.0
 
   stat-mode@1.0.0: {}
+
+  statuses@2.0.2:
+    optional: true
 
   std-env@3.10.0: {}
 
@@ -6265,6 +6972,9 @@ snapshots:
 
   tmp@0.2.5: {}
 
+  toidentifier@1.0.1:
+    optional: true
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.4.0
@@ -6296,6 +7006,13 @@ snapshots:
   type-fest@0.13.1:
     optional: true
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+    optional: true
+
   typescript-eslint@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)
@@ -6318,6 +7035,9 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
+
+  unpipe@1.0.0:
+    optional: true
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -6347,6 +7067,9 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  vary@1.1.2:
+    optional: true
 
   verror@1.10.1:
     dependencies:
@@ -6560,6 +7283,11 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+    optional: true
 
   zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
Add ClaudeSDKExecutor that wraps @anthropic-ai/claude-agent-sdk to provide
a full agent execution engine leveraging Claude Code's battle-tested tools
(Read, Edit, Bash, Grep, Glob), agent loop, checkpoint system, and MCP
integration.

Key changes:
- New `sdk/` module: ClaudeSDKExecutor, event mapper, permission mapper, types
- SessionService routes `claude-sdk` adapter type through SDK executor
- SDK unavailable → graceful fallback to direct Anthropic API path
- Anthropic providers now default to `claude-sdk` adapter
- MCP server configs passthrough to SDK from Spark's McpService
- Permission mode mapping: Spark's 8 modes → SDK's 6 modes
- SDK messages (AsyncGenerator) → Spark AgentEvent stream for UI
- Skill system prompts + composed rules appended to SDK's system prompt
- Protocol types updated to include `claude-sdk` adapter option
- Capability review document added to docs/reviews/

https://claude.ai/code/session_01Ut8B5BoNSwiV4TsCPCo7pq