### PR TITLE
Handle `/copy` slash command in renderer

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -12,7 +12,7 @@
 
 import { typedIpcHandle, pushStreamEvent } from './typed-ipc.js'
 import { getCanvasHostBridge } from '../canvas-host-bridge.js'
-import { app, dialog, shell, Notification } from 'electron'
+import { app, clipboard, dialog, shell, Notification } from 'electron'
 import { execFile } from 'node:child_process'
 import crypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
@@ -3209,6 +3209,11 @@ export function registerAllIpcHandlers(): void {
   typedIpcHandle('file:read-text', async (req) => {
     const content = await fs.readFile(req.path, 'utf-8')
     return { content }
+  })
+
+  typedIpcHandle('clipboard:write-text', async (req) => {
+    clipboard.writeText(req.text)
+    return { success: true }
   })
 
   // ─── App Info Handlers ─────────────────────────────────────────────────────

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -76,6 +76,7 @@ import {
   resolveComposerRunningAgentIds,
 } from '../services/composer-working-state'
 import { shouldShowScrollToBottom } from './chat-scroll'
+import { getLastAssistantMessageMarkdown, isLocalCopySlashCommand } from './chat-copy'
 import { useToast } from '../components/Toast'
 import { parseSkillManifest } from '../utils/skills-data'
 import {
@@ -871,6 +872,7 @@ export function ChatView({
         contextInputTokens={contextInputTokens}
         contextUsage={contextUsage}
         isWorking={composerIsWorking}
+        messages={activeMessages}
         approvalRequest={approvalRequest}
         {...(onApprovalClose !== undefined ? { onApprovalClose } : {})}
         onCreateSession={(options) =>
@@ -916,6 +918,7 @@ export function ChatView({
         contextInputTokens={contextInputTokens}
         contextUsage={contextUsage}
         isWorking={composerIsWorking}
+        messages={activeMessages}
         approvalRequest={approvalRequest}
         {...(onApprovalClose !== undefined ? { onApprovalClose } : {})}
         onCreateSession={(options) =>
@@ -6152,6 +6155,7 @@ function ComposerV2({
   contextInputTokens,
   contextUsage,
   isWorking,
+  messages,
   approvalRequest,
   onApprovalClose,
   onCreateSession,
@@ -6195,6 +6199,7 @@ function ComposerV2({
   contextInputTokens: number
   contextUsage: ContextUsageState | null
   isWorking: boolean
+  messages: UIMessage[]
   approvalRequest?: PermissionApprovalRequest | null
   onApprovalClose?: (sessionId: string, requestId?: string) => void
   onCreateSession: (options: {
@@ -6328,6 +6333,7 @@ function ComposerV2({
   const { invoke: cancelQueuedTurn } = useIpcInvoke('session:cancel-queued-turn')
   const { invoke: sendQueuedTurnNow } = useIpcInvoke('session:send-queued-turn-now')
   const { invoke: getSetting } = useIpcInvoke('settings:get')
+  const { invoke: writeClipboardText } = useIpcInvoke('clipboard:write-text')
   const pendingRuntimePatchRef = useRef<SessionRuntimePatch>({})
 
   const effectiveAgentId = session?.agentId ?? draftAgentId
@@ -6736,6 +6742,27 @@ function ComposerV2({
       const requestAttachments = toSessionAttachments(turnAttachments)
       // 斜杠命令拦截：以 / 开头的消息走 command:execute
       if (text.startsWith('/')) {
+        if (isLocalCopySlashCommand(text)) {
+          const markdown = getLastAssistantMessageMarkdown(messages)
+          if (markdown == null) {
+            toast.error('没有可复制的上一条 Assistant 消息。')
+            setValue(text)
+            return
+          }
+          setSending(true)
+          try {
+            await writeClipboardText({ text: markdown })
+            toast.success('已复制上一条 Assistant 消息。')
+            clearDraftBuckets([draftBucketKey, session?.id, 'draft:new'])
+          } catch (err) {
+            console.error('复制上一条 Assistant 消息失败', err)
+            toast.error(err instanceof Error ? err.message : '复制失败')
+            setValue(text)
+          } finally {
+            setSending(false)
+          }
+          return
+        }
         setSending(true)
         try {
           // 如果没有活跃 session，先创建一个（命令需要 session 上下文）。
@@ -6898,6 +6925,8 @@ function ComposerV2({
       onSent,
       refreshQueueState,
       selectedProvider,
+      messages,
+      writeClipboardText,
       sendTurn,
       session?.id,
       createWorktree,

--- a/apps/desktop/src/renderer/design/views/chat-copy.ts
+++ b/apps/desktop/src/renderer/design/views/chat-copy.ts
@@ -1,0 +1,39 @@
+import type { UIBlock, UIMessage } from '../services/event-mapper'
+
+export function isLocalCopySlashCommand(text: string): boolean {
+  return /^\/copy(?:\s|$)/i.test(text.trim())
+}
+
+export function serializeAssistantMessageToMarkdown(message: UIMessage): string {
+  return message.blocks
+    .map((block: UIBlock) => {
+      switch (block.kind) {
+        case 'text':
+          return block.content.trim()
+        case 'thinking':
+          return block.content.trim() ? `> ${block.content.trim().replace(/\n/g, '\n> ')}` : ''
+        case 'error':
+          return `**错误:** ${block.message}`.trim()
+        case 'tool_call': {
+          const output = block.output ?? block.error ?? ''
+          return output.trim() ? `\`\`\`\n${output.trim()}\n\`\`\`` : ''
+        }
+        case 'file_change':
+          return block.diff?.trim()
+            ? `### ${block.changeType}: ${block.path}\n\n\`\`\`diff\n${block.diff.trim()}\n\`\`\``
+            : `### ${block.changeType}: ${block.path}`
+        default:
+          return ''
+      }
+    })
+    .filter((part) => part.length > 0)
+    .join('\n\n')
+    .trim()
+}
+
+export function getLastAssistantMessageMarkdown(messages: UIMessage[]): string | null {
+  const message = [...messages].reverse().find((item) => item.role === 'assistant')
+  if (message == null) return null
+  const markdown = serializeAssistantMessageToMarkdown(message)
+  return markdown.length > 0 ? markdown : null
+}

--- a/apps/desktop/src/renderer/tests/renderer.test.ts
+++ b/apps/desktop/src/renderer/tests/renderer.test.ts
@@ -12,6 +12,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ToastProvider } from '../design/components/Toast'
+import type { UIMessage } from '../design/services/event-mapper'
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -22,6 +23,60 @@ vi.mock('react-router-dom', async () => {
     ...actual,
     BrowserRouter: ({ children }: { children: React.ReactNode }) => children,
   }
+})
+
+describe('ChatView /copy helpers', () => {
+  it('serializes the last assistant message to Markdown', async () => {
+    const { getLastAssistantMessageMarkdown, isLocalCopySlashCommand } = await import(
+      '../design/views/chat-copy'
+    )
+    const messages: UIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        status: 'completed',
+        blocks: [{ kind: 'text', content: 'copy what?', isStreaming: false }],
+        usage: null,
+        eventIds: [],
+      },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        status: 'completed',
+        blocks: [{ kind: 'text', content: 'First answer', isStreaming: false }],
+        usage: null,
+        eventIds: [],
+      },
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        status: 'completed',
+        blocks: [{ kind: 'text', content: '## Latest\n\nUse this.', isStreaming: false }],
+        usage: null,
+        eventIds: [],
+      },
+    ]
+
+    expect(isLocalCopySlashCommand('/copy')).toBe(true)
+    expect(isLocalCopySlashCommand('/copy please')).toBe(true)
+    expect(getLastAssistantMessageMarkdown(messages)).toBe('## Latest\n\nUse this.')
+  })
+
+  it('returns null when there is no assistant message to copy', async () => {
+    const { getLastAssistantMessageMarkdown } = await import('../design/views/chat-copy')
+    const messages: UIMessage[] = [
+      {
+        id: 'user-1',
+        role: 'user',
+        status: 'completed',
+        blocks: [{ kind: 'text', content: 'hello', isStreaming: false }],
+        usage: null,
+        eventIds: [],
+      },
+    ]
+
+    expect(getLastAssistantMessageMarkdown(messages)).toBeNull()
+  })
 })
 
 describe('Renderer Smoke Tests', () => {

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -355,7 +355,6 @@ function registerSdkCommands(registry: CommandRegistry): void {
         '`/memory` — 管理记忆文件',
         '`/skill list|run` — Skill 管理',
         '`/add-dir <path>` — 添加工作目录',
-        '`/copy` — 复制上次输出',
         '`/goal <objective>` — 设置任务目标',
         '',
         '▸ **Agent 技能命令** (Layer 3)',
@@ -719,19 +718,6 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'workspace',
     risk: 'none',
     usage: '/review [instructions]',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
-  })
-
-  registry.register({
-    id: 'sdk:codex:copy',
-    name: 'copy',
-    aliases: [],
-    layer: 'sdk',
-    group: 'utility',
-    description: '复制上次 agent 输出为 Markdown',
-    scope: 'session',
-    risk: 'none',
-    usage: '/copy',
     handler: async () => ({ success: true, message: '', forwardToAgent: true }),
   })
 

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -770,6 +770,14 @@ export interface FileReadTextResponse {
   content: string
 }
 
+export interface ClipboardWriteTextRequest {
+  text: string
+}
+
+export interface ClipboardWriteTextResponse {
+  success: boolean
+}
+
 // ─── App Paths Channels ──────────────────────────────────────────────────────
 
 export interface AppGetTempProjectDirRequest {}
@@ -3962,6 +3970,7 @@ export interface IpcChannelMap {
   // File operations
   'file:write-text': [FileWriteTextRequest, FileWriteTextResponse]
   'file:read-text': [FileReadTextRequest, FileReadTextResponse]
+  'clipboard:write-text': [ClipboardWriteTextRequest, ClipboardWriteTextResponse]
 
   // App Info
   'app:get-info': [AppGetInfoRequest, AppGetInfoResponse]

--- a/packages/protocol/src/schemas/index.ts
+++ b/packages/protocol/src/schemas/index.ts
@@ -233,6 +233,10 @@ export const FilePrepareImagePreviewRequestSchema = z.object({
   sourcePath: z.string().min(1),
 })
 
+export const ClipboardWriteTextRequestSchema = z.object({
+  text: z.string().max(10_000_000),
+})
+
 export const SessionCancelRequestSchema = z.object({
   sessionId: SessionIdSchema,
 })
@@ -524,6 +528,7 @@ export const IpcSchemaRegistry = {
   'dialog:open-file': DialogOpenFileRequestSchema,
   'file:save-pasted-image': FileSavePastedImageRequestSchema,
   'file:prepare-image-preview': FilePrepareImagePreviewRequestSchema,
+  'clipboard:write-text': ClipboardWriteTextRequestSchema,
   'app:get-startup-settings': z.object({}),
   'app:set-startup-settings': z.object({
     openAtLogin: z.boolean(),


### PR DESCRIPTION
### Motivation

- 避免把简单的复制操作发到 Agent 端执行，将 `/copy` 在 renderer 本地处理以减少误导性 agent turn。 
- 提供受控的剪贴板写入通道以满足桌面端复制需求并保持主/渲染进程边界清晰。 
- 同步更新 runtime 的命令注册，防止 `/copy` 在 runtime 被当成可转发命令。

### Description

- 在渲染端 `ComposerV2`（`apps/desktop/src/renderer/design/views/ChatView.tsx`）拦截以 `/` 开头的命令，检测并本地处理 `/copy`，找到最后一条 assistant 消息并序列化为 Markdown 后通过 IPC 写入剪贴板。 
- 提取复制相关逻辑到 `apps/desktop/src/renderer/design/views/chat-copy.ts`，新增 `isLocalCopySlashCommand`、`serializeAssistantMessageToMarkdown` 和 `getLastAssistantMessageMarkdown` 辅助函数。 
- 新增 typed IPC `clipboard:write-text`：在 protocol 定义中增加 request/response 类型与 zod schema（`packages/protocol/src/ipc/index.ts`、`packages/protocol/src/schemas/index.ts`），并在主进程实现 handler 使用 Electron 的 `clipboard.writeText`（`apps/desktop/src/main/ipc/index.ts`）。 
- 从 agent runtime 的 SDK 命令注册中移除 `/copy`（`packages/agent-runtime/src/core/command-registry.ts`），避免将复制命令误导为 agent 转发操作。 
- 增加单元测试覆盖 `getLastAssistantMessageMarkdown` 与命令识别（`apps/desktop/src/renderer/tests/renderer.test.ts`）。

### Testing

- 运行针对新 helper 的单测：
  - `pnpm --filter @spark/desktop exec vitest run src/renderer/tests/renderer.test.ts -t "ChatView /copy helpers"` — 通过（目标测试通过）。
- 类型检查：`pnpm --filter @spark/desktop typecheck` — 通过。 
- 已尝试按仓库要求运行 GitNexus 的 impact/detect 分析以评估改动影响，但运行环境中缺少 `.gitnexus/run.cjs` 且 `npx gitnexus` 未产出可用分析结果，因此未能生成 blast-radius 报告（按仓库 AGENTS.md 尝试执行分析，但工具在当前环境中无法完成）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392ce8c9083238dfd315333987ebf)