### PR TITLE
Only emit command-completed status when no follow-up Agent turn

### DIFF
--- a/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fileURLToPath } from 'node:url'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import type { AgentEvent } from '@spark/protocol'
 import { SessionService } from '../../services/session.service.js'
 
@@ -53,6 +56,7 @@ const mockState = vi.hoisted(() => ({
   events: [] as EventRow[],
   sdkConfigs: [] as Array<Record<string, unknown>>,
   sdkTurns: [] as Array<{ sessionId: string; turnId: string; message: string }>,
+  workspaces: new Map<string, { id: string; root_path: string }>(),
 }))
 
 vi.mock('@spark/shared/keystore', () => ({
@@ -198,7 +202,11 @@ vi.mock('@spark/storage', () => {
   }
 
   class RulesRepository { list(): unknown[] { return [] } }
-  class WorkspaceRepository { get(): null { return null } }
+  class WorkspaceRepository {
+    get(id: string): { id: string; root_path: string } | null {
+      return mockState.workspaces.get(id) ?? null
+    }
+  }
   class McpServerRepository { listAll(): unknown[] { return [] } }
   class SettingsRepository { get(): null { return null } }
   class SkillRepository {
@@ -207,6 +215,11 @@ vi.mock('@spark/storage', () => {
   }
   class AgentRepository {
     get(): null { return null }
+  }
+  class ContextPreferenceRepository {
+    getPreference(): null { return null }
+    getOverrides(): { pinnedPaths: string[]; excludedPaths: string[] } { return { pinnedPaths: [], excludedPaths: [] } }
+    upsertPreference(): void {}
   }
   class SessionSummaryRepository {
     getLatest(): null { return null }
@@ -223,6 +236,7 @@ vi.mock('@spark/storage', () => {
     SettingsRepository,
     SkillRepository,
     AgentRepository,
+    ContextPreferenceRepository,
     SessionSummaryRepository,
   }
 })
@@ -272,6 +286,7 @@ describe('SessionService runtime provider/model resolution', () => {
     mockState.events.length = 0
     mockState.sdkConfigs.length = 0
     mockState.sdkTurns.length = 0
+    mockState.workspaces.clear()
     events = []
 
     seedProvider({
@@ -391,6 +406,57 @@ describe('SessionService runtime provider/model resolution', () => {
       provider: 'spark',
       isFinal: true,
     }))
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'agent_status',
+      status: 'completed',
+      message: '/rename completed',
+    }))
+  })
+
+  it('does not inject command completed before /validate --repair follow-up Agent turn', async () => {
+    const workspaceRoot = mkdtempSync(path.join(tmpdir(), 'spark-validate-repair-'))
+    writeFileSync(
+      path.join(workspaceRoot, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'node -e "process.exit(1)"' } }),
+    )
+    mockState.workspaces.set('repair-workspace', { id: 'repair-workspace', root_path: workspaceRoot })
+
+    try {
+      const service = new SessionService({} as never, (event) => events.push(event))
+      const { sessionId } = await service.createSession({
+        providerProfileId: 'tencent-provider',
+        agentAdapter: 'claude-sdk',
+        permissionMode: 'claude-plan',
+        title: 'Repair validation session',
+        workspaceId: 'repair-workspace',
+      })
+
+      const result = await service.executeCommandAsEvents({
+        sessionId,
+        message: '/validate npm run typecheck --repair',
+      })
+
+      expect(result).toMatchObject({ isCommand: true, forwardToAgent: false, started: true })
+      expect(mockState.sdkTurns).toHaveLength(1)
+      expect(mockState.sdkTurns[0]?.message).toContain('验证命令: npm run typecheck')
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'assistant_message',
+        provider: 'spark',
+        isFinal: true,
+      }))
+      const sparkCommandCompleted = events.find((event) =>
+        event.type === 'agent_status' &&
+        event.status === 'completed' &&
+        event.message === '/validate completed'
+      )
+      expect(sparkCommandCompleted).toBeUndefined()
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'agent_status',
+        status: 'completed',
+      }))
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true })
+    }
   })
 
   it('passes selected attachments into the Claude SDK turn config', async () => {

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -33,6 +33,7 @@ import type {
   SessionSearchResponse,
   UserMessageEvent,
   AssistantMessageEvent,
+  AgentStatusEvent,
   HookNode,
   SessionAttachment,
   UserQuestionPrompt,
@@ -545,10 +546,14 @@ export class SessionService {
 
     if (result.forwardToAgent) return { isCommand: true, forwardToAgent: true }
 
-    // Inject result as events into the chat stream
+    // Inject result as events into the chat stream. Internal commands that end here
+    // emit a terminal agent_status so the UI can clear loading, but commands that
+    // enqueue a follow-up Agent turn must not mark the overall user request complete.
+    const followUpPrompt = result.followUpPrompt?.trim()
+    const hasFollowUpPrompt = followUpPrompt != null && followUpPrompt.length > 0
     const turnId = crypto.randomUUID()
     const seq0 = this.seqCounters.get(params.sessionId) ?? 0
-    this.seqCounters.set(params.sessionId, seq0 + 2)
+    this.seqCounters.set(params.sessionId, seq0 + (hasFollowUpPrompt ? 2 : 3))
 
     const userEvent: UserMessageEvent = {
       id: crypto.randomUUID(),
@@ -577,7 +582,22 @@ export class SessionService {
       isFinal: true,
     }
 
-    for (const event of [userEvent, assistantEvent]) {
+    const commandEvents: AgentEvent[] = [userEvent, assistantEvent]
+    if (!hasFollowUpPrompt) {
+      const completedEvent: AgentStatusEvent = {
+        id: crypto.randomUUID(),
+        type: 'agent_status',
+        sessionId: params.sessionId,
+        turnId,
+        timestamp: new Date().toISOString(),
+        seq: seq0 + 2,
+        status: 'completed',
+        message: `/${cmdName} completed`,
+      }
+      commandEvents.push(completedEvent)
+    }
+
+    for (const event of commandEvents) {
       this.onEvent(event)
       try {
         eventRepo.insert({
@@ -592,10 +612,10 @@ export class SessionService {
       }
     }
 
-    if (result.followUpPrompt != null && result.followUpPrompt.trim().length > 0) {
+    if (hasFollowUpPrompt) {
       const sendResult = await this.sendTurn({
         sessionId: params.sessionId,
-        message: result.followUpPrompt,
+        message: followUpPrompt,
         ...(result.followUpSkillId != null ? { skillId: result.followUpSkillId } : {}),
         ...(result.followUpSkillParams != null ? { skillParams: result.followUpSkillParams } : {}),
       })


### PR DESCRIPTION
### Motivation
- Prevent UI flicker and misleading completed→running transitions when a slash command triggers a follow-up Agent turn (e.g. `/validate --repair`).
- Ensure purely internal commands (e.g. `/rename`, `/status`, `/usage`) still clear loading by emitting a terminal completed status.

### Description
- Update `executeCommandAsEvents` to trim and inspect `followUpPrompt` and set `hasFollowUpPrompt` to drive event semantics. (`packages/agent-runtime/src/services/session.service.ts`).
- Emit a terminal `agent_status: completed` event only when `hasFollowUpPrompt` is false; otherwise, omit the completed event and let the follow-up `sendTurn` lifecycle close the Agent turn naturally.
- Adjust sequence counter accounting so event `seq` ordering remains consistent in both cases, and pass the trimmed follow-up prompt into `sendTurn` when present.
- Add unit test coverage verifying `/rename` still emits `agent_status: completed` and that `/validate --repair` with a follow-up does not inject a premature `/validate completed` and that `sendTurn` is invoked (`packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts`).

### Testing
- Ran the focused unit suite: `pnpm --filter @spark/agent-runtime exec vitest run src/__tests__/services/session-runtime-config.test.ts`, and the tests passed.
- Type-check: `pnpm --filter @spark/agent-runtime typecheck` succeeded with no TypeScript errors after the change.
- Attempted GitNexus impact/detect_changes (`npx gitnexus ...`) as requested by repository guidance, but the CLI produced no impact/report output in this environment; no HIGH/CRITICAL risk was reported by other checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392d4aba48323b526bc96402bcaa1)