### PR TITLE
Close operation panel after successful run and reset running state

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -59,7 +59,7 @@ export function CanvasOperationPanel({
   /** 关联的 CanvasTask（可能为 null，pending 状态） */
   task?: CanvasTask | null
   onClose: () => void
-  onRun: (params: OperationRunParams) => void
+  onRun: (params: OperationRunParams) => Promise<void> | void
   onRetry: () => void
 }) {
   const operation = nodeOperation(node) ?? 'text_generate'
@@ -246,7 +246,8 @@ export function CanvasOperationPanel({
     )
   }, [parameterFields, selectedCapability, task?.modelParams])
 
-  const handleRun = useCallback(() => {
+  const handleRun = useCallback(async () => {
+    if (running || node.data.status === 'running') return
     if (!prompt.trim() && !capability?.inputTypes.includes('image') && !capability?.inputTypes.includes('video')) {
       message.warning('请输入提示词')
       return
@@ -275,28 +276,38 @@ export function CanvasOperationPanel({
       ]),
     )
     setRunning(true)
-    onRun({
-      prompt: prompt.trim(),
-      ...(negativePrompt.trim() ? { negativePrompt: negativePrompt.trim() } : {}),
-      inputNodeIds: runInputNodeIds,
-      ...(selectedModel?.providerKind === 'xai'
-        ? { inputTransport: 'base64' as const }
-        : { inputTransport: 'cloud_url' as const }),
-      ...(selectedModel?.providerProfileId ? { providerProfileId: selectedModel.providerProfileId } : {}),
-      ...(selectedModel?.manifestId ? { manifestId: selectedModel.manifestId } : {}),
-      ...(selectedModel?.effectiveModelId ? { modelId: selectedModel.effectiveModelId } : {}),
-      ...(Object.keys(nextModelParams).length > 0 ? { modelParams: nextModelParams } : {}),
-    })
+    try {
+      await onRun({
+        prompt: prompt.trim(),
+        ...(negativePrompt.trim() ? { negativePrompt: negativePrompt.trim() } : {}),
+        inputNodeIds: runInputNodeIds,
+        ...(selectedModel?.providerKind === 'xai'
+          ? { inputTransport: 'base64' as const }
+          : { inputTransport: 'cloud_url' as const }),
+        ...(selectedModel?.providerProfileId ? { providerProfileId: selectedModel.providerProfileId } : {}),
+        ...(selectedModel?.manifestId ? { manifestId: selectedModel.manifestId } : {}),
+        ...(selectedModel?.effectiveModelId ? { modelId: selectedModel.effectiveModelId } : {}),
+        ...(Object.keys(nextModelParams).length > 0 ? { modelParams: nextModelParams } : {}),
+      })
+    } catch (error) {
+      console.error('[CanvasOperationPanel] Failed to run operation node:', error)
+      message.error('提交任务失败，请调整参数后重试')
+    } finally {
+      setRunning(false)
+    }
   }, [
+    canEditMediaInputs,
     capability,
     customParams,
     modelParamDraft,
     negativePrompt,
+    node.data.status,
     onRun,
     parameterFields,
     prompt,
     selectedCapability,
     selectedModel,
+    running,
     expandedSourceInputNodes,
     selectedInputNodeIds,
   ])

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -1938,37 +1938,37 @@ export function CanvasWorkspaceView({
                 setActiveOperationPanelNodeId(null)
                 setSelectedNodeIds([])
               }}
-              onRun={(params) => {
-                void (async () => {
-                  if (!(await ensureCanvasWorkflowLogin())) return
-                  const taskInputNodes = resolveCanvasInputNodes(
-                    params.inputNodeIds,
-                    snapshot.nodes,
-                  )
-                  const inputFiles = await buildCloudTaskInputFiles(
-                    taskInputNodes,
-                    params.inputTransport,
-                  )
-                  const mergedPrompt = mergePromptWithNodeContext(params.prompt, taskInputNodes)
-                  const effectivePrompt =
-                    mergedPrompt ||
-                    (inputFiles.length > 0
-                      ? fallbackPromptForOperation((opNode.data.operation ?? opNode.type) as CanvasOperationType)
-                      : '')
-                  await runOperationNode(opNode.id, {
-                    prompt: effectivePrompt,
-                    ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
-                    inputNodeIds: taskInputNodes.map((item) => item.id),
-                    inputAssetIds: taskInputNodes
-                      .map((item) => item.assetId)
-                      .filter((id): id is string => Boolean(id)),
-                    ...(inputFiles.length > 0 ? { inputFiles } : {}),
-                    ...(params.providerProfileId ? { providerProfileId: params.providerProfileId } : {}),
-                    ...(params.manifestId ? { manifestId: params.manifestId } : {}),
-                    ...(params.modelId ? { modelId: params.modelId } : {}),
-                    ...(params.modelParams ? { modelParams: params.modelParams } : {}),
-                  })
-                })()
+              onRun={async (params) => {
+                if (!(await ensureCanvasWorkflowLogin())) return
+                const taskInputNodes = resolveCanvasInputNodes(
+                  params.inputNodeIds,
+                  snapshot.nodes,
+                )
+                const inputFiles = await buildCloudTaskInputFiles(
+                  taskInputNodes,
+                  params.inputTransport,
+                )
+                const mergedPrompt = mergePromptWithNodeContext(params.prompt, taskInputNodes)
+                const effectivePrompt =
+                  mergedPrompt ||
+                  (inputFiles.length > 0
+                    ? fallbackPromptForOperation((opNode.data.operation ?? opNode.type) as CanvasOperationType)
+                    : '')
+                await runOperationNode(opNode.id, {
+                  prompt: effectivePrompt,
+                  ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
+                  inputNodeIds: taskInputNodes.map((item) => item.id),
+                  inputAssetIds: taskInputNodes
+                    .map((item) => item.assetId)
+                    .filter((id): id is string => Boolean(id)),
+                  ...(inputFiles.length > 0 ? { inputFiles } : {}),
+                  ...(params.providerProfileId ? { providerProfileId: params.providerProfileId } : {}),
+                  ...(params.manifestId ? { manifestId: params.manifestId } : {}),
+                  ...(params.modelId ? { modelId: params.modelId } : {}),
+                  ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                })
+                setActiveOperationPanelNodeId(null)
+                setSelectedNodeIds([])
               }}
               onRetry={() => void retryOperationNode(opNode.id)}
             />


### PR DESCRIPTION
### Motivation
- Prevent duplicate submissions and ensure the operation panel's `running` UI state is properly reset after an async run. 
- Close the operation panel and clear selection only after the operation actually completes successfully to avoid losing context on failure. 
- Preserve existing behaviour that keeps the panel open on failures so users can adjust params and retry.

### Description
- Updated `CanvasOperationPanel` to accept an async `onRun` handler (`onRun: (params) => Promise<void> | void`) and made `handleRun` `async` so it `await`s the caller, guards against duplicate runs with `running` and `node.data.status === 'running'`, and always resets local `running` in a `finally` block while showing an error message on failure. 
- Kept the panel open on failure (no close on exception) so users can fix inputs and retry. 
- Updated `CanvasWorkspaceView`'s `onRun` callback to `await runOperationNode(...)` and only then call `setActiveOperationPanelNodeId(null)` and `setSelectedNodeIds([])` to close the panel and clear selection after a successful run.

### Testing
- Ran `pnpm --filter @spark/desktop typecheck` which completed successfully. 
- Ran `pnpm --filter @spark/desktop lint` which failed due to existing workspace lint errors unrelated to these changes. 
- Ran `eslint` focused on the modified files which surfaced existing React hook / lint findings in the codebase; the new changes themselves type-check. 
- Attempted GitNexus impact/detect (`npx gitnexus impact` / `npx gitnexus detect_changes`) but the CLI produced no actionable report in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3391e0c570832598e256a0cf76e10e)