### PR TITLE
feat(agent-runtime): expand /doctor diagnostics and CommandDeps (SDK, shell, MCP, agent health)

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -285,6 +285,125 @@ describe('Built-in commands', () => {
     expect(result.message).toContain('M src/app.ts')
   })
 
+  it('/doctor reports missing workspace', async () => {
+    const result = await registry.execute(parse('/doctor'), ctx, makeDeps({
+      getWorkspacePath: () => null,
+      execShell: vi.fn(async (command: string) => ({
+        stdout: command.includes('git --version') ? 'git version 2.40.0' : 'spark-shell-ok',
+        stderr: '',
+        exitCode: 0,
+      })),
+      checkSdkAvailability: vi.fn(async () => ({ claudeSdk: true, codexCli: true, openaiSdk: true })),
+      checkWorkspaceShell: vi.fn(async () => ({ available: true, shell: '/bin/bash' })),
+      getCurrentAgentSummary: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'Agent',
+        exists: true,
+        enabled: true,
+        hasModelConfig: true,
+      })),
+      getMcpStatusSummary: vi.fn(() => []),
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('## Session')
+    expect(result.message).toContain('Workspace: ⚠️ 未打开')
+    expect(result.message).toContain('未打开 workspace')
+  })
+
+  it('/doctor reports missing shell', async () => {
+    const result = await registry.execute(parse('/doctor'), ctx, makeDeps({
+      getWorkspacePath: () => '/workspace/app',
+      checkSdkAvailability: vi.fn(async () => ({ claudeSdk: true, codexCli: true, openaiSdk: true })),
+      checkWorkspaceShell: vi.fn(async () => ({ available: false, error: 'ENOENT' })),
+      getCurrentAgentSummary: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'Agent',
+        exists: true,
+        enabled: true,
+        hasModelConfig: true,
+      })),
+      getMcpStatusSummary: vi.fn(() => []),
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Shell: ❌ 不可用：ENOENT')
+    expect(result.message).toContain('workspace shell 不可执行')
+  })
+
+  it('/doctor reports missing provider and model', async () => {
+    const result = await registry.execute(parse('/doctor'), ctx, makeDeps({
+      getSession: vi.fn(() => ({ title: 'Test', status: 'idle', modelId: null, providerProfileId: '' })),
+      getProviderName: vi.fn(() => null),
+      getWorkspacePath: () => '/workspace/app',
+      execShell: vi.fn(async (command: string) => ({
+        stdout: command.includes('git --version') ? 'git version 2.40.0' : 'spark-shell-ok',
+        stderr: '',
+        exitCode: 0,
+      })),
+      checkSdkAvailability: vi.fn(async () => ({ claudeSdk: true, codexCli: true, openaiSdk: true })),
+      checkWorkspaceShell: vi.fn(async () => ({ available: true, shell: '/bin/bash' })),
+      getCurrentAgentSummary: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'Agent',
+        exists: true,
+        enabled: true,
+        hasModelConfig: false,
+      })),
+      getMcpStatusSummary: vi.fn(() => []),
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('Provider: ❌ 未配置')
+    expect(result.message).toContain('Model: ⚠️ 未配置')
+    expect(result.message).toContain('当前 session 缺少 provider 配置')
+  })
+
+  it('/doctor reports all healthy sections', async () => {
+    const result = await registry.execute(parse('/doctor'), ctx, makeDeps({
+      getSession: vi.fn(() => ({
+        title: 'Test',
+        status: 'idle',
+        modelId: 'gpt-4.1',
+        providerProfileId: 'p1',
+        agentAdapter: 'codex',
+        permissionMode: 'codex-default',
+        agentId: 'agent-1',
+      })),
+      getWorkspacePath: () => '/workspace/app',
+      execShell: vi.fn(async (command: string) => ({
+        stdout: command.includes('git --version') ? 'git version 2.40.0' : 'spark-shell-ok',
+        stderr: '',
+        exitCode: 0,
+      })),
+      checkSdkAvailability: vi.fn(async () => ({ claudeSdk: true, codexCli: true, openaiSdk: true })),
+      checkWorkspaceShell: vi.fn(async () => ({ available: true, shell: '/bin/bash' })),
+      getCurrentAgentSummary: vi.fn(() => ({
+        id: 'agent-1',
+        name: 'Agent',
+        exists: true,
+        enabled: true,
+        hasModelConfig: true,
+        providerProfileId: 'p1',
+        modelId: 'gpt-4.1',
+      })),
+      getMcpStatusSummary: vi.fn(() => [{
+        id: 'mcp-1',
+        name: 'Local MCP',
+        enabled: true,
+        connected: true,
+        toolCount: 3,
+      }]),
+    }))
+
+    expect(result.success).toBe(true)
+    for (const section of ['## Session', '## Provider/Model', '## Agent Adapter', '## Shell/Git', '## MCP', '## Known Issues / Suggestions']) {
+      expect(result.message).toContain(section)
+    }
+    expect(result.message).toContain('✅ 未发现明显问题')
+    expect(result.message).toContain('1/1 enabled servers connected')
+  })
+
   it('/skill run selects a skill for the follow-up turn', async () => {
     const result = await registry.execute(parse('/skill run skill:review inspect changes'), ctx, makeDeps({
       listSkills: () => [{

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -108,7 +108,7 @@ export interface CommandDefinition {
 
 /** 命令执行所需的外部依赖（由 SessionService 注入） */
 export interface CommandDeps {
-  getSession: (id: string) => { title: string; status: string; modelId: string | null; providerProfileId: string } | null
+  getSession: (id: string) => { title: string; status: string; modelId: string | null; providerProfileId: string; agentAdapter?: string; permissionMode?: string; agentId?: string | null } | null
   updateSession: (id: string, fields: { modelId?: string | null; title?: string }) => Promise<void>
   clearSessionEvents: (id: string) => Promise<void>
   getProviderName: (id: string) => string | null
@@ -125,7 +125,13 @@ export interface CommandDeps {
   listSessionCheckpoints?: (id: string) => CheckpointSnapshot[]
   restoreCheckpoint?: (sessionId: string, checkpointRef: string) => Promise<CheckpointRestoreResult>
   listSkills?: (query?: string) => Array<{ id: string; name: string; description: string; tags: string[]; enabled: boolean }>
+  getSessionRuntimeInfo?: (sessionId: string) => { providerProfileId?: string | null; providerName?: string | null; modelId?: string | null; agentAdapter?: string | null; permissionMode?: string | null } | null
+  checkSdkAvailability?: () => Promise<{ claudeSdk: boolean; codexCli: boolean; openaiSdk: boolean }>
+  checkWorkspaceShell?: (cwd?: string | null) => Promise<{ available: boolean; shell?: string; error?: string }>
+  getMcpStatusSummary?: () => Array<{ id: string; name: string; enabled: boolean; connected: boolean; toolCount: number; error?: string }>
+  getCurrentAgentSummary?: (sessionId: string) => { id: string; name: string; exists: boolean; enabled: boolean; hasModelConfig: boolean; providerProfileId?: string | null; modelId?: string | null } | null
 }
+
 
 /** 命令面板展示用的轻量类型 */
 export interface CommandListItem {
@@ -514,25 +520,77 @@ function registerSdkCommands(registry: CommandRegistry): void {
     scope: 'global',
     risk: 'none',
     usage: '/doctor',
-    handler: async (_cmd, _ctx, deps) => {
-      const lines: string[] = ['**环境诊断**', '']
-      // Check git
-      if (deps.execShell) {
-        try {
-          const { stdout } = await deps.execShell('git --version')
-          lines.push(`✅ Git: ${stdout.trim()}`)
-        } catch {
-          lines.push('❌ Git: 未安装')
-        }
+    handler: async (_cmd, ctx, deps) => {
+      const session = deps.getSession(ctx.sessionId)
+      const runtime = deps.getSessionRuntimeInfo?.(ctx.sessionId) ?? null
+      const providerId = runtime?.providerProfileId ?? session?.providerProfileId ?? ctx.providerId ?? null
+      const providerName = runtime?.providerName ?? (providerId ? deps.getProviderName(providerId) : null)
+      const modelId = runtime?.modelId ?? session?.modelId ?? ctx.model ?? null
+      const agentAdapter = runtime?.agentAdapter ?? session?.agentAdapter ?? null
+      const permissionMode = runtime?.permissionMode ?? session?.permissionMode ?? null
+      const workspacePath = deps.getWorkspacePath?.() ?? null
+      const sdk = await resolveSdkAvailability(deps)
+      const shell = await resolveWorkspaceShell(deps, workspacePath)
+      const git = await resolveGitVersion(deps, workspacePath)
+      const mcpServers = deps.getMcpStatusSummary?.() ?? []
+      const agent = deps.getCurrentAgentSummary?.(ctx.sessionId) ?? null
+      const issues: string[] = []
+
+      if (session == null) issues.push('当前 session 不存在，请重新打开或创建会话。')
+      if (!workspacePath) issues.push('未打开 workspace，Git、验证脚本和本地 shell 能力受限。')
+      if (!shell.available) issues.push(`workspace shell 不可执行${shell.error ? `：${shell.error}` : '。'}`)
+      if (!providerId) issues.push('当前 session 缺少 provider 配置。')
+      if (!modelId) issues.push('当前 session 未显式设置 model，将依赖 provider 或 agent 默认模型。')
+      if (!agentAdapter) issues.push('当前 session 缺少 agent adapter 配置。')
+      if (agent != null) {
+        if (!agent.exists) issues.push(`当前 Agent 不存在：${agent.id}`)
+        else if (!agent.enabled) issues.push(`当前 Agent 已禁用：${agent.name}`)
+        if (!agent.hasModelConfig) issues.push(`当前 Agent 缺少模型配置：${agent.name}`)
       } else {
-        lines.push('⚠️ Shell 不可用，跳过检查')
+        issues.push('无法读取当前 Agent 配置摘要。')
       }
-      // Check workspace
-      const wsPath = deps.getWorkspacePath?.()
-      lines.push(wsPath ? `✅ 工作区: ${wsPath}` : '⚠️ 工作区: 未打开')
-      // Check session
-      lines.push('✅ Spark Agent 运行正常')
-      return { success: true, message: lines.join('\n') }
+      if (!sdk.claudeSdk && agentAdapter === 'claude-sdk') issues.push('Claude SDK 不可用，但当前 adapter 为 claude-sdk。')
+      if (!sdk.codexCli && agentAdapter === 'codex') issues.push('Codex CLI 不可用，本地 Codex adapter 可能无法运行。')
+      if (!sdk.openaiSdk) issues.push('OpenAI SDK 不可用，OpenAI Responses adapter 可能无法运行。')
+
+      const lines = [
+        '**环境诊断**',
+        '',
+        '## Session',
+        session == null ? '- ❌ Session: 不存在' : `- ✅ Session: ${ctx.sessionId} (${session.status})`,
+        `- Workspace: ${workspacePath ? `✅ ${workspacePath}` : '⚠️ 未打开'}`,
+        `- Permission Mode: ${permissionMode ? `✅ ${permissionMode}` : '⚠️ 未配置'}`,
+        '',
+        '## Provider/Model',
+        `- Provider: ${providerId ? `✅ ${providerName ?? providerId} (${providerId})` : '❌ 未配置'}`,
+        `- Model: ${modelId ? `✅ ${modelId}` : '⚠️ 未配置（使用默认）'}`,
+        `- Claude SDK: ${sdk.claudeSdk ? '✅ 可用' : '❌ 不可用'}`,
+        `- Codex CLI: ${sdk.codexCli ? '✅ 可用' : '❌ 不可用'}`,
+        `- OpenAI SDK: ${sdk.openaiSdk ? '✅ 可用' : '❌ 不可用'}`,
+        '',
+        '## Agent Adapter',
+        `- Adapter: ${agentAdapter ? `✅ ${agentAdapter}` : '❌ 未配置'}`,
+        agent == null
+          ? '- Agent: ⚠️ 未提供摘要'
+          : `- Agent: ${agent.exists ? (agent.enabled ? '✅' : '⚠️') : '❌'} ${agent.name} (${agent.id})`,
+        agent == null ? '- Agent Model Config: ⚠️ 未知' : `- Agent Model Config: ${agent.hasModelConfig ? '✅ 已配置' : '⚠️ 缺失'}`,
+        '',
+        '## Shell/Git',
+        `- Shell: ${shell.available ? `✅ 可执行${shell.shell ? ` (${shell.shell})` : ''}` : `❌ 不可用${shell.error ? `：${shell.error}` : ''}`}`,
+        `- Git: ${git.available ? `✅ ${git.version}` : `❌ 不可用${git.error ? `：${git.error}` : ''}`}`,
+        '',
+        '## MCP',
+        ...formatMcpStatus(mcpServers),
+        '',
+        '## Known Issues / Suggestions',
+        ...(issues.length > 0 ? issues.map((issue) => `- ${issue}`) : ['- ✅ 未发现明显问题。']),
+      ]
+
+      return {
+        success: true,
+        message: lines.join('\n'),
+        data: { session: session != null, workspacePath, providerId, modelId, agentAdapter, permissionMode, sdk, shell, git, mcpServers, agent, issues },
+      }
     },
   })
 
@@ -1100,6 +1158,63 @@ function registerBuiltinCommands(registry: CommandRegistry): void {
     usage: '/goal <objective> | /goal clear | /goal pause | /goal resume',
     handler: async () => ({ success: true, message: '', forwardToAgent: true }),
   })
+}
+
+async function resolveSdkAvailability(deps: CommandDeps): Promise<{ claudeSdk: boolean; codexCli: boolean; openaiSdk: boolean }> {
+  if (deps.checkSdkAvailability) return deps.checkSdkAvailability()
+  return {
+    claudeSdk: false,
+    codexCli: false,
+    openaiSdk: false,
+  }
+}
+
+async function resolveWorkspaceShell(
+  deps: CommandDeps,
+  cwd: string | null,
+): Promise<{ available: boolean; shell?: string; error?: string }> {
+  if (deps.checkWorkspaceShell) return deps.checkWorkspaceShell(cwd)
+  if (!deps.execShell) return { available: false, error: 'Shell dependency is not registered' }
+  try {
+    const result = await deps.execShell('echo spark-shell-ok', cwd ?? undefined)
+    const output = `${result.stdout}\n${result.stderr}`
+    return result.exitCode === 0 && output.includes('spark-shell-ok')
+      ? { available: true }
+      : { available: false, error: `exit ${result.exitCode}` }
+  } catch (err) {
+    return { available: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+async function resolveGitVersion(
+  deps: CommandDeps,
+  cwd: string | null,
+): Promise<{ available: boolean; version?: string; error?: string }> {
+  if (!deps.execShell) return { available: false, error: 'Shell dependency is not registered' }
+  try {
+    const result = await deps.execShell('git --version', cwd ?? undefined)
+    const output = [result.stdout, result.stderr].filter((part) => part.trim().length > 0).join('\n').trim()
+    return result.exitCode === 0
+      ? { available: true, version: output || 'git available' }
+      : { available: false, error: output || `exit ${result.exitCode}` }
+  } catch (err) {
+    return { available: false, error: err instanceof Error ? err.message : String(err) }
+  }
+}
+
+function formatMcpStatus(
+  servers: Array<{ id: string; name: string; enabled: boolean; connected: boolean; toolCount: number; error?: string }>,
+): string[] {
+  if (servers.length === 0) return ['- ⚠️ 未配置 MCP server，或当前运行时未提供 MCP 摘要。']
+  const enabled = servers.filter((server) => server.enabled)
+  const connected = enabled.filter((server) => server.connected)
+  const lines = [`- Summary: ${connected.length}/${enabled.length} enabled servers connected (${servers.length} total)`]
+  for (const server of servers) {
+    const state = server.enabled ? (server.connected ? '✅ connected' : '❌ disconnected') : '⚠️ disabled'
+    const error = server.error ? ` — ${server.error}` : ''
+    lines.push(`- ${state}: ${server.name} (${server.toolCount} tools)${error}`)
+  }
+  return lines
 }
 
 /* ============================================================

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -70,7 +70,7 @@ import { RuntimeCompositionService } from './runtime-composition.service.js'
 import { ProjectContextService } from './project-context.service.js'
 import { ValidationSuggestionService } from './validation-suggestion.service.js'
 import { SkillLoader } from '../skills/skill-loader.js'
-import { ClaudeSDKExecutor, CodexCliExecutor, CodexOpenAIExecutor } from '../sdk/index.js'
+import { ClaudeSDKExecutor, CodexCliExecutor, CodexOpenAIExecutor, isSDKAvailable } from '../sdk/index.js'
 import type { SDKExecutorConfig, SDKMcpServerConfig, SDKTurnAttachment } from '../sdk/index.js'
 import { getResumeCircuitBreaker } from '../sdk/index.js'
 import { buildConversationHistoryWithSummary } from './conversation-summarizer.js'
@@ -384,6 +384,12 @@ export class SessionService {
           status: s.status,
           modelId: s.model_id ?? null,
           providerProfileId: s.provider_profile_id ?? '',
+          agentAdapter: getAgentAdapterFromSession(s.agent_adapter, s.chat_mode, providerRepo.get(s.provider_profile_id ?? '')?.provider_type ?? null),
+          permissionMode: getPermissionModeFromSession(
+            s.permission_mode,
+            getAgentAdapterFromSession(s.agent_adapter, s.chat_mode, providerRepo.get(s.provider_profile_id ?? '')?.provider_type ?? null),
+          ),
+          agentId: s.agent_id ?? null,
         }
       },
       updateSession: async (id, fields) => {
@@ -438,6 +444,46 @@ export class SessionService {
           checkpointRef,
         }),
       listSkills: (query) => listSkillSummaries(new SkillRepository(this.db), workspacePath, query),
+      getSessionRuntimeInfo: (id) => {
+        const s = sessionRepo.get(id)
+        if (s == null) return null
+        const provider = providerRepo.get(s.provider_profile_id ?? '')
+        const adapter = getAgentAdapterFromSession(s.agent_adapter, s.chat_mode, provider?.provider_type ?? null)
+        return {
+          providerProfileId: s.provider_profile_id ?? null,
+          providerName: provider?.name ?? null,
+          modelId: s.model_id ?? null,
+          agentAdapter: adapter,
+          permissionMode: getPermissionModeFromSession(s.permission_mode, adapter),
+        }
+      },
+      checkSdkAvailability: async () => ({
+        claudeSdk: await isSDKAvailable(),
+        codexCli: await checkCommandAvailable('codex --version', workspacePath),
+        openaiSdk: await checkOpenAISdkAvailable(),
+      }),
+      checkWorkspaceShell: async (cwd) => checkWorkspaceShellAvailable(cwd ?? workspacePath),
+      getMcpStatusSummary: () => this.mcpService.listServers().map((server) => ({
+        id: server.id,
+        name: server.name,
+        enabled: server.enabled,
+        ...this.mcpService.getServerStatus(server.id),
+      })),
+      getCurrentAgentSummary: (id) => {
+        const s = sessionRepo.get(id)
+        const agentId = s?.agent_id ?? 'platform-manager-agent'
+        const agent = new AgentRepository(this.db).get(agentId)
+        if (agent == null) return { id: agentId, name: agentId, exists: false, enabled: false, hasModelConfig: false }
+        return {
+          id: agent.id,
+          name: agent.name,
+          exists: true,
+          enabled: agent.enabled,
+          hasModelConfig: Boolean(agent.providerProfileId || agent.modelId),
+          providerProfileId: agent.providerProfileId ?? null,
+          modelId: agent.modelId ?? null,
+        }
+      },
     }
 
     const ctx = {
@@ -489,6 +535,12 @@ export class SessionService {
           status: s.status,
           modelId: s.model_id ?? null,
           providerProfileId: s.provider_profile_id ?? '',
+          agentAdapter: getAgentAdapterFromSession(s.agent_adapter, s.chat_mode, providerRepo.get(s.provider_profile_id ?? '')?.provider_type ?? null),
+          permissionMode: getPermissionModeFromSession(
+            s.permission_mode,
+            getAgentAdapterFromSession(s.agent_adapter, s.chat_mode, providerRepo.get(s.provider_profile_id ?? '')?.provider_type ?? null),
+          ),
+          agentId: s.agent_id ?? null,
         }
       },
       updateSession: async (id, fields) => {
@@ -532,6 +584,46 @@ export class SessionService {
           checkpointRef,
         }),
       listSkills: (query) => listSkillSummaries(new SkillRepository(this.db), workspacePath, query),
+      getSessionRuntimeInfo: (id) => {
+        const s = sessionRepo.get(id)
+        if (s == null) return null
+        const provider = providerRepo.get(s.provider_profile_id ?? '')
+        const adapter = getAgentAdapterFromSession(s.agent_adapter, s.chat_mode, provider?.provider_type ?? null)
+        return {
+          providerProfileId: s.provider_profile_id ?? null,
+          providerName: provider?.name ?? null,
+          modelId: s.model_id ?? null,
+          agentAdapter: adapter,
+          permissionMode: getPermissionModeFromSession(s.permission_mode, adapter),
+        }
+      },
+      checkSdkAvailability: async () => ({
+        claudeSdk: await isSDKAvailable(),
+        codexCli: await checkCommandAvailable('codex --version', workspacePath),
+        openaiSdk: await checkOpenAISdkAvailable(),
+      }),
+      checkWorkspaceShell: async (cwd) => checkWorkspaceShellAvailable(cwd ?? workspacePath),
+      getMcpStatusSummary: () => this.mcpService.listServers().map((server) => ({
+        id: server.id,
+        name: server.name,
+        enabled: server.enabled,
+        ...this.mcpService.getServerStatus(server.id),
+      })),
+      getCurrentAgentSummary: (id) => {
+        const s = sessionRepo.get(id)
+        const agentId = s?.agent_id ?? 'platform-manager-agent'
+        const agent = new AgentRepository(this.db).get(agentId)
+        if (agent == null) return { id: agentId, name: agentId, exists: false, enabled: false, hasModelConfig: false }
+        return {
+          id: agent.id,
+          name: agent.name,
+          exists: true,
+          enabled: agent.enabled,
+          hasModelConfig: Boolean(agent.providerProfileId || agent.modelId),
+          providerProfileId: agent.providerProfileId ?? null,
+          modelId: agent.modelId ?? null,
+        }
+      },
     }
 
     const ctx = {
@@ -4312,6 +4404,46 @@ function getAllowedMcpServerIds(agent: AgentItem, workflow: WorkflowItem | null)
     }
   }
   return ids.size > 0 ? ids : undefined
+}
+
+async function checkCommandAvailable(command: string, cwd: string | null): Promise<boolean> {
+  const { exec } = await import('node:child_process')
+  const { promisify } = await import('node:util')
+  const execAsync = promisify(exec)
+  try {
+    await execAsync(command, { cwd: cwd ?? undefined, timeout: 5000, maxBuffer: 64 * 1024 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function checkWorkspaceShellAvailable(cwd: string | null): Promise<{ available: boolean; shell?: string; error?: string }> {
+  const { exec } = await import('node:child_process')
+  const { promisify } = await import('node:util')
+  const execAsync = promisify(exec)
+  const shell = process.env.SHELL
+  const withShell = (result: { available: boolean; error?: string }): { available: boolean; shell?: string; error?: string } => ({
+    ...result,
+    ...(shell != null ? { shell } : {}),
+  })
+  try {
+    const { stdout } = await execAsync('echo spark-shell-ok', { cwd: cwd ?? undefined, timeout: 5000, maxBuffer: 64 * 1024 })
+    return stdout.includes('spark-shell-ok')
+      ? withShell({ available: true })
+      : withShell({ available: false, error: 'unexpected shell output' })
+  } catch (err) {
+    return withShell({ available: false, error: err instanceof Error ? err.message : String(err) })
+  }
+}
+
+async function checkOpenAISdkAvailable(): Promise<boolean> {
+  try {
+    await import('openai')
+    return true
+  } catch {
+    return false
+  }
 }
 
 type NormalizedWorkflowNode = {


### PR DESCRIPTION
### Motivation

- Improve the `/doctor` diagnostic command to surface richer runtime information (session/provider/model/adapter/permissionMode) so operators can quickly identify configuration or environment problems. 
- Provide programmatic hooks in `CommandDeps` so the SessionService can supply SDK/CLI availability, workspace shell capability, MCP server summaries, and a current-Agent health snapshot for diagnostics.

### Description

- Extended `CommandDeps` with optional APIs: `getSessionRuntimeInfo`, `checkSdkAvailability`, `checkWorkspaceShell`, `getMcpStatusSummary`, and `getCurrentAgentSummary`, and added `agentAdapter`/`permissionMode`/`agentId` to `getSession` return shape. 
- Rewrote the `/doctor` handler to produce sectioned output ("Session", "Provider/Model", "Agent Adapter", "Shell/Git", "MCP", "Known Issues / Suggestions") and to aggregate checks for SDKs, Codex CLI, workspace shell/git, MCP servers, and agent model/config health. 
- Added internal helpers in the command registry: `resolveSdkAvailability`, `resolveWorkspaceShell`, `resolveGitVersion`, and `formatMcpStatus` to provide sensible fallbacks when deps are not injected. 
- Wired SessionService to provide the new `CommandDeps` implementations and added runtime helpers there (`checkCommandAvailable`, `checkWorkspaceShellAvailable`, `checkOpenAISdkAvailable`) to perform the actual availability checks. 
- Added unit tests for `/doctor` covering: missing workspace, missing shell, missing provider/model, and an all-healthy scenario.

### Testing

- Ran the targeted unit tests: `vitest` for `src/__tests__/core/command-registry.test.ts`, and the `command-registry` test file passed (46 tests passed). 
- Ran TypeScript typecheck (`tsc --noEmit`) and it completed successfully after fixes. 
- Noted that running the full `agent-runtime` unit suite exercised unrelated environment-sensitive tests that failed in this environment (missing `libsecret-1.so.0`, some long-running/timeouts and unrelated executor tests); these failures are pre-existing and unrelated to the `/doctor` changes. 
- Attempted to run GitNexus `impact` / `detect_changes` for blast-radius verification, but the CLI invocation did not complete in this environment, so full GitNexus impact/detect_changes output is not available (changes were reviewed via diffs and targeted tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392d7a420832382bf843ecfd519a5)