### PR TITLE
fix(agent-runtime): detect .claude/commands directory in init

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -285,6 +285,40 @@ describe('Built-in commands', () => {
     expect(result.message).toContain('M src/app.ts')
   })
 
+  it('/init returns existing project config when .claude/commands directory exists', async () => {
+    const execShell = vi.fn(async () => ({ stdout: 'exists\n', stderr: '', exitCode: 0 }))
+    const deps = makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell,
+    })
+
+    const result = await registry.execute(parse('/init'), ctx, deps)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('项目配置已存在')
+    expect(execShell).toHaveBeenCalledTimes(1)
+    expect(execShell).toHaveBeenCalledWith('test -d .claude/commands && echo "exists" || echo "not_found"', '/fake/workspace')
+  })
+
+  it('/init creates .claude/commands directory for an empty workspace', async () => {
+    const execShell = vi.fn(async (command: string) => ({
+      stdout: command.startsWith('test -d ') ? 'not_found\n' : '',
+      stderr: '',
+      exitCode: 0,
+    }))
+    const deps = makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell,
+    })
+
+    const result = await registry.execute(parse('/init'), ctx, deps)
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('已创建 `.claude/commands/` 目录')
+    expect(execShell).toHaveBeenNthCalledWith(1, 'test -d .claude/commands && echo "exists" || echo "not_found"', '/fake/workspace')
+    expect(execShell).toHaveBeenNthCalledWith(2, 'mkdir -p .claude/commands', '/fake/workspace')
+  })
+
   it('/skill run selects a skill for the follow-up turn', async () => {
     const result = await registry.execute(parse('/skill run skill:review inspect changes'), ctx, makeDeps({
       listSkills: () => [{

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -671,7 +671,7 @@ function registerSdkCommands(registry: CommandRegistry): void {
         return { success: false, message: 'Shell 执行不可用。' }
       }
       try {
-        const { stdout } = await deps.execShell('test -f .claude/commands && echo "exists" || echo "not_found"', cwd)
+        const { stdout } = await deps.execShell('test -d .claude/commands && echo "exists" || echo "not_found"', cwd)
         if (stdout.trim() === 'exists') {
           return { success: true, message: '项目配置已存在。如需重新初始化，请先删除 `.claude/` 目录。' }
         }


### PR DESCRIPTION
### Motivation
- Ensure `/init` checks for the presence of a `.claude/commands` directory (not a file) so the handler correctly detects an existing commands directory and creates it when missing under an existing `.claude` directory.  

### Description
- Change existence check in the `/init` handler from `test -f .claude/commands && echo "exists" || echo "not_found"` to `test -d .claude/commands && echo "exists" || echo "not_found"` in `packages/agent-runtime/src/core/command-registry.ts`.  
- Preserve the creation step `mkdir -p .claude/commands` so `.claude` can exist while `commands` is created if absent.  
- Add unit tests covering both scenarios in `packages/agent-runtime/src/__tests__/core/command-registry.test.ts`: one test where `.claude/commands/` already exists and `/init` returns the existing-config message, and one test where workspace is empty and `/init` invokes `mkdir -p .claude/commands`.

### Testing
- Ran `pnpm exec vitest run src/__tests__/core/command-registry.test.ts` inside `packages/agent-runtime`, and the `command-registry` test file passed (44 tests passed).  
- Attempting the full package test command (`pnpm --filter @spark/agent-runtime test:unit` with the extra arg) caused the whole runtime suite to run and surfaced unrelated existing failures, including missing `libsecret-1.so.0` for `keytar`, a timed-out scheduled-task test, and a few SDK-related assertion failures.  
- Attempted `npx gitnexus detect_changes --scope compare --base-ref master` for impact detection but the `gitnexus` run timed out in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392d1aae88323b29f61637a530c4d)