### PR TITLE
fix(git): validate `/git log [n]` limit (1-100) and add tests

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -285,6 +285,38 @@ describe('Built-in commands', () => {
     expect(result.message).toContain('M src/app.ts')
   })
 
+  it('/git log with numeric limit executes locally', async () => {
+    const deps = makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell: vi.fn(async () => ({ stdout: 'abc123 test commit', stderr: '', exitCode: 0 })),
+    })
+    const result = await registry.execute(parse('/git log 5'), ctx, deps)
+    expect(result.success).toBe(true)
+    expect(deps.execShell).toHaveBeenCalledWith('git log --oneline -5', '/fake/workspace')
+  })
+
+  it('/git log rejects non-numeric limit', async () => {
+    const deps = makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    })
+    const result = await registry.execute(parse('/git log foo'), ctx, deps)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('用法：/git log [n]')
+    expect(deps.execShell).not.toHaveBeenCalled()
+  })
+
+  it('/git log rejects shell injection attempts without executing', async () => {
+    const deps = makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    })
+    const result = await registry.execute(parse('/git log "1; rm -rf /"'), ctx, deps)
+    expect(result.success).toBe(false)
+    expect(result.message).toContain('用法：/git log [n]')
+    expect(deps.execShell).not.toHaveBeenCalled()
+  })
+
   it('/skill run selects a skill for the follow-up turn', async () => {
     const result = await registry.execute(parse('/skill run skill:review inspect changes'), ctx, makeDeps({
       listSkills: () => [{

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -146,6 +146,18 @@ export interface CommandListItem {
    ============================================================ */
 
 /** Convert a skill name to a slug suitable for a slash command. */
+const GIT_LOG_LIMIT_USAGE = '用法：/git log [n]（n 必须是 1-100 的正整数）'
+
+function parseGitLogLimit(value: string | undefined): number | null {
+  const raw = value ?? '10'
+  if (!/^[1-9]\d*$/.test(raw)) return null
+
+  const limit = Number(raw)
+  if (!Number.isSafeInteger(limit) || limit > 100) return null
+
+  return limit
+}
+
 function slugify(name: string): string {
   return name
     .toLowerCase()
@@ -1042,8 +1054,11 @@ function registerBuiltinCommands(registry: CommandRegistry): void {
           return { success: true, message: stdout.trim() ? `\`\`\`\n${stdout}\n\`\`\`` : '工作区干净，无变更。' }
         }
         if (subcommand === 'log') {
-          const n = cmd.args[1] || '10'
-          const { stdout } = await deps.execShell(`git log --oneline -${n}`, cwd)
+          const limit = parseGitLogLimit(cmd.args[1])
+          if (limit == null) {
+            return { success: false, message: GIT_LOG_LIMIT_USAGE }
+          }
+          const { stdout } = await deps.execShell(`git log --oneline -${limit}`, cwd)
           return { success: true, message: `\`\`\`\n${stdout}\n\`\`\`` }
         }
         if (subcommand === 'stash') {


### PR DESCRIPTION
### Motivation

- Prevent shell-injection and malformed input when running `/git log [n]` by validating the numeric limit before constructing the shell command. 
- Provide a clear usage error for invalid input and impose a reasonable upper bound (100) to avoid excessive output.

### Description

- Add `GIT_LOG_LIMIT_USAGE` and `parseGitLogLimit` to validate that the `n` argument is a positive integer between 1 and 100 and return a numeric `limit` or `null` on invalid input in `packages/agent-runtime/src/core/command-registry.ts`.
- Replace the previous naive `const n = cmd.args[1] || '10'` usage with `parseGitLogLimit(cmd.args[1])`, returning `success: false` and the usage string when validation fails, and using the validated `limit` to build the `git log --oneline -${limit}` command.
- Add unit tests in `packages/agent-runtime/src/__tests__/core/command-registry.test.ts` covering: a numeric limit (`/git log 5`) invoking `execShell` with the validated `-5`, a non-numeric input (`/git log foo`) returning an error and not calling `execShell`, and a quoted injection-like input (`/git log "1; rm -rf /"`) also rejected without executing `execShell`.

### Testing

- Ran the command-targeted unit tests with `pnpm vitest run src/__tests__/core/command-registry.test.ts` from `packages/agent-runtime` and the suite passed (`45 tests` passed).
- Ran TypeScript check with `pnpm --filter @spark/agent-runtime typecheck` and it passed without errors.
- Attempted broader checks (`pnpm --filter @spark/agent-runtime test:unit` and GitNexus `detect_changes`/`impact`) but the environment run surfaced unrelated/timeboxed failures or install timeouts; the change-specific unit tests and typecheck succeeded and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392d305048323b37e830850dad866)