### PR TITLE
Fix canvas image dimension parameter handling

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@lobehub/ui', () => ({
+  Button: 'button',
+  Checkbox: 'input',
+  Input: 'input',
+  Select: 'select',
+  Tag: 'span',
+}))
+vi.mock('../../Icons', () => ({ Icons: new Proxy({}, { get: () => () => null }) }))
+vi.mock('@spark/protocol', () => ({ capabilityForOperation: () => [] }))
+vi.mock('./canvas.api', () => ({ canvasApi: { listMediaModels: vi.fn() } }))
+
+import {
+  mergeSchemaFields,
+  normalizeModelParamsForSubmit,
+  updateModelParamDraftValue,
+  type SchemaField,
+} from './CanvasInlineAiComposer'
+
+const field = (name: string): SchemaField => ({
+  name,
+  title: name,
+  type: 'string',
+  enumValues: [],
+})
+
+describe('CanvasInlineAiComposer image dimension params', () => {
+  it('shows and submits only size when the model schema accepts size', () => {
+    const fields = mergeSchemaFields(
+      [field('size')],
+      [field('aspect_ratio'), field('quality')],
+    )
+
+    expect(fields.map((item) => item.name)).toEqual(['size', 'quality'])
+    expect(
+      normalizeModelParamsForSubmit(
+        { size: '1024x1024', aspect_ratio: '1:1', quality: 'high' },
+        {},
+        fields,
+      ),
+    ).toEqual({ size: '1024x1024', quality: 'high' })
+  })
+
+  it('shows and submits only aspect_ratio when the model schema accepts aspect_ratio', () => {
+    const fields = mergeSchemaFields(
+      [field('aspect_ratio')],
+      [field('size'), field('quality')],
+    )
+
+    expect(fields.map((item) => item.name)).toEqual(['aspect_ratio', 'quality'])
+    expect(
+      normalizeModelParamsForSubmit(
+        { size: '1024x1024', aspect_ratio: '16:9', quality: 'standard' },
+        {},
+        fields,
+      ),
+    ).toEqual({ aspect_ratio: '16:9', quality: 'standard' })
+  })
+
+  it('clears the alternate image dimension draft when selecting size or aspect ratio', () => {
+    expect(
+      updateModelParamDraftValue(
+        { size: '', aspect_ratio: '1:1', aspectRatio: '1:1' },
+        'size',
+        '1536x1024',
+      ),
+    ).toEqual({ size: '1536x1024', aspect_ratio: '', aspectRatio: '' })
+
+    expect(
+      updateModelParamDraftValue(
+        { size: '1024x1024', aspect_ratio: '' },
+        'aspect_ratio',
+        '16:9',
+      ),
+    ).toEqual({ size: '', aspect_ratio: '16:9' })
+  })
+
+  it('cleans submitted defaults when both size and aspect_ratio are present', () => {
+    const fields = mergeSchemaFields([field('size'), field('aspect_ratio')])
+
+    expect(
+      normalizeModelParamsForSubmit(
+        { size: '1024x1024', aspect_ratio: '16:9' },
+        { size: '1024x1024' },
+        fields,
+      ),
+    ).toEqual({ aspect_ratio: '16:9' })
+
+    expect(
+      normalizeModelParamsForSubmit(
+        { size: '1536x1024', aspect_ratio: '1:1' },
+        { aspect_ratio: '1:1' },
+        fields,
+      ),
+    ).toEqual({ size: '1536x1024' })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.tsx
@@ -720,10 +720,9 @@ export function CanvasInlineAiComposer({
                     value={modelParamDraft[field.name] || undefined}
                     allowClear
                     onChange={(value) => {
-                      setModelParamDraft((prev) => ({
-                        ...prev,
-                        [field.name]: value == null ? '' : String(value),
-                      }))
+                      setModelParamDraft((prev) =>
+                        updateModelParamDraftValue(prev, field.name, value == null ? '' : String(value)),
+                      )
                     }}
                     options={field.enumValues.map((value) => ({ value, label: value }))}
                   />
@@ -732,10 +731,9 @@ export function CanvasInlineAiComposer({
                     value={modelParamDraft[field.name] || undefined}
                     allowClear
                     onChange={(value) => {
-                      setModelParamDraft((prev) => ({
-                        ...prev,
-                        [field.name]: value == null ? '' : String(value),
-                      }))
+                      setModelParamDraft((prev) =>
+                        updateModelParamDraftValue(prev, field.name, value == null ? '' : String(value)),
+                      )
                     }}
                     options={[
                       { value: 'true', label: 'true' },
@@ -748,7 +746,9 @@ export function CanvasInlineAiComposer({
                     type={field.type === 'integer' || field.type === 'number' ? 'number' : 'text'}
                     placeholder={field.placeholder}
                     onChange={(e) => {
-                      setModelParamDraft((prev) => ({ ...prev, [field.name]: e.target.value }))
+                      setModelParamDraft((prev) =>
+                        updateModelParamDraftValue(prev, field.name, e.target.value),
+                      )
                     }}
                   />
                 )}
@@ -853,6 +853,7 @@ export function CanvasInlineAiComposer({
                 ...buildCustomModelParams(customParams),
               },
               selectedCapability?.defaults ?? {},
+              parameterFields,
             )
             const effectivePrompt = mergeProjectPrompt(
               prompt.trim() || fallbackPromptForOperation(operation),
@@ -1393,6 +1394,7 @@ export function mergeSchemaFields(
   baseFields: SchemaField[],
   ...suggestedFieldGroups: SchemaField[][]
 ): SchemaField[] {
+  const dimensionFieldPolicy = imageDimensionFieldPolicy(baseFields)
   const seen = new Set<string>()
   const result: SchemaField[] = []
   for (const field of baseFields) {
@@ -1401,6 +1403,7 @@ export function mergeSchemaFields(
     result.push(field)
   }
   for (const field of suggestedFieldGroups.flat()) {
+    if (!dimensionFieldPolicy.allows(field.name)) continue
     const existingIndex = result.findIndex((item) => item.name === field.name)
     if (existingIndex >= 0) {
       const existing = result[existingIndex]
@@ -1416,6 +1419,24 @@ export function mergeSchemaFields(
     result.push(field)
   }
   return result.slice(0, 18)
+}
+
+function imageDimensionFieldPolicy(fields: SchemaField[]): {
+  allows: (name: string) => boolean
+  accepted: Set<string>
+} {
+  const accepted = new Set(
+    fields
+      .map((field) => field.name)
+      .filter((name) => name === 'size' || name === 'aspect_ratio' || name === 'aspectRatio'),
+  )
+  return {
+    accepted,
+    allows: (name) =>
+      accepted.size === 0 ||
+      (name !== 'size' && name !== 'aspect_ratio' && name !== 'aspectRatio') ||
+      accepted.has(name),
+  }
 }
 
 function readComposerCache(): ComposerCache {
@@ -1550,6 +1571,22 @@ export function buildModelParams(
   return params
 }
 
+export function updateModelParamDraftValue(
+  draft: Record<string, string>,
+  fieldName: string,
+  value: string,
+): Record<string, string> {
+  const next = { ...draft, [fieldName]: value }
+  if (value.trim().length === 0) return next
+  if (fieldName === 'size') {
+    next.aspect_ratio = ''
+    next.aspectRatio = ''
+  } else if (fieldName === 'aspect_ratio' || fieldName === 'aspectRatio') {
+    next.size = ''
+  }
+  return next
+}
+
 export function buildCustomModelParams(drafts: CustomParamDraft[]): Record<string, unknown> {
   const params: Record<string, unknown> = {}
   for (const draft of drafts) {
@@ -1580,13 +1617,27 @@ export function buildCustomModelParams(drafts: CustomParamDraft[]): Record<strin
 export function normalizeModelParamsForSubmit(
   params: Record<string, unknown>,
   defaults: Record<string, unknown>,
+  fields?: SchemaField[],
 ): Record<string, unknown> {
   const next = { ...params }
+  if (fields) {
+    const policy = imageDimensionFieldPolicy(fields)
+    if (policy.accepted.size > 0) {
+      for (const name of ['size', 'aspect_ratio', 'aspectRatio']) {
+        if (!policy.accepted.has(name)) delete next[name]
+      }
+    }
+  }
   const aspect = stringParam(next.aspectRatio) ?? stringParam(next.aspect_ratio)
   const size = stringParam(next.size)
   const defaultSize = stringParam(defaults.size)
+  const defaultAspect =
+    stringParam(defaults.aspectRatio) ?? stringParam(defaults.aspect_ratio)
   if (aspect && size && defaultSize && size === defaultSize) {
     delete next.size
+  } else if (aspect && size && defaultAspect && aspect === defaultAspect) {
+    delete next.aspectRatio
+    delete next.aspect_ratio
   }
   return next
 }

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -17,6 +17,7 @@ import {
   operationSuggestedFields,
   schemaFields,
   updateCustomParam,
+  updateModelParamDraftValue,
   type CustomParamDraft,
   type CustomParamType,
 } from './CanvasInlineAiComposer'
@@ -265,6 +266,7 @@ export function CanvasOperationPanel({
         ...buildCustomModelParams(customParams),
       },
       selectedCapability?.defaults ?? {},
+      parameterFields,
     )
     const runInputNodeIds = Array.from(
       new Set([
@@ -471,10 +473,9 @@ export function CanvasOperationPanel({
                       value={modelParamDraft[field.name] || undefined}
                       options={field.enumValues.map((value) => ({ value, label: value }))}
                       onChange={(value) =>
-                        setModelParamDraft((prev) => ({
-                          ...prev,
-                          [field.name]: value == null ? '' : String(value),
-                        }))
+                        setModelParamDraft((prev) =>
+                          updateModelParamDraftValue(prev, field.name, value == null ? '' : String(value)),
+                        )
                       }
                       disabled={running}
                     />
@@ -488,10 +489,9 @@ export function CanvasOperationPanel({
                         { value: 'false', label: 'false' },
                       ]}
                       onChange={(value) =>
-                        setModelParamDraft((prev) => ({
-                          ...prev,
-                          [field.name]: value == null ? '' : String(value),
-                        }))
+                        setModelParamDraft((prev) =>
+                          updateModelParamDraftValue(prev, field.name, value == null ? '' : String(value)),
+                        )
                       }
                       disabled={running}
                     />
@@ -502,7 +502,9 @@ export function CanvasOperationPanel({
                       placeholder={field.placeholder}
                       value={modelParamDraft[field.name] ?? ''}
                       onChange={(e) =>
-                        setModelParamDraft((prev) => ({ ...prev, [field.name]: e.target.value }))
+                        setModelParamDraft((prev) =>
+                          updateModelParamDraftValue(prev, field.name, e.target.value),
+                        )
                       }
                       disabled={running}
                     />


### PR DESCRIPTION
### Motivation
- Ensure image-generation parameters are schema-aware so the UI only shows and submits dimension params a model actually accepts (avoid sending `size` when schema only accepts `aspect_ratio` and vice versa).
- Provide UI-level mutual exclusivity between `size` and `aspect_ratio` so selecting one clears or disables the other to prevent conflicting inputs.
- Keep both entry points (`CanvasInlineAiComposer` and `CanvasOperationPanel`) consistent when rendering and submitting model parameters.

### Description
- Added a shared `imageDimensionFieldPolicy` used by `mergeSchemaFields()` to filter dimension suggestions so only the `size`/`aspect_ratio` variant present in the model/schema is included in the merged parameter list.  (`CanvasInlineAiComposer.tsx`)
- Introduced `updateModelParamDraftValue()` to implement UI-level mutual exclusivity by clearing the alternate dimension field when one is selected or edited, and wired UI controls in both `CanvasInlineAiComposer` and `CanvasOperationPanel` to use it. (`CanvasInlineAiComposer.tsx`, `CanvasOperationPanel.tsx`)
- Extended `normalizeModelParamsForSubmit()` to accept the rendered `parameterFields` and remove unsupported image-dimension params before submission, and added logic to drop duplicate/defaulted values when both `size` and `aspect_ratio` are present. (`CanvasInlineAiComposer.tsx`)
- Propagated the `parameterFields` into submit normalization in both the inline composer and the operation panel so both paths strip unsupported params consistently. (`CanvasInlineAiComposer.tsx`, `CanvasOperationPanel.tsx`)
- Added unit tests `CanvasInlineAiComposer.test.ts` covering: a model/schema that only accepts `size`, a model/schema that only accepts `aspect_ratio`, the draft clearing mutual-exclusion behavior, and cleanup logic when defaults produce duplicate `size`/`aspect_ratio`. (`apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.test.ts`)

### Testing
- Ran the focused unit tests for the changes with `vitest` targeting `CanvasInlineAiComposer.test.ts` and the test file passed (4 tests passed). 
- Ran TypeScript checks with `pnpm --dir apps/desktop typecheck` which completed successfully with no type errors.
- Attempted to run the broader `test:unit` suite during development but the full suite failed in this environment due to unrelated environment/test setup issues (JSON import attributes, missing native libs like `libsecret-1.so.0`, and other preexisting test mocks); these failures are external to the changes in this PR and the focused tests above cover the modified behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3391ddb26c8325a26f7b0e9dfb8b58)