### PR TITLE
Forward agent-handled commands, enrich `/help` output, and emit `agent_status` events for commands

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -178,6 +178,14 @@ describe('Built-in commands', () => {
     expect(result.message).toContain('/help')
   })
 
+  it('/help command returns implemented command details', async () => {
+    const result = await registry.execute(parse('/help compact'), ctx, makeDeps())
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('/compact')
+    expect(result.message).toContain('交给 Agent 处理')
+    expect(result.message).not.toContain('待实现')
+  })
+
   it('/status returns session info', async () => {
     const result = await registry.execute(parse('/status'), ctx, makeDeps())
     expect(result.success).toBe(true)
@@ -214,6 +222,14 @@ describe('Built-in commands', () => {
     const result = await registry.execute(parse('/clear'), ctx, deps)
     expect(result.success).toBe(true)
     expect(deps.clearSessionEvents).toHaveBeenCalledWith('sess-1')
+  })
+
+  it('/compact forwards to agent instead of clearing session events', async () => {
+    const deps = makeDeps()
+    const result = await registry.execute(parse('/compact summarize decisions'), ctx, deps)
+    expect(result.success).toBe(true)
+    expect(result.forwardToAgent).toBe(true)
+    expect(deps.clearSessionEvents).not.toHaveBeenCalled()
   })
 
   it('/approval on enables approval', async () => {

--- a/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
@@ -391,6 +391,10 @@ describe('SessionService runtime provider/model resolution', () => {
       provider: 'spark',
       isFinal: true,
     }))
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'agent_status',
+      status: 'completed',
+    }))
   })
 
   it('passes selected attachments into the Claude SDK turn config', async () => {

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -2,7 +2,7 @@
  * CommandRegistry — 三层命令注册表
  *
  * 三层架构:
- *   Layer 1: SDK 原生命令（Claude Agent SDK / Codex SDK）
+ *   Layer 1: SDK 兼容命令（Claude Agent SDK / Codex SDK；未在 Spark 本地实现的命令透传给 Agent）
  *   Layer 2: 程序内置命令（Session/Model/Context/Permission/...）
  *   Layer 3: Agent 技能命令（Skill manifest 注册）
  *
@@ -168,6 +168,10 @@ const SUBCOMMAND_COMMANDS = new Set([
   'goal',
 ])
 
+function forwardToAgent(message = ''): CommandResult {
+  return { success: true, message, forwardToAgent: true }
+}
+
 export class CommandRegistry {
   private commands = new Map<string, CommandDefinition>()
   private aliasIndex = new Map<string, string>()  // alias → command name
@@ -314,10 +318,29 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'global',
     risk: 'none',
     usage: '/help [command]',
-    handler: async (cmd, _ctx, deps) => {
-      const targetCmd = cmd.args[0]
+    handler: async (cmd) => {
+      const targetCmd = cmd.args[0]?.replace(/^\//, '').toLowerCase()
       if (targetCmd) {
-        return { success: true, message: `查看 /${targetCmd} 的详细帮助（待实现）` }
+        const def = registry.get(targetCmd)
+        if (def == null) {
+          return { success: false, message: `未知命令 /${targetCmd}。输入 /help 查看所有可用命令。` }
+        }
+        const lines = [
+          `**/${def.name}**`,
+          '',
+          `- 描述：${def.description}`,
+          `- 来源：${def.layer}`,
+          `- 分组：${def.group}`,
+          `- 作用域：${def.scope}`,
+          `- 风险：${def.risk}`,
+          ...(def.usage != null ? [`- 用法：\`${def.usage}\``] : []),
+          ...(def.aliases.length > 0 ? [`- 别名：${def.aliases.map((alias) => `\`/${alias}\``).join('、')}`] : []),
+          `- 执行方式：${isAgentForwardedCommand(def) ? '交给 Agent 处理' : 'Spark 内部处理'}`,
+        ]
+        return {
+          success: true,
+          message: lines.join('\n'),
+        }
       }
       const lines = [
         '**可用命令**',
@@ -328,7 +351,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
         '`/model [model-id]` — 切换模型',
         '`/rename <title>` — 重命名会话',
         '`/clear` — 清空会话消息',
-        '`/compact` — 压缩上下文',
+        '`/compact [instructions]` — 交给 Agent 总结/压缩上下文（不会清空会话）',
         '`/checkpoint list|restore` — 管理快照',
         '',
         '▸ **工具与诊断**',
@@ -448,14 +471,11 @@ function registerSdkCommands(registry: CommandRegistry): void {
     aliases: [],
     layer: 'sdk',
     group: 'context',
-    description: '压缩上下文（清除早期消息以释放 token）',
+    description: '压缩上下文（交给 Agent 总结，不清空会话）',
     scope: 'session',
     risk: 'low',
-    usage: '/compact',
-    handler: async (_cmd, ctx, deps) => {
-      await deps.clearSessionEvents(ctx.sessionId)
-      return { success: true, message: '上下文已压缩，早期消息已清除。' }
-    },
+    usage: '/compact [instructions]',
+    handler: async () => forwardToAgent('已交给 Agent 以对话形式总结/压缩上下文。'),
   })
 
   registry.register({
@@ -693,7 +713,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'workspace',
     risk: 'low',
     usage: '/add-dir <path>',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
 
   registry.register({
@@ -706,7 +726,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'workspace',
     risk: 'none',
     usage: '/memory',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
 
   registry.register({
@@ -719,7 +739,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'workspace',
     risk: 'none',
     usage: '/review [instructions]',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
 
   registry.register({
@@ -732,7 +752,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'session',
     risk: 'none',
     usage: '/copy',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
 
   registry.register({
@@ -745,7 +765,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'session',
     risk: 'none',
     usage: '/plan [task]',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
 
   registry.register({
@@ -758,8 +778,14 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'session',
     risk: 'none',
     usage: '/side [message]',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
+}
+
+function isAgentForwardedCommand(def: CommandDefinition): boolean {
+  const forwardedCommands = new Set(['compact', 'add-dir', 'memory', 'review', 'copy', 'plan', 'side', 'goal'])
+  if (forwardedCommands.has(def.name)) return true
+  return def.name === 'git'
 }
 
 function readWorkspaceScripts(cwd: string): Record<string, string> {
@@ -1026,7 +1052,7 @@ function registerBuiltinCommands(registry: CommandRegistry): void {
 
       // add/commit/push/pull 等写操作直接交给 AI Agent 执行
       if (subcommand && GIT_AGENT_SUBCOMMANDS.has(subcommand)) {
-        return { success: true, message: '', forwardToAgent: true }
+        return forwardToAgent()
       }
 
       const cwd = deps.getWorkspacePath?.()
@@ -1098,7 +1124,7 @@ function registerBuiltinCommands(registry: CommandRegistry): void {
     risk: 'none',
     hasSubcommands: true,
     usage: '/goal <objective> | /goal clear | /goal pause | /goal resume',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
+    handler: async () => forwardToAgent(),
   })
 }
 

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -33,6 +33,7 @@ import type {
   SessionSearchResponse,
   UserMessageEvent,
   AssistantMessageEvent,
+  AgentStatusEvent,
   HookNode,
   SessionAttachment,
   UserQuestionPrompt,
@@ -548,7 +549,7 @@ export class SessionService {
     // Inject result as events into the chat stream
     const turnId = crypto.randomUUID()
     const seq0 = this.seqCounters.get(params.sessionId) ?? 0
-    this.seqCounters.set(params.sessionId, seq0 + 2)
+    this.seqCounters.set(params.sessionId, seq0 + 3)
 
     const userEvent: UserMessageEvent = {
       id: crypto.randomUUID(),
@@ -577,7 +578,17 @@ export class SessionService {
       isFinal: true,
     }
 
-    for (const event of [userEvent, assistantEvent]) {
+    const completedEvent: AgentStatusEvent = {
+      id: crypto.randomUUID(),
+      type: 'agent_status',
+      sessionId: params.sessionId,
+      turnId,
+      timestamp: new Date().toISOString(),
+      seq: seq0 + 2,
+      status: 'completed',
+    }
+
+    for (const event of [userEvent, assistantEvent, completedEvent]) {
       this.onEvent(event)
       try {
         eventRepo.insert({


### PR DESCRIPTION
### Motivation
- Make a clear distinction between commands handled locally and those that should be forwarded to the AI Agent and surface that in help text. 
- Ensure commands forwarded to the Agent use a consistent return shape and reduce duplicated `forwardToAgent` objects. 
- Record command completion status in the event stream so UI/consumers can observe command lifecycles.

### Description
- Add a `forwardToAgent` helper and `isAgentForwardedCommand` to centralize agent-forward decision and return value. 
- Enhance the `/help` handler to show detailed information for a given command, including whether it is forwarded to the Agent, and normalize the target command lookup. 
- Change several SDK/builtin command handlers (e.g. `compact`, `add-dir`, `memory`, `review`, `copy`, `plan`, `side`, `goal`, and git write subcommands) to return `forwardToAgent()` instead of ad-hoc objects. 
- Update `compact` to be forwarded to the Agent (and update description/usage text accordingly). 
- Increment sequence counter and emit an `agent_status` event with `status: 'completed'` after injecting command response events into the stream in `SessionService`, and persist that event alongside the user/assistant events.

### Testing
- Added unit tests in `packages/agent-runtime/src/__tests__/core/command-registry.test.ts` to verify `/help` details and that `/compact` forwards to the agent, and updated command behavior tests accordingly. 
- Updated `packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts` to expect an `agent_status` event after `/rename` command. 
- Ran the `agent-runtime` test suite containing the modified tests and the updated tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3389b55b148323b6ec7410ae56900d)