### PR TITLE
fix(diff): split `/diff` into Working tree, Staged and Untracked sections

### DIFF
--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -285,6 +285,76 @@ describe('Built-in commands', () => {
     expect(result.message).toContain('M src/app.ts')
   })
 
+  it('/diff shows only unstaged working tree diff', async () => {
+    const execShell = vi.fn(async (command: string) => {
+      if (command === 'git diff') {
+        return { stdout: 'diff --git a/src/app.ts b/src/app.ts\n+unstaged', stderr: '', exitCode: 0 }
+      }
+      return { stdout: '', stderr: '', exitCode: 0 }
+    })
+    const result = await registry.execute(parse('/diff'), ctx, makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell,
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('## Working tree diff')
+    expect(result.message).toContain('```diff\n')
+    expect(result.message).toContain('+unstaged')
+    expect(result.message).toContain('## Staged diff')
+    expect(result.message).toContain('## Untracked files')
+    expect(execShell).toHaveBeenCalledWith('git diff', '/fake/workspace')
+    expect(execShell).toHaveBeenCalledWith('git diff --cached', '/fake/workspace')
+    expect(execShell).toHaveBeenCalledWith('git ls-files --others --exclude-standard', '/fake/workspace')
+  })
+
+  it('/diff shows only staged diff', async () => {
+    const execShell = vi.fn(async (command: string) => {
+      if (command === 'git diff --cached') {
+        return { stdout: 'diff --git a/src/app.ts b/src/app.ts\n+staged', stderr: '', exitCode: 0 }
+      }
+      return { stdout: '', stderr: '', exitCode: 0 }
+    })
+    const result = await registry.execute(parse('/diff'), ctx, makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell,
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('## Working tree diff')
+    expect(result.message).toContain('## Staged diff')
+    expect(result.message).toContain('+staged')
+    expect(result.message).toContain('## Untracked files')
+  })
+
+  it('/diff shows only untracked files outside diff fences', async () => {
+    const execShell = vi.fn(async (command: string) => {
+      if (command === 'git ls-files --others --exclude-standard') {
+        return { stdout: 'notes.txt\nsrc/new-file.ts\n', stderr: '', exitCode: 0 }
+      }
+      return { stdout: '', stderr: '', exitCode: 0 }
+    })
+    const result = await registry.execute(parse('/diff'), ctx, makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell,
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('## Untracked files')
+    expect(result.message).toContain('```\nnotes.txt\nsrc/new-file.ts\n```')
+    expect(result.message).not.toContain('```diff\nnotes.txt')
+  })
+
+  it('/diff returns no changes when working tree, staged, and untracked are empty', async () => {
+    const result = await registry.execute(parse('/diff'), ctx, makeDeps({
+      getWorkspacePath: () => '/fake/workspace',
+      execShell: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })),
+    }))
+
+    expect(result.success).toBe(true)
+    expect(result.message).toBe('没有文件变更。')
+  })
+
   it('/skill run selects a skill for the follow-up turn', async () => {
     const result = await registry.execute(parse('/skill run skill:review inspect changes'), ctx, makeDeps({
       listSkills: () => [{

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -156,6 +156,26 @@ function slugify(name: string): string {
     .replace(/^-|-$/g, '')
 }
 
+function clipCommandSectionOutput(output: string, maxLength = 4000): string {
+  return output.length > maxLength ? `${output.slice(0, maxLength)}\n... output truncated ...` : output
+}
+
+function formatDiffSection(title: string, diff: string): string {
+  const body = diff.trim()
+  if (!body) {
+    return `## ${title}\n\n_No changes._`
+  }
+  return `## ${title}\n\n\`\`\`diff\n${clipCommandSectionOutput(body)}\n\`\`\``
+}
+
+function formatUntrackedFilesSection(files: string): string {
+  const body = files.trim()
+  if (!body) {
+    return '## Untracked files\n\n_No untracked files._'
+  }
+  return `## Untracked files\n\n\`\`\`\n${clipCommandSectionOutput(body)}\n\`\`\``
+}
+
 /* ============================================================
    Command Registry
    ============================================================ */
@@ -493,11 +513,22 @@ function registerSdkCommands(registry: CommandRegistry): void {
         return { success: false, message: 'Shell 执行不可用。' }
       }
       try {
-        const { stdout } = await deps.execShell('git diff && git diff --cached && git ls-files --others --exclude-standard | head -20', cwd)
-        if (!stdout.trim()) {
+        const [workingTreeDiff, stagedDiff, untrackedFiles] = await Promise.all([
+          deps.execShell('git diff', cwd),
+          deps.execShell('git diff --cached', cwd),
+          deps.execShell('git ls-files --others --exclude-standard', cwd),
+        ])
+        if (!workingTreeDiff.stdout.trim() && !stagedDiff.stdout.trim() && !untrackedFiles.stdout.trim()) {
           return { success: true, message: '没有文件变更。' }
         }
-        return { success: true, message: `\`\`\`diff\n${stdout.slice(0, 4000)}\n\`\`\`` }
+        return {
+          success: true,
+          message: [
+            formatDiffSection('Working tree diff', workingTreeDiff.stdout),
+            formatDiffSection('Staged diff', stagedDiff.stdout),
+            formatUntrackedFilesSection(untrackedFiles.stdout),
+          ].join('\n\n'),
+        }
       } catch (err) {
         return { success: false, message: `执行 git diff 失败：${err instanceof Error ? err.message : String(err)}` }
       }


### PR DESCRIPTION
### Motivation

- Make `/diff` output clearer by separating unstaged changes, staged changes, and untracked files into distinct markdown sections. 
- Ensure untracked file lists are displayed outside of `diff` fences so they remain readable and are not interpreted as diffs. 
- Prevent a single large section from crowding out others by clipping output per section.

### Description

- Change `/diff` handler to run three independent commands: `git diff`, `git diff --cached`, and `git ls-files --others --exclude-standard`, and treat their outputs separately. 
- Format results into three markdown sections: `## Working tree diff`, `## Staged diff`, and `## Untracked files`, with untracked files rendered in a plain code block rather than a `diff` block. 
- Add per-section clipping (`clipCommandSectionOutput`) to limit each section's length and avoid one section dominating the response. 
- Add unit tests covering unstaged-only, staged-only, untracked-only, and the empty/no-change case that returns `没有文件变更。`.

### Testing

- Added tests in `packages/agent-runtime/src/__tests__/core/command-registry.test.ts` for the four scenarios and ran `pnpm vitest run packages/agent-runtime/src/__tests__/core/command-registry.test.ts`. 
- Test run result: `1 passed (46 tests)` (the updated test file executed and all tests passed). 
- No other automated test failures observed when running the focused test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3392d822a4832386bf150e35b3cc7c)