### PR TITLE
fix(agent-runtime): wire /usage session totals

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -184,6 +184,16 @@ describe('Built-in commands', () => {
     expect(result.message).toContain('sess-1')
   })
 
+  it('/usage shows session token and cost totals from deps', async () => {
+    const result = await registry.execute(parse('/usage'), ctx, makeDeps({
+      getSessionUsage: vi.fn(() => ({ totalInputTokens: 1234, totalOutputTokens: 567, totalCost: 0.0425 })),
+    }))
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('1,234')
+    expect(result.message).toContain('567')
+    expect(result.message).toContain('$0.0425')
+  })
+
   it('/model with arg updates model', async () => {
     const deps = makeDeps()
     const result = await registry.execute(parse('/model gpt-4o'), ctx, deps)

--- a/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
@@ -164,6 +164,26 @@ vi.mock('@spark/storage', () => {
     }
   }
 
+  class UsageLedgerRepository {
+    getSessionUsage(_sessionId: string): {
+      totalInputTokens: number
+      totalOutputTokens: number
+      totalCacheReadTokens: number
+      totalCacheWriteTokens: number
+      totalCostUsd: number
+      recordCount: number
+    } {
+      return {
+        totalInputTokens: 0,
+        totalOutputTokens: 0,
+        totalCacheReadTokens: 0,
+        totalCacheWriteTokens: 0,
+        totalCostUsd: 0,
+        recordCount: 0,
+      }
+    }
+  }
+
   class EventRepository {
     countBySession(sessionId: string): number {
       return mockState.events.filter((row) => row.session_id === sessionId).length
@@ -217,6 +237,7 @@ vi.mock('@spark/storage', () => {
     SessionRepository,
     ProviderProfileRepository,
     EventRepository,
+    UsageLedgerRepository,
     RulesRepository,
     WorkspaceRepository,
     McpServerRepository,
@@ -391,6 +412,72 @@ describe('SessionService runtime provider/model resolution', () => {
       provider: 'spark',
       isFinal: true,
     }))
+  })
+
+  it('renders /usage from persisted usage_update events when ledger is empty', async () => {
+    const service = new SessionService({} as never, (event) => events.push(event))
+    const { sessionId } = await service.createSession({
+      providerProfileId: 'tencent-provider',
+      agentAdapter: 'claude-sdk',
+      permissionMode: 'claude-plan',
+      title: 'Usage session',
+    })
+
+    mockState.events.push({
+      id: 'usage-1',
+      session_id: sessionId,
+      run_id: null,
+      turn_id: 'turn-1',
+      event_type: 'usage_update',
+      event_json: JSON.stringify({
+        id: 'usage-1',
+        sessionId,
+        turnId: 'turn-1',
+        timestamp: '2026-05-28T00:00:00.000Z',
+        seq: 0,
+        type: 'usage_update',
+        provider: 'claude',
+        model: 'glm-5',
+        inputTokens: 100,
+        outputTokens: 40,
+        estimatedCostUsd: 0.0123,
+      }),
+      seq: 0,
+      created_at: '2026-05-28T00:00:00.000Z',
+    }, {
+      id: 'usage-2',
+      session_id: sessionId,
+      run_id: null,
+      turn_id: 'turn-2',
+      event_type: 'usage_update',
+      event_json: JSON.stringify({
+        id: 'usage-2',
+        sessionId,
+        turnId: 'turn-2',
+        timestamp: '2026-05-28T00:00:00.000Z',
+        seq: 1,
+        type: 'usage_update',
+        provider: 'claude',
+        model: 'glm-5',
+        inputTokens: 25,
+        outputTokens: 10,
+        estimatedCostUsd: 0.0032,
+      }),
+      seq: 1,
+      created_at: '2026-05-28T00:00:00.000Z',
+    })
+
+    const result = await service.executeCommandAsEvents({ sessionId, message: '/usage' })
+
+    expect(result).toMatchObject({ isCommand: true, forwardToAgent: false, started: false })
+    const assistant = events.slice().reverse().find((event: AgentEvent) => event.type === 'assistant_message')
+    expect(assistant).toEqual(expect.objectContaining({
+      type: 'assistant_message',
+      provider: 'spark',
+      content: expect.stringContaining('125'),
+    }))
+    expect((assistant as Extract<AgentEvent, { type: 'assistant_message' }> | undefined)?.content).toContain('50')
+    expect((assistant as Extract<AgentEvent, { type: 'assistant_message' }> | undefined)?.content).toContain('$0.0155')
   })
 
   it('passes selected attachments into the Claude SDK turn config', async () => {

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -18,6 +18,7 @@ import {
   TeamDispatchRepository,
   TeamDefinitionRepository,
   MediaModelManifestRepository,
+  UsageLedgerRepository,
 } from '@spark/storage'
 import type { AgentItem, WorkflowItem } from '@spark/storage'
 import type { SparkDatabase } from '@spark/storage'
@@ -178,6 +179,51 @@ const HISTORY_CONTEXT_ENTRY_MAX_CHARS = 4_000
 const TERMINAL_AGENT_STATUSES = new Set<string>(['idle', 'completed', 'cancelled', 'error'])
 // Keep SDK resume opt-in until the Claude Code child process can recover cleanly from resume failures.
 const ENABLE_CLAUDE_SDK_RESUME = false
+
+type SessionUsageTotals = { totalInputTokens: number; totalOutputTokens: number; totalCost: number }
+
+function getSessionUsageFromPersistence(db: SparkDatabase, eventRepo: EventRepository, sessionId: string): SessionUsageTotals | null {
+  try {
+    const ledgerUsage = new UsageLedgerRepository(db).getSessionUsage(sessionId)
+    if (ledgerUsage.recordCount > 0) {
+      return {
+        totalInputTokens: ledgerUsage.totalInputTokens,
+        totalOutputTokens: ledgerUsage.totalOutputTokens,
+        totalCost: ledgerUsage.totalCostUsd,
+      }
+    }
+  } catch {
+    // Usage ledger may be unavailable in older test doubles or partially migrated databases.
+  }
+
+  let totalInputTokens = 0
+  let totalOutputTokens = 0
+  let totalCost = 0
+  let usageEventCount = 0
+
+  for (const row of eventRepo.queryBySession({ sessionId, eventType: 'usage_update', limit: 10_000 }).events) {
+    try {
+      const event = JSON.parse(row.event_json) as Partial<AgentEvent> & {
+        inputTokens?: unknown
+        outputTokens?: unknown
+        estimatedCostUsd?: unknown
+      }
+      const inputTokens = typeof event.inputTokens === 'number' ? event.inputTokens : 0
+      const outputTokens = typeof event.outputTokens === 'number' ? event.outputTokens : 0
+      const estimatedCostUsd = typeof event.estimatedCostUsd === 'number' ? event.estimatedCostUsd : 0
+      totalInputTokens += inputTokens
+      totalOutputTokens += outputTokens
+      totalCost += estimatedCostUsd
+      usageEventCount += 1
+    } catch {
+      // Ignore malformed historical events.
+    }
+  }
+
+  if (usageEventCount === 0) return null
+  return { totalInputTokens, totalOutputTokens, totalCost }
+}
+
 /**
  * Canvas Agent 桥：由主进程注入。SessionService 在 sendTurn 时调用
  * `canvasMcpProvider(sessionId)` 拿到 in-process MCP server 配置；若 session
@@ -425,10 +471,7 @@ export class SessionService {
       getSessionEventCount: (id) => {
         return eventRepo.countBySession(id)
       },
-      getSessionUsage: (_id) => {
-        // TODO: integrate with UsageLedger
-        return null
-      },
+      getSessionUsage: (id) => getSessionUsageFromPersistence(this.db, eventRepo, id),
       listSessionCheckpoints: (id) => listSessionCheckpointsFromEvents(eventRepo, id),
       restoreCheckpoint: async (id, checkpointRef) =>
         restoreSessionCheckpoint({
@@ -522,7 +565,7 @@ export class SessionService {
         }
       },
       getSessionEventCount: (id) => eventRepo.countBySession(id),
-      getSessionUsage: (_id) => null,
+      getSessionUsage: (id) => getSessionUsageFromPersistence(this.db, eventRepo, id),
       listSessionCheckpoints: (id) => listSessionCheckpointsFromEvents(eventRepo, id),
       restoreCheckpoint: async (id, checkpointRef) =>
         restoreSessionCheckpoint({


### PR DESCRIPTION
### Motivation
- Surface accurate session usage totals to `/status` and `/usage` commands by providing `CommandDeps.getSessionUsage(sessionId)` instead of returning `null`.

### Description
- Implemented `getSessionUsageFromPersistence(db, eventRepo, sessionId)` which prefers `UsageLedgerRepository.getSessionUsage(sessionId)` and falls back to summing `usage_update` events from `EventRepository` (summing `inputTokens`, `outputTokens`, `estimatedCostUsd`).
- Wired `getSessionUsage: (id) => getSessionUsageFromPersistence(this.db, eventRepo, id)` into `CommandDeps` in both `executeCommand` and `executeCommandAsEvents` code paths in `packages/agent-runtime/src/services/session.service.ts`.
- Added a unit test to `packages/agent-runtime/src/__tests__/core/command-registry.test.ts` to assert `/usage` renders totals from the injected `getSessionUsage` dep.
- Added a mock `UsageLedgerRepository` and a test in `packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts` that injects `usage_update` events and verifies `/usage` returns aggregated totals when the ledger is empty.

### Testing
- Ran the focused tests with `pnpm --filter @spark/agent-runtime exec vitest run src/__tests__/core/command-registry.test.ts src/__tests__/services/session-runtime-config.test.ts` and they passed.
- Ran TypeScript check with `pnpm --filter @spark/agent-runtime typecheck` and it passed.
- A broader `test:unit` run in this environment exercised unrelated existing test failures (external deps / platform differences); the changes in this PR are covered by the targeted tests above and the typecheck run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392ccaf448323a8bce2258b1e1a98)