### PR TITLE
Inherit canvas operation prompts and model params from inputs

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -65,7 +65,8 @@ export function CanvasOperationPanel({
   const operation = nodeOperation(node) ?? 'text_generate'
   const capability = getCanvasCapability(operation)
   const operationText = operationLabel(operation)
-  const canEditMediaInputs = capability?.inputTypes.some((type) => type === 'image' || type === 'video') ?? false
+  const canEditMediaInputs =
+    capability?.inputTypes.some((type) => type === 'image' || type === 'video') ?? false
 
   // 上游输入节点（used_as_input edge 的 source）
   const sourceInputNodes = useMemo(() => {
@@ -113,24 +114,64 @@ export function CanvasOperationPanel({
     return snapshot.nodes.filter((n) => outputIds.has(n.id) && !n.hidden)
   }, [snapshot.edges, snapshot.nodes, node.id])
 
-  // 参数状态：从 task 或 node.data 带入
-  const [prompt, setPrompt] = useState(task?.prompt ?? node.data.prompt ?? '')
-  const [negativePrompt, setNegativePrompt] = useState(task?.negativePrompt ?? '')
+  const inheritedNegativePrompt = useMemo(() => {
+    const taskNegativePrompt = task?.negativePrompt?.trim()
+    if (taskNegativePrompt) return taskNegativePrompt
+    const nodeNegativePrompt = node.data.negativePrompt?.trim()
+    if (nodeNegativePrompt) return nodeNegativePrompt
+    for (const sourceNode of expandedSourceInputNodes) {
+      const sourceTask = sourceNode.taskId
+        ? snapshot.tasks.find((item) => item.id === sourceNode.taskId)
+        : null
+      const sourceTaskNegativePrompt = sourceTask?.negativePrompt?.trim()
+      if (sourceTaskNegativePrompt) return sourceTaskNegativePrompt
+      const sourceNodeNegativePrompt = sourceNode.data.negativePrompt?.trim()
+      if (sourceNodeNegativePrompt) return sourceNodeNegativePrompt
+    }
+    return snapshot.project.settings?.negativePrompt?.trim() ?? ''
+  }, [
+    expandedSourceInputNodes,
+    node.data.negativePrompt,
+    snapshot.project.settings?.negativePrompt,
+    snapshot.tasks,
+    task?.negativePrompt,
+  ])
+
+  // 参数状态：从 task、node.data、项目/上游继承值带入
+  const [prompt, setPrompt] = useState(
+    task?.prompt ?? node.data.prompt ?? snapshot.project.settings?.prompt ?? '',
+  )
+  const [negativePrompt, setNegativePrompt] = useState(inheritedNegativePrompt)
   const [mediaModels, setMediaModels] = useState<CanvasMediaModelSummary[]>([])
   const [modelsLoading, setModelsLoading] = useState(false)
   const [selectedModelKey, setSelectedModelKey] = useState('')
   const [modelParamDraft, setModelParamDraft] = useState<Record<string, string>>({})
   const [customParams, setCustomParams] = useState<CustomParamDraft[]>([])
   const [selectedInputNodeIds, setSelectedInputNodeIds] = useState<string[]>(() =>
-    (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map((item) => item.id),
+    (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map(
+      (item) => item.id,
+    ),
   )
   const [running, setRunning] = useState(false)
 
   useEffect(() => {
     setSelectedInputNodeIds(
-      (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map((item) => item.id),
+      (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map(
+        (item) => item.id,
+      ),
     )
   }, [canEditMediaInputs, editableSourceMediaNodes, expandedSourceInputNodes])
+
+  useEffect(() => {
+    setPrompt(task?.prompt ?? node.data.prompt ?? snapshot.project.settings?.prompt ?? '')
+    setNegativePrompt(inheritedNegativePrompt)
+  }, [
+    inheritedNegativePrompt,
+    node.data.prompt,
+    node.id,
+    snapshot.project.settings?.prompt,
+    task?.prompt,
+  ])
 
   useEffect(() => {
     let cancelled = false
@@ -166,8 +207,13 @@ export function CanvasOperationPanel({
 
   const statusTag = useMemo(() => {
     const s = node.data.status ?? 'pending'
-    const color = s === 'completed' ? 'green' : s === 'failed' ? 'red' : s === 'running' ? 'blue' : 'default'
-    return <Tag color={color} bordered>{operationStatusLabel(s)}</Tag>
+    const color =
+      s === 'completed' ? 'green' : s === 'failed' ? 'red' : s === 'running' ? 'blue' : 'default'
+    return (
+      <Tag color={color} bordered>
+        {operationStatusLabel(s)}
+      </Tag>
+    )
   }, [node.data.status])
 
   const mediaCapabilityIds = useMemo(() => capabilityForOperation(operation), [operation])
@@ -222,11 +268,17 @@ export function CanvasOperationPanel({
         (!task?.modelId || model.effectiveModelId === task.modelId),
     )
     setSelectedModelKey(mediaModelKey(fromTask ?? supportedMediaModels[0]!))
-  }, [selectedModelKey, supportedMediaModels, task?.manifestId, task?.modelId, task?.providerProfileId])
+  }, [
+    selectedModelKey,
+    supportedMediaModels,
+    task?.manifestId,
+    task?.modelId,
+    task?.providerProfileId,
+  ])
 
   useEffect(() => {
     const defaults = selectedCapability?.defaults ?? {}
-    const existing = task?.modelParams ?? {}
+    const existing = task?.modelParams ?? node.data.modelParams ?? {}
     const next: Record<string, string> = {}
     const fieldNames = new Set(parameterFields.map((field) => field.name))
     for (const field of parameterFields) {
@@ -247,7 +299,11 @@ export function CanvasOperationPanel({
   }, [parameterFields, selectedCapability, task?.modelParams])
 
   const handleRun = useCallback(() => {
-    if (!prompt.trim() && !capability?.inputTypes.includes('image') && !capability?.inputTypes.includes('video')) {
+    if (
+      !prompt.trim() &&
+      !capability?.inputTypes.includes('image') &&
+      !capability?.inputTypes.includes('video')
+    ) {
       message.warning('请输入提示词')
       return
     }
@@ -282,7 +338,9 @@ export function CanvasOperationPanel({
       ...(selectedModel?.providerKind === 'xai'
         ? { inputTransport: 'base64' as const }
         : { inputTransport: 'cloud_url' as const }),
-      ...(selectedModel?.providerProfileId ? { providerProfileId: selectedModel.providerProfileId } : {}),
+      ...(selectedModel?.providerProfileId
+        ? { providerProfileId: selectedModel.providerProfileId }
+        : {}),
       ...(selectedModel?.manifestId ? { manifestId: selectedModel.manifestId } : {}),
       ...(selectedModel?.effectiveModelId ? { modelId: selectedModel.effectiveModelId } : {}),
       ...(Object.keys(nextModelParams).length > 0 ? { modelParams: nextModelParams } : {}),
@@ -302,18 +360,17 @@ export function CanvasOperationPanel({
   ])
 
   const selectedInputIdSet = useMemo(() => new Set(selectedInputNodeIds), [selectedInputNodeIds])
-  const inputNodes = useMemo(
-    () => {
-      const byId = new Map(snapshot.nodes.map((item) => [item.id, item]))
-      return selectedInputNodeIds
-        .map((id) => byId.get(id))
-        .filter((item): item is CanvasNode => item != null)
-        .filter((item) => !item.hidden && selectedInputIdSet.has(item.id))
-    },
-    [selectedInputIdSet, selectedInputNodeIds, snapshot.nodes],
-  )
+  const inputNodes = useMemo(() => {
+    const byId = new Map(snapshot.nodes.map((item) => [item.id, item]))
+    return selectedInputNodeIds
+      .map((id) => byId.get(id))
+      .filter((item): item is CanvasNode => item != null)
+      .filter((item) => !item.hidden && selectedInputIdSet.has(item.id))
+  }, [selectedInputIdSet, selectedInputNodeIds, snapshot.nodes])
   const mediaInputs = inputNodes.filter((n) => n.type === 'image' || n.type === 'video')
-  const textInputs = expandedSourceInputNodes.filter((n) => n.type === 'text' || n.type === 'prompt')
+  const textInputs = expandedSourceInputNodes.filter(
+    (n) => n.type === 'text' || n.type === 'prompt',
+  )
 
   return (
     <div className="canvas-operation-panel" onMouseDown={(e) => e.stopPropagation()}>
@@ -321,7 +378,11 @@ export function CanvasOperationPanel({
         <div className="canvas-operation-panel-title">
           {operationLabel(operation)}
           {statusTag}
-          {outputNodes.length > 0 && <Tag color="purple" bordered>{outputNodes.length} 产出</Tag>}
+          {outputNodes.length > 0 && (
+            <Tag color="purple" bordered>
+              {outputNodes.length} 产出
+            </Tag>
+          )}
         </div>
         <Button size="small" type="text" icon={<Icons.X size={15} />} onClick={onClose} />
       </div>
@@ -335,7 +396,9 @@ export function CanvasOperationPanel({
                 输入 ({inputNodes.length + textInputs.length})
               </div>
               {sourceInputNodes.some((item) => item.type === 'group') && (
-                <Tag bordered color="gold">已展开组内元素</Tag>
+                <Tag bordered color="gold">
+                  已展开组内元素
+                </Tag>
               )}
             </div>
             {canEditMediaInputs && (
@@ -395,8 +458,14 @@ export function CanvasOperationPanel({
             {textInputs.length > 0 && (
               <div className="canvas-operation-panel-text-inputs">
                 {textInputs.map((n) => (
-                  <div key={n.id} className="canvas-operation-panel-text-input" title={n.title ?? ''}>
-                    <span className="canvas-operation-panel-text-input-title">{n.title ?? '文本'}</span>
+                  <div
+                    key={n.id}
+                    className="canvas-operation-panel-text-input"
+                    title={n.title ?? ''}
+                  >
+                    <span className="canvas-operation-panel-text-input-title">
+                      {n.title ?? '文本'}
+                    </span>
                     <span className="canvas-operation-panel-text-input-content">
                       {(n.data.text ?? '').slice(0, 80) || '(空)'}
                     </span>
@@ -619,7 +688,9 @@ export function CanvasOperationPanel({
           重试
         </Button>
         <div className="canvas-operation-panel-footer-spacer" />
-        <Button size="small" onClick={onClose}>取消</Button>
+        <Button size="small" onClick={onClose}>
+          取消
+        </Button>
         <Button
           size="small"
           type="primary"
@@ -635,7 +706,10 @@ export function CanvasOperationPanel({
   )
 }
 
-function expandOperationInputNodes(sourceNodes: CanvasNode[], allNodes: CanvasNode[]): CanvasNode[] {
+function expandOperationInputNodes(
+  sourceNodes: CanvasNode[],
+  allNodes: CanvasNode[],
+): CanvasNode[] {
   const byId = new Map(allNodes.map((item) => [item.id, item]))
   const seen = new Set<string>()
   const result: CanvasNode[] = []
@@ -670,10 +744,7 @@ function expandOperationInputNodes(sourceNodes: CanvasNode[], allNodes: CanvasNo
   return result
 }
 
-function isSupportedMediaInputNode(
-  node: CanvasNode,
-  inputTypes: readonly string[],
-): boolean {
+function isSupportedMediaInputNode(node: CanvasNode, inputTypes: readonly string[]): boolean {
   if (node.type === 'image') return inputTypes.includes('image')
   if (node.type === 'video') return inputTypes.includes('video')
   return false

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -401,16 +401,12 @@ export function snapshotFromDb(
   let nodes = db.nodes.filter(
     (node) => node.projectId === projectId && node.boardId === boardId && !node.hidden,
   )
-  let edges = db.edges.filter(
-    (edge) => edge.projectId === projectId && edge.boardId === boardId,
-  )
+  let edges = db.edges.filter((edge) => edge.projectId === projectId && edge.boardId === boardId)
   // 防御性兜底：若按 boardId 过滤后无节点，但项目实际存在非隐藏节点，
   // 说明节点 boardId 与当前 board 不匹配（旧数据 / 迁移残留），回退显示全部，
   // 避免画布「节点全部消失」。这种情况通常出现在旧项目首次进入多 board 视图时。
   if (nodes.length === 0) {
-    const allProjectNodes = db.nodes.filter(
-      (node) => node.projectId === projectId && !node.hidden,
-    )
+    const allProjectNodes = db.nodes.filter((node) => node.projectId === projectId && !node.hidden)
     if (allProjectNodes.length > 0) {
       nodes = allProjectNodes
       edges = db.edges.filter((edge) => edge.projectId === projectId)
@@ -521,7 +517,8 @@ function cloneImportedSnapshot(snapshot: CanvasSnapshot): CanvasSnapshot {
 
   const projectId = mapId(next.project.id, 'canvas_project')
   // 多 board：把 boards[] 的每个 id 都登记到 idMap，旧快照只有单 board 时用 next.board
-  const sourceBoards = Array.isArray(next.boards) && next.boards.length > 0 ? next.boards : [next.board]
+  const sourceBoards =
+    Array.isArray(next.boards) && next.boards.length > 0 ? next.boards : [next.board]
   const oldActiveBoardId = next.activeBoardId ?? next.board.id
   for (const board of sourceBoards) mapId(board.id, 'canvas_board')
   const newActiveBoardId = idMap.get(oldActiveBoardId) ?? idMap.get(next.board.id)!
@@ -551,8 +548,7 @@ function cloneImportedSnapshot(snapshot: CanvasSnapshot): CanvasSnapshot {
     updatedAt: at,
   }))
   next.activeBoardId = newActiveBoardId
-  next.board =
-    next.boards.find((board) => board.id === newActiveBoardId) ?? next.boards[0]!
+  next.board = next.boards.find((board) => board.id === newActiveBoardId) ?? next.boards[0]!
   next.assets = next.assets.map((asset) => ({
     ...asset,
     id: mapId(asset.id, 'canvas_asset'),
@@ -813,6 +809,42 @@ function createNodeBase(input: {
     createdAt: at,
     updatedAt: at,
   }
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function pickInheritedModelParams(
+  params: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!params) return {}
+  const keys = [
+    'aspectRatio',
+    'duration',
+    'durationSeconds',
+    'fps',
+    'height',
+    'imageCount',
+    'quality',
+    'resolution',
+    'seed',
+    'size',
+    'style',
+    'width',
+  ]
+  const next: Record<string, unknown> = {}
+  for (const key of keys) {
+    if (params[key] != null) next[key] = params[key]
+  }
+  return next
+}
+
+function mergeInheritedModelParams(
+  target: Record<string, unknown>,
+  source: Record<string, unknown> | undefined,
+): void {
+  Object.assign(target, pickInheritedModelParams(source))
 }
 
 function sortCanvasNodes(nodes: CanvasNode[]): CanvasNode[] {
@@ -1327,10 +1359,7 @@ export const canvasApi = {
     }
   },
 
-  async openSnapshot(
-    projectId: string,
-    activeBoardId?: string | null,
-  ): Promise<CanvasSnapshot> {
+  async openSnapshot(projectId: string, activeBoardId?: string | null): Promise<CanvasSnapshot> {
     // 解析激活 board 优先级：显式参数 > project.metadata.activeBoardId（用户上次选择）> 默认
     const resolvePreferredBoard = (db: CanvasDb): string | null | undefined => {
       if (activeBoardId) return activeBoardId
@@ -1468,13 +1497,11 @@ export const canvasApi = {
    * 深拷贝 board：复制其名下节点/边/任务（重映射 id），资产项目级共享不复制文件。
    * group 结构、parentNodeId 关系一并保留。
    */
-  async duplicateBoard(
-    projectId: string,
-    boardId: string,
-    name?: string,
-  ): Promise<CanvasSnapshot> {
+  async duplicateBoard(projectId: string, boardId: string, name?: string): Promise<CanvasSnapshot> {
     const db = readDb()
-    const sourceBoard = db.boards.find((item) => item.id === boardId && item.projectId === projectId)
+    const sourceBoard = db.boards.find(
+      (item) => item.id === boardId && item.projectId === projectId,
+    )
     if (!sourceBoard) return this.openSnapshot(projectId)
     const at = now()
     const newBoardId = uid('canvas_board')
@@ -1561,10 +1588,7 @@ export const canvasApi = {
       }
       // 复制任务节点（type=task）的 taskId 指向新 task
       const clonedTaskNodes = db.nodes.filter(
-        (n) =>
-          n.boardId === newBoardId &&
-          n.projectId === projectId &&
-          n.taskId === task.id,
+        (n) => n.boardId === newBoardId && n.projectId === projectId && n.taskId === task.id,
       )
       for (const tn of clonedTaskNodes) {
         tn.taskId = newTaskId
@@ -1589,7 +1613,9 @@ export const canvasApi = {
     const db = readDb()
     const project = db.projects.find((item) => item.id === projectId)
     if (!project) throw new Error('Canvas project not found')
-    const targetBoard = db.boards.find((item) => item.id === boardId && item.projectId === projectId)
+    const targetBoard = db.boards.find(
+      (item) => item.id === boardId && item.projectId === projectId,
+    )
     if (!targetBoard) throw new Error('Canvas board not found')
     // 持久化用户选择的激活 board（跨会话保留）
     project.metadata = { ...(project.metadata ?? {}), activeBoardId: boardId }
@@ -1665,7 +1691,9 @@ export const canvasApi = {
     targetBoardId: string,
   ): Promise<CanvasSnapshot> {
     const db = readDb()
-    const targetBoard = db.boards.find((item) => item.id === targetBoardId && item.projectId === projectId)
+    const targetBoard = db.boards.find(
+      (item) => item.id === targetBoardId && item.projectId === projectId,
+    )
     if (!targetBoard) return this.openSnapshot(projectId)
     const selected = new Set(nodeIds)
     const sourceNodes = db.nodes.filter(
@@ -1744,7 +1772,9 @@ export const canvasApi = {
     }>
   }): Promise<CanvasSnapshot> {
     const db = readDb()
-    const board = db.boards.find((item) => item.id === input.boardId && item.projectId === input.projectId)
+    const board = db.boards.find(
+      (item) => item.id === input.boardId && item.projectId === input.projectId,
+    )
     if (!board) throw new Error('Canvas board not found')
     const at = now()
     let maxZ = Math.max(
@@ -1876,8 +1906,12 @@ export const canvasApi = {
     y: number
   }): Promise<CanvasNode | null> {
     const db = readDb()
-    const asset = db.assets.find((item) => item.id === input.assetId && item.projectId === input.projectId)
-    const board = db.boards.find((item) => item.id === input.boardId && item.projectId === input.projectId)
+    const asset = db.assets.find(
+      (item) => item.id === input.assetId && item.projectId === input.projectId,
+    )
+    const board = db.boards.find(
+      (item) => item.id === input.boardId && item.projectId === input.projectId,
+    )
     if (!asset || !board) return null
     const maxZ = Math.max(
       0,
@@ -1896,7 +1930,11 @@ export const canvasApi = {
     const size = fitMediaNodeSize(asset.type, asset.width, asset.height)
     const data: CanvasNode['data'] =
       nodeType === 'text' || nodeType === 'prompt'
-        ? { text: asset.contentText ?? '', format: nodeType === 'prompt' ? 'prompt' : 'plain', origin: 'asset' }
+        ? {
+            text: asset.contentText ?? '',
+            format: nodeType === 'prompt' ? 'prompt' : 'plain',
+            origin: 'asset',
+          }
         : {
             ...(asset.url ? { url: asset.url } : {}),
             ...(asset.thumbnailUrl ? { thumbnailUrl: asset.thumbnailUrl } : {}),
@@ -1918,7 +1956,11 @@ export const canvasApi = {
     node.zIndex = maxZ + 1
     db.nodes.push(node)
     // 记录资产最近使用（挂 metadata，第一阶段）
-    asset.metadata = { ...asset.metadata, lastUsedAt: now(), usageCount: ((asset.metadata.usageCount as number) ?? 0) + 1 }
+    asset.metadata = {
+      ...asset.metadata,
+      lastUsedAt: now(),
+      usageCount: ((asset.metadata.usageCount as number) ?? 0) + 1,
+    }
     asset.updatedAt = now()
     updateProjectCounts(db, input.projectId)
     writeDb(db)
@@ -1931,10 +1973,7 @@ export const canvasApi = {
   // v2 模型：references 多图多描述 + tags 数组；老 imageAssetId/attributes 自动迁移。
 
   /** 创建影视公用资产 */
-  async createFilmAsset(
-    projectId: string,
-    input: CreateFilmAssetInput,
-  ): Promise<CanvasAsset> {
+  async createFilmAsset(projectId: string, input: CreateFilmAssetInput): Promise<CanvasAsset> {
     const db = readDb()
     const at = now()
     const assetType = filmKindToAssetType(input.kind)
@@ -2018,11 +2057,7 @@ export const canvasApi = {
   },
 
   /** 列出项目内指定种类的影视资产 */
-  listFilmAssets(
-    db: CanvasDb,
-    projectId: string,
-    kind?: FilmAssetKind,
-  ): CanvasAsset[] {
+  listFilmAssets(db: CanvasDb, projectId: string, kind?: FilmAssetKind): CanvasAsset[] {
     return db.assets.filter((asset) => {
       if (asset.projectId !== projectId) return false
       const assetKind = asset.metadata?.kind
@@ -2045,7 +2080,8 @@ export const canvasApi = {
     const db = readDb()
     const query = (options.query ?? '').trim().toLowerCase()
     const kinds = options.kinds && options.kinds.length > 0 ? new Set(options.kinds) : null
-    const tagsFilter = options.tags && options.tags.length > 0 ? options.tags.map((t) => t.toLowerCase()) : null
+    const tagsFilter =
+      options.tags && options.tags.length > 0 ? options.tags.map((t) => t.toLowerCase()) : null
     const list = this.listFilmAssets(db, projectId).filter((asset) => {
       if (kinds) {
         const k = asset.metadata?.['kind']
@@ -2058,7 +2094,10 @@ export const canvasApi = {
       if (query) {
         const title = (asset.title ?? '').toLowerCase()
         const content = (asset.contentText ?? '').toLowerCase()
-        const prompt = typeof asset.metadata?.['prompt'] === 'string' ? (asset.metadata['prompt'] as string).toLowerCase() : ''
+        const prompt =
+          typeof asset.metadata?.['prompt'] === 'string'
+            ? (asset.metadata['prompt'] as string).toLowerCase()
+            : ''
         const attrs = asset.metadata?.['attributes']
         const attrText =
           attrs && typeof attrs === 'object' && !Array.isArray(attrs)
@@ -2145,7 +2184,13 @@ export const canvasApi = {
     projectId: string,
     assetId: string,
   ): {
-    shotSegments: Array<{ groupId: string; groupName: string; segmentId: string; segmentTitle: string; segmentIndex: number }>
+    shotSegments: Array<{
+      groupId: string
+      groupName: string
+      segmentId: string
+      segmentTitle: string
+      segmentIndex: number
+    }>
     nodes: Array<{ id: string; type: string; title: string | null }>
   } {
     const db = readDb()
@@ -2178,17 +2223,16 @@ export const canvasApi = {
           if (!seg || typeof seg !== 'object') continue
           const s = seg as Record<string, unknown>
           const charIds = Array.isArray(s['characterAssetIds'])
-            ? (s['characterAssetIds'] as unknown[]).filter((x): x is string => typeof x === 'string')
+            ? (s['characterAssetIds'] as unknown[]).filter(
+                (x): x is string => typeof x === 'string',
+              )
             : []
-          const sceneId = typeof s['sceneAssetId'] === 'string' ? (s['sceneAssetId'] as string) : null
+          const sceneId =
+            typeof s['sceneAssetId'] === 'string' ? (s['sceneAssetId'] as string) : null
           const propIds = Array.isArray(s['propAssetIds'])
             ? (s['propAssetIds'] as unknown[]).filter((x): x is string => typeof x === 'string')
             : []
-          if (
-            charIds.includes(assetId) ||
-            sceneId === assetId ||
-            propIds.includes(assetId)
-          ) {
+          if (charIds.includes(assetId) || sceneId === assetId || propIds.includes(assetId)) {
             shotSegments.push({
               groupId: typeof g['id'] === 'string' ? (g['id'] as string) : '',
               groupName: typeof g['name'] === 'string' ? (g['name'] as string) : '未命名分组',
@@ -2221,21 +2265,14 @@ export const canvasApi = {
   // ─── 分镜分组 CRUD（存 project.metadata.film.shotGroups）─────────────────
 
   /** 读取项目的分镜分组 */
-  readShotGroups(
-    db: CanvasDb,
-    projectId: string,
-  ): ShotGroup[] {
+  readShotGroups(db: CanvasDb, projectId: string): ShotGroup[] {
     const project = db.projects.find((item) => item.id === projectId)
     const film = project?.metadata?.film as FilmProjectData | undefined
     return film?.shotGroups ?? []
   },
 
   /** 写入分镜分组（不可变更新 project.metadata） */
-  writeShotGroups(
-    db: CanvasDb,
-    projectId: string,
-    groups: ShotGroup[],
-  ): void {
+  writeShotGroups(db: CanvasDb, projectId: string, groups: ShotGroup[]): void {
     const project = db.projects.find((item) => item.id === projectId)
     if (!project) return
     const film = (project.metadata?.film ?? {}) as FilmProjectData
@@ -2283,10 +2320,7 @@ export const canvasApi = {
   },
 
   /** 删除分镜分组 */
-  async deleteShotGroup(
-    projectId: string,
-    groupId: string,
-  ): Promise<{ shotGroups: ShotGroup[] }> {
+  async deleteShotGroup(projectId: string, groupId: string): Promise<{ shotGroups: ShotGroup[] }> {
     const db = readDb()
     let groups = this.readShotGroups(db, projectId)
     groups = groups.filter((item) => item.id !== groupId)
@@ -3080,7 +3114,6 @@ export const canvasApi = {
     return this.openSnapshot(projectId)
   },
 
-
   /**
    * 创建类型化操作节点（文档：AI 操作按类型分拆节点）。
    * type=operation 的节点 + CanvasTask（pending）+ 输入 used_as_input 连线。
@@ -3097,17 +3130,52 @@ export const canvasApi = {
     const db = readDb()
     const at = now()
     const taskId = uid('canvas_task')
-    const board = db.boards.find((item) => item.id === input.boardId && item.projectId === input.projectId)
+    const board = db.boards.find(
+      (item) => item.id === input.boardId && item.projectId === input.projectId,
+    )
     if (!board) throw new Error('Canvas board not found')
     const inputNodes = db.nodes.filter(
       (n) => input.inputNodeIds.includes(n.id) && n.projectId === input.projectId && !n.hidden,
     )
+    const project = db.projects.find((item) => item.id === input.projectId)
+    const inputTasks = inputNodes
+      .map((node) =>
+        node.taskId
+          ? db.tasks.find((task) => task.id === node.taskId && task.projectId === input.projectId)
+          : null,
+      )
+      .filter((task): task is CanvasTask => task != null)
     const promptContext = inputNodes
       .filter((n) => n.type === 'text' || n.type === 'prompt')
       .map((n) => n.data.text ?? '')
       .filter(Boolean)
       .join('\n\n')
-    const maxZ = Math.max(0, ...db.nodes.filter((n) => n.projectId === input.projectId).map((n) => n.zIndex))
+    const inheritedPrompt =
+      promptContext ||
+      inputNodes
+        .map((node) => nonEmptyString(node.data.prompt))
+        .find((value): value is string => value != null) ||
+      inputTasks
+        .map((task) => nonEmptyString(task.prompt))
+        .find((value): value is string => value != null) ||
+      nonEmptyString(project?.settings?.prompt) ||
+      ''
+    const inheritedNegativePrompt =
+      inputTasks
+        .map((task) => nonEmptyString(task.negativePrompt))
+        .find((value): value is string => value != null) ||
+      inputNodes
+        .map((node) => nonEmptyString(node.data.negativePrompt))
+        .find((value): value is string => value != null) ||
+      nonEmptyString(project?.settings?.negativePrompt)
+    const inheritedModelParams: Record<string, unknown> = {}
+    for (const task of inputTasks) mergeInheritedModelParams(inheritedModelParams, task.modelParams)
+    for (const node of inputNodes)
+      mergeInheritedModelParams(inheritedModelParams, node.data.modelParams)
+    const maxZ = Math.max(
+      0,
+      ...db.nodes.filter((n) => n.projectId === input.projectId).map((n) => n.zIndex),
+    )
     const node = createNodeBase({
       projectId: input.projectId,
       boardId: input.boardId,
@@ -3123,7 +3191,11 @@ export const canvasApi = {
         status: 'pending',
         progress: 0,
         message: '点击下方编辑面板调整参数后运行',
-        ...(promptContext ? { prompt: promptContext } : {}),
+        ...(inheritedPrompt ? { prompt: inheritedPrompt } : {}),
+        ...(inheritedNegativePrompt ? { negativePrompt: inheritedNegativePrompt } : {}),
+        ...(Object.keys(inheritedModelParams).length > 0
+          ? { modelParams: inheritedModelParams }
+          : {}),
         origin: 'manual',
       },
       at,
@@ -3139,13 +3211,13 @@ export const canvasApi = {
       status: 'pending',
       progress: 0,
       title: input.title ?? operationLabel(input.operation),
-      prompt: promptContext || null,
-      negativePrompt: null,
+      prompt: inheritedPrompt || null,
+      negativePrompt: inheritedNegativePrompt ?? null,
       inputNodeIds: input.inputNodeIds,
       inputAssetIds: inputNodes.map((n) => n.assetId).filter((id): id is string => Boolean(id)),
       outputNodeIds: [],
       outputAssetIds: [],
-      modelParams: {},
+      modelParams: inheritedModelParams,
       createdAt: at,
       updatedAt: at,
     }
@@ -3182,9 +3254,10 @@ export const canvasApi = {
     const oldTask = db.tasks.find((t) => t.id === node.taskId && t.projectId === projectId)
     if (!oldTask) throw new Error('未找到原任务')
     const oldOutputNodes = db.nodes.filter((n) => oldTask.outputNodeIds.includes(n.id))
-    const baseX = oldOutputNodes.length > 0
-      ? Math.max(...oldOutputNodes.map((n) => n.x + n.width)) + 60
-      : node.x + node.width + 60
+    const baseX =
+      oldOutputNodes.length > 0
+        ? Math.max(...oldOutputNodes.map((n) => n.x + n.width)) + 60
+        : node.x + node.width + 60
     const baseY = node.y
     const request: CreateCanvasTaskRequest = {
       boardId: node.boardId,
@@ -3229,7 +3302,9 @@ export const canvasApi = {
     if (!node) throw new Error('操作节点不存在')
     // 取输入节点（used_as_input edge 的 source）
     const existingInputNodeIds = db.edges
-      .filter((e) => e.targetNodeId === nodeId && e.type === 'used_as_input' && e.projectId === projectId)
+      .filter(
+        (e) => e.targetNodeId === nodeId && e.type === 'used_as_input' && e.projectId === projectId,
+      )
       .map((e) => e.sourceNodeId)
     const inputNodeIds = Array.from(new Set(params.inputNodeIds ?? existingInputNodeIds))
     const inputNodes = db.nodes.filter(
@@ -3260,11 +3335,14 @@ export const canvasApi = {
     }
     // output 位置：节点右侧
     const oldOutputs = db.nodes.filter((n) =>
-      db.edges.some((e) => e.sourceNodeId === nodeId && e.type === 'generated' && e.targetNodeId === n.id),
+      db.edges.some(
+        (e) => e.sourceNodeId === nodeId && e.type === 'generated' && e.targetNodeId === n.id,
+      ),
     )
-    const baseX = oldOutputs.length > 0
-      ? Math.max(...oldOutputs.map((n) => n.x + n.width)) + 60
-      : node.x + node.width + 60
+    const baseX =
+      oldOutputs.length > 0
+        ? Math.max(...oldOutputs.map((n) => n.x + n.width)) + 60
+        : node.x + node.width + 60
     const request = {
       operation: (node.data.operation ?? node.type) as CanvasOperationType,
       prompt: params.prompt,

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
@@ -114,6 +114,9 @@ export type CanvasNodeData = {
   progress?: number
   message?: string
   prompt?: string
+  /** 继承/暂存的反向提示词；任务持久化仍以 CanvasTask.negativePrompt 为准 */
+  negativePrompt?: string
+  modelParams?: Record<string, unknown>
   /** UI 表现层子类型（如 'script'），不改变底层 node type */
   subtype?: string
   /** 节点展示分类，用于添加节点菜单分组：内容 / 任务 / 资源 */

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationInheritance.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationInheritance.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { canvasApi } from './canvas.api'
+import type { CanvasDb } from './canvas.api'
+
+const STORAGE_KEY = 'spark-canvas:v1'
+
+const at = '2026-06-18T00:00:00.000Z'
+
+function seedCanvasDb(db: CanvasDb) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(db))
+}
+
+describe('canvas operation inheritance', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.stubGlobal('window', window)
+    Object.assign(window, {
+      spark: {
+        invoke: vi.fn().mockResolvedValue({ rootPath: '/tmp/project-1' }),
+      },
+    })
+  })
+
+  it('creates downstream operation nodes with inherited negative prompt and key model params', async () => {
+    seedCanvasDb({
+      projects: [
+        {
+          id: 'project-1',
+          userId: 0,
+          title: 'Project',
+          status: 'active',
+          settings: { prompt: 'project prompt', negativePrompt: 'project negative' },
+          nodeCount: 1,
+          assetCount: 1,
+          taskCount: 1,
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      boards: [
+        {
+          id: 'board-1',
+          projectId: 'project-1',
+          userId: 0,
+          name: 'Board',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          settings: {},
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      assets: [
+        {
+          id: 'asset-1',
+          projectId: 'project-1',
+          userId: 0,
+          type: 'image',
+          source: 'ai_generated',
+          title: 'Source image',
+          url: 'file:///source.png',
+          metadata: {},
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      nodes: [
+        {
+          id: 'node-source',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          userId: 0,
+          type: 'image',
+          title: 'Source image',
+          assetId: 'asset-1',
+          taskId: 'task-source',
+          parentNodeId: null,
+          x: 10,
+          y: 20,
+          width: 240,
+          height: 180,
+          rotation: 0,
+          zIndex: 1,
+          locked: false,
+          hidden: false,
+          data: { url: 'file:///source.png' },
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      edges: [],
+      tasks: [
+        {
+          id: 'task-source',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          userId: 0,
+          operation: 'text_to_image',
+          status: 'completed',
+          progress: 100,
+          title: 'Source task',
+          prompt: 'cinematic portrait',
+          negativePrompt: 'blurry, low quality',
+          inputNodeIds: [],
+          inputAssetIds: [],
+          outputNodeIds: ['node-source'],
+          outputAssetIds: ['asset-1'],
+          modelParams: { aspectRatio: '16:9', seed: 1234, internalDebug: true },
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+    })
+
+    const snapshot = await canvasApi.createOperationNode({
+      projectId: 'project-1',
+      boardId: 'board-1',
+      operation: 'image_to_image',
+      inputNodeIds: ['node-source'],
+      x: 310,
+      y: 20,
+    })
+
+    const operationNode = snapshot.nodes.find((node) => node.type === 'image_to_image')
+    expect(operationNode).toBeDefined()
+    const pendingTask = snapshot.tasks.find((task) => task.id === operationNode?.taskId)
+    expect(pendingTask?.prompt).toBe('cinematic portrait')
+    expect(pendingTask?.negativePrompt).toBe('blurry, low quality')
+    expect(pendingTask?.modelParams).toEqual({ aspectRatio: '16:9', seed: 1234 })
+    expect(operationNode?.data.negativePrompt).toBe('blurry, low quality')
+    expect(operationNode?.data.modelParams).toEqual({ aspectRatio: '16:9', seed: 1234 })
+  })
+})


### PR DESCRIPTION
### Motivation
- Allow operation nodes to inherit `prompt`, `negativePrompt`, and a safe subset of `modelParams` from input nodes/tasks or project settings so downstream operations start with sensible defaults instead of forced `null`.
- Surface inherited values in the operation panel UI so users see and can submit upstream `negativePrompt` and model parameters without losing the task-level source-of-truth (`CanvasTask.negativePrompt`).

### Description
- Added `negativePrompt?: string` and `modelParams?: Record<string, unknown>` to `CanvasNodeData` to carry temporary/inherited metadata at the node level (`apps/desktop/src/renderer/design/views/canvas/canvas.types.ts`).
- Implemented helpers `nonEmptyString`, `pickInheritedModelParams`, and `mergeInheritedModelParams` and updated `createOperationNode()` to collect inherited `prompt` / `negativePrompt` / key `modelParams` from input nodes, their associated tasks, and project settings and write them into the new pending node and `CanvasTask` when present (`apps/desktop/src/renderer/design/views/canvas/canvas.api.ts`).
- Ensure `negativePrompt` is not forcibly written as `null`; only set it on the new pending `CanvasTask` and node data when an upstream value exists. (`canvas.api.ts`).
- Updated `CanvasOperationPanel` initial state to prefer `task?.negativePrompt`, then `node.data.negativePrompt`, then upstream task/node/project settings, and to initialize model params from `task?.modelParams` or `node.data.modelParams` when available (`apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx`).
- Added a unit test `src/renderer/design/views/canvas/canvasOperationInheritance.test.ts` that seeds a project with an upstream completed image task that has `negativePrompt` and `modelParams`, then creates a downstream operation and asserts the pending node and task inherit the negative prompt and filtered model params.

### Testing
- Ran the new unit test: `pnpm --filter @spark/desktop exec vitest run src/renderer/design/views/canvas/canvasOperationInheritance.test.ts` — test passed.
- Ran typecheck: `pnpm --filter @spark/desktop typecheck` — succeeded with no type errors.
- Ran `git diff --check` and basic whitespace/format checks — no issues found.
- Attempted GitNexus impact/detect_changes (`npx gitnexus detect_changes --scope compare --base_ref master`) but the CLI install/execution timed out in this environment, so automated blast-radius/detect_changes output was unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3391e3b7e88325b4dd030b310765db)