### PR TITLE
Remove unsupported /side command forwarding

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -251,6 +251,19 @@ describe('Built-in commands', () => {
     expect(result.success).toBe(false)
   })
 
+  it('/side is removed instead of forwarding as a normal agent turn', async () => {
+    const result = await registry.execute(parse('/side should be separate'), ctx, makeDeps())
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('/help')
+    expect(result.forwardToAgent).not.toBe(true)
+  })
+
+  it('/btw alias is removed with /side', async () => {
+    const result = await registry.execute(parse('/btw should be separate'), ctx, makeDeps())
+    expect(result.success).toBe(false)
+    expect(result.forwardToAgent).not.toBe(true)
+  })
+
   it('/git add forwards to agent', async () => {
     const result = await registry.execute(parse('/git add .'), ctx, makeDeps())
     expect(result.success).toBe(true)

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -747,19 +747,6 @@ function registerSdkCommands(registry: CommandRegistry): void {
     usage: '/plan [task]',
     handler: async () => ({ success: true, message: '', forwardToAgent: true }),
   })
-
-  registry.register({
-    id: 'sdk:codex:side',
-    name: 'side',
-    aliases: ['btw'],
-    layer: 'sdk',
-    group: 'utility',
-    description: '开启旁路对话',
-    scope: 'session',
-    risk: 'none',
-    usage: '/side [message]',
-    handler: async () => ({ success: true, message: '', forwardToAgent: true }),
-  })
 }
 
 function readWorkspaceScripts(cwd: string): Record<string, string> {


### PR DESCRIPTION
### Motivation

- The product currently does not support true "side" conversations, so registering `/side` (and its alias `/btw`) as an SDK command incorrectly caused those messages to be forwarded as ordinary agent turns.
- To avoid confusing behavior and accidental context pollution, `/side` should be treated as unsupported for now and surface as an unknown command.

### Description

- Removed the `/side` SDK command registration from `packages/agent-runtime/src/core/command-registry.ts` so it is no longer present in the built-in SDK commands.
- Added tests in `packages/agent-runtime/src/__tests__/core/command-registry.test.ts` to assert that `/side` and `/btw` are reported as unknown commands and do not set `forwardToAgent`.
- Kept other SDK commands intact and limited the change to the command registration and corresponding unit tests.

### Testing

- Ran the targeted tests with `pnpm --filter @spark/agent-runtime exec vitest run src/__tests__/core/command-registry.test.ts`, and the test file passed (`44 tests` all green).
- A full `test:unit` run for the package exercised many suites; the `command-registry` tests passed but the full run reported unrelated failures/timeouts and environment issues (e.g. missing `libsecret-1.so.0`, timeouts, and some existing assertion failures) that are not caused by this change.
- Attempted to run `gitnexus`/impact/detect_changes as required by the repo guidance, but `gitnexus`/`.gitnexus/run.cjs` could not be executed (module/installation/network failures), so `impact()`/`detect_changes()` could not be completed prior to commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392d026e883238720cf7be2c978ad)