### PR TITLE
feat(canvas): add video frame role selectors and pass `inputRoles` to task input builder

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Button, Input, Select, Tag, Tooltip, message } from 'antd'
 import { Icons } from '../../Icons'
-import { capabilityForOperation, type CanvasMediaModelSummary } from '@spark/protocol'
+import {
+  capabilityForOperation,
+  type CanvasMediaModelSummary,
+  type CanvasMediaTaskInputFile,
+} from '@spark/protocol'
 import { operationLabel } from './canvas.api'
 import { getCanvasCapability, nodeOperation } from './canvas.capabilities'
 import { AssetThumbnail } from './CanvasAssetThumbnail'
@@ -35,11 +39,14 @@ import type {
  * 三区：操作类型 / 输入预览 / 参数编辑。确定后运行。
  */
 
+type CanvasTaskInputRole = NonNullable<CanvasMediaTaskInputFile['role']>
+
 export type OperationRunParams = {
   prompt: string
   negativePrompt?: string
   inputNodeIds?: string[]
   inputTransport?: CanvasInputTransport
+  inputRoles?: Record<string, CanvasTaskInputRole>
   providerProfileId?: string
   manifestId?: string
   modelId?: string
@@ -65,7 +72,8 @@ export function CanvasOperationPanel({
   const operation = nodeOperation(node) ?? 'text_generate'
   const capability = getCanvasCapability(operation)
   const operationText = operationLabel(operation)
-  const canEditMediaInputs = capability?.inputTypes.some((type) => type === 'image' || type === 'video') ?? false
+  const canEditMediaInputs =
+    capability?.inputTypes.some((type) => type === 'image' || type === 'video') ?? false
 
   // 上游输入节点（used_as_input edge 的 source）
   const sourceInputNodes = useMemo(() => {
@@ -97,9 +105,10 @@ export function CanvasOperationPanel({
           return true
         })
         .sort((left, right) => left.x - right.x || left.y - right.y || left.zIndex - right.zIndex)
-        .map((item) => ({
+        .map((item, index) => ({
           value: item.id,
-          label: item.title ?? (item.type === 'video' ? '视频节点' : '图片节点'),
+          label: item.title ?? (item.type === 'video' ? `视频 ${index + 1}` : `图片 ${index + 1}`),
+          type: item.type,
         })),
     [capability, node.id, snapshot.nodes],
   )
@@ -122,13 +131,20 @@ export function CanvasOperationPanel({
   const [modelParamDraft, setModelParamDraft] = useState<Record<string, string>>({})
   const [customParams, setCustomParams] = useState<CustomParamDraft[]>([])
   const [selectedInputNodeIds, setSelectedInputNodeIds] = useState<string[]>(() =>
-    (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map((item) => item.id),
+    (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map(
+      (item) => item.id,
+    ),
   )
+  const [firstFrameNodeId, setFirstFrameNodeId] = useState('')
+  const [lastFrameNodeId, setLastFrameNodeId] = useState('')
+  const [referenceFrameNodeIds, setReferenceFrameNodeIds] = useState<string[]>([])
   const [running, setRunning] = useState(false)
 
   useEffect(() => {
     setSelectedInputNodeIds(
-      (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map((item) => item.id),
+      (canEditMediaInputs ? editableSourceMediaNodes : expandedSourceInputNodes).map(
+        (item) => item.id,
+      ),
     )
   }, [canEditMediaInputs, editableSourceMediaNodes, expandedSourceInputNodes])
 
@@ -166,8 +182,13 @@ export function CanvasOperationPanel({
 
   const statusTag = useMemo(() => {
     const s = node.data.status ?? 'pending'
-    const color = s === 'completed' ? 'green' : s === 'failed' ? 'red' : s === 'running' ? 'blue' : 'default'
-    return <Tag color={color} bordered>{operationStatusLabel(s)}</Tag>
+    const color =
+      s === 'completed' ? 'green' : s === 'failed' ? 'red' : s === 'running' ? 'blue' : 'default'
+    return (
+      <Tag color={color} bordered>
+        {operationStatusLabel(s)}
+      </Tag>
+    )
   }, [node.data.status])
 
   const mediaCapabilityIds = useMemo(() => capabilityForOperation(operation), [operation])
@@ -199,6 +220,48 @@ export function CanvasOperationPanel({
       ) ?? null
     )
   }, [mediaCapabilityIds, selectedModel])
+  const supportsVideoFrameRoles = useMemo(
+    () =>
+      operationSupportsVideoFrameRoles(operation) &&
+      mediaInputOptions.some((option) => option.type === 'image'),
+    [mediaInputOptions, operation],
+  )
+  const videoFrameMaxImages = useMemo(
+    () => videoImageLimitForCapability(operation, selectedCapability),
+    [operation, selectedCapability],
+  )
+  const canUseLastFrame = supportsVideoFrameRoles && videoFrameMaxImages > 1
+  const selectedFrameCount =
+    (firstFrameNodeId ? 1 : 0) + (lastFrameNodeId ? 1 : 0) + referenceFrameNodeIds.length
+  const referenceFrameCapacity = Math.max(
+    0,
+    videoFrameMaxImages - (firstFrameNodeId ? 1 : 0) - (lastFrameNodeId ? 1 : 0),
+  )
+  const frameImageOptions = useMemo(
+    () => mediaInputOptions.filter((option) => option.type === 'image'),
+    [mediaInputOptions],
+  )
+  const hasExplicitFrameInput =
+    supportsVideoFrameRoles &&
+    Boolean(firstFrameNodeId || lastFrameNodeId || referenceFrameNodeIds.length > 0)
+  const explicitFrameNodeIds = useMemo(
+    () =>
+      supportsVideoFrameRoles
+        ? normalizeVideoFrameNodeIds(
+            firstFrameNodeId,
+            lastFrameNodeId,
+            referenceFrameNodeIds,
+            videoFrameMaxImages,
+          )
+        : [],
+    [
+      firstFrameNodeId,
+      lastFrameNodeId,
+      referenceFrameNodeIds,
+      supportsVideoFrameRoles,
+      videoFrameMaxImages,
+    ],
+  )
   const parameterFields = useMemo(
     () =>
       mergeSchemaFields(
@@ -222,7 +285,13 @@ export function CanvasOperationPanel({
         (!task?.modelId || model.effectiveModelId === task.modelId),
     )
     setSelectedModelKey(mediaModelKey(fromTask ?? supportedMediaModels[0]!))
-  }, [selectedModelKey, supportedMediaModels, task?.manifestId, task?.modelId, task?.providerProfileId])
+  }, [
+    selectedModelKey,
+    supportedMediaModels,
+    task?.manifestId,
+    task?.modelId,
+    task?.providerProfileId,
+  ])
 
   useEffect(() => {
     const defaults = selectedCapability?.defaults ?? {}
@@ -247,18 +316,31 @@ export function CanvasOperationPanel({
   }, [parameterFields, selectedCapability, task?.modelParams])
 
   const handleRun = useCallback(() => {
-    if (!prompt.trim() && !capability?.inputTypes.includes('image') && !capability?.inputTypes.includes('video')) {
+    if (
+      !prompt.trim() &&
+      !capability?.inputTypes.includes('image') &&
+      !capability?.inputTypes.includes('video')
+    ) {
       message.warning('请输入提示词')
       return
     }
     if (
       canEditMediaInputs &&
       capability?.inputTypes.some((type) => type === 'image' || type === 'video') &&
-      selectedInputNodeIds.length === 0
+      selectedInputNodeIds.length === 0 &&
+      !hasExplicitFrameInput
     ) {
       message.warning('请至少选择一个输入图片或视频节点')
       return
     }
+    const inputRoles = supportsVideoFrameRoles
+      ? buildVideoFrameInputRoles(
+          explicitFrameNodeIds,
+          firstFrameNodeId,
+          lastFrameNodeId,
+          referenceFrameNodeIds,
+        )
+      : undefined
     const nextModelParams = normalizeModelParamsForSubmit(
       {
         ...buildModelParams(parameterFields, modelParamDraft),
@@ -269,6 +351,7 @@ export function CanvasOperationPanel({
     const runInputNodeIds = Array.from(
       new Set([
         ...selectedInputNodeIds,
+        ...explicitFrameNodeIds,
         ...expandedSourceInputNodes
           .filter((item) => item.type === 'text' || item.type === 'prompt')
           .map((item) => item.id),
@@ -282,10 +365,13 @@ export function CanvasOperationPanel({
       ...(selectedModel?.providerKind === 'xai'
         ? { inputTransport: 'base64' as const }
         : { inputTransport: 'cloud_url' as const }),
-      ...(selectedModel?.providerProfileId ? { providerProfileId: selectedModel.providerProfileId } : {}),
+      ...(selectedModel?.providerProfileId
+        ? { providerProfileId: selectedModel.providerProfileId }
+        : {}),
       ...(selectedModel?.manifestId ? { manifestId: selectedModel.manifestId } : {}),
       ...(selectedModel?.effectiveModelId ? { modelId: selectedModel.effectiveModelId } : {}),
       ...(Object.keys(nextModelParams).length > 0 ? { modelParams: nextModelParams } : {}),
+      ...(inputRoles && Object.keys(inputRoles).length > 0 ? { inputRoles } : {}),
     })
   }, [
     capability,
@@ -298,22 +384,30 @@ export function CanvasOperationPanel({
     selectedCapability,
     selectedModel,
     expandedSourceInputNodes,
+    explicitFrameNodeIds,
+    firstFrameNodeId,
+    hasExplicitFrameInput,
+    lastFrameNodeId,
     selectedInputNodeIds,
+    referenceFrameNodeIds,
+    supportsVideoFrameRoles,
   ])
 
-  const selectedInputIdSet = useMemo(() => new Set(selectedInputNodeIds), [selectedInputNodeIds])
-  const inputNodes = useMemo(
-    () => {
-      const byId = new Map(snapshot.nodes.map((item) => [item.id, item]))
-      return selectedInputNodeIds
-        .map((id) => byId.get(id))
-        .filter((item): item is CanvasNode => item != null)
-        .filter((item) => !item.hidden && selectedInputIdSet.has(item.id))
-    },
-    [selectedInputIdSet, selectedInputNodeIds, snapshot.nodes],
+  const selectedInputIdSet = useMemo(
+    () => new Set([...selectedInputNodeIds, ...explicitFrameNodeIds]),
+    [explicitFrameNodeIds, selectedInputNodeIds],
   )
+  const inputNodes = useMemo(() => {
+    const byId = new Map(snapshot.nodes.map((item) => [item.id, item]))
+    return Array.from(selectedInputIdSet)
+      .map((id) => byId.get(id))
+      .filter((item): item is CanvasNode => item != null)
+      .filter((item) => !item.hidden && selectedInputIdSet.has(item.id))
+  }, [selectedInputIdSet, snapshot.nodes])
   const mediaInputs = inputNodes.filter((n) => n.type === 'image' || n.type === 'video')
-  const textInputs = expandedSourceInputNodes.filter((n) => n.type === 'text' || n.type === 'prompt')
+  const textInputs = expandedSourceInputNodes.filter(
+    (n) => n.type === 'text' || n.type === 'prompt',
+  )
 
   return (
     <div className="canvas-operation-panel" onMouseDown={(e) => e.stopPropagation()}>
@@ -321,7 +415,11 @@ export function CanvasOperationPanel({
         <div className="canvas-operation-panel-title">
           {operationLabel(operation)}
           {statusTag}
-          {outputNodes.length > 0 && <Tag color="purple" bordered>{outputNodes.length} 产出</Tag>}
+          {outputNodes.length > 0 && (
+            <Tag color="purple" bordered>
+              {outputNodes.length} 产出
+            </Tag>
+          )}
         </div>
         <Button size="small" type="text" icon={<Icons.X size={15} />} onClick={onClose} />
       </div>
@@ -335,22 +433,139 @@ export function CanvasOperationPanel({
                 输入 ({inputNodes.length + textInputs.length})
               </div>
               {sourceInputNodes.some((item) => item.type === 'group') && (
-                <Tag bordered color="gold">已展开组内元素</Tag>
+                <Tag bordered color="gold">
+                  已展开组内元素
+                </Tag>
               )}
             </div>
             {canEditMediaInputs && (
-              <Select
-                mode="multiple"
-                size="small"
-                allowClear
-                showSearch
-                value={selectedInputNodeIds}
-                placeholder="选择或调整输入图片/视频节点"
-                options={mediaInputOptions}
-                optionFilterProp="label"
-                onChange={(value) => setSelectedInputNodeIds(value.map(String))}
-                disabled={running}
-              />
+              <>
+                <Select
+                  mode="multiple"
+                  size="small"
+                  allowClear
+                  showSearch
+                  value={
+                    supportsVideoFrameRoles
+                      ? selectedInputNodeIds.filter((id) =>
+                          mediaInputOptions.some(
+                            (option) => option.value === id && option.type === 'video',
+                          ),
+                        )
+                      : selectedInputNodeIds
+                  }
+                  placeholder={
+                    supportsVideoFrameRoles
+                      ? '选择输入视频节点（图片请用下方帧角色）'
+                      : '选择或调整输入图片/视频节点'
+                  }
+                  options={
+                    supportsVideoFrameRoles
+                      ? mediaInputOptions.filter((option) => option.type === 'video')
+                      : mediaInputOptions
+                  }
+                  optionFilterProp="label"
+                  onChange={(value) => {
+                    const values = value.map(String)
+                    setSelectedInputNodeIds((prev) =>
+                      supportsVideoFrameRoles
+                        ? [
+                            ...prev.filter((id) =>
+                              mediaInputOptions.some(
+                                (option) => option.value === id && option.type === 'image',
+                              ),
+                            ),
+                            ...values,
+                          ]
+                        : values,
+                    )
+                  }}
+                  disabled={running}
+                />
+                {supportsVideoFrameRoles && (
+                  <div className="canvas-operation-panel-frame-roles">
+                    <div className="canvas-frame-role-grid">
+                      <div className="canvas-param-field">
+                        <span>首帧</span>
+                        <Select
+                          size="small"
+                          allowClear
+                          showSearch
+                          value={firstFrameNodeId || undefined}
+                          options={frameImageOptions}
+                          optionFilterProp="label"
+                          disabled={running}
+                          onChange={(value) => {
+                            const next = value == null ? '' : String(value)
+                            setFirstFrameNodeId(next)
+                            if (next && next === lastFrameNodeId) setLastFrameNodeId('')
+                            if (next)
+                              setReferenceFrameNodeIds((prev) => prev.filter((id) => id !== next))
+                          }}
+                        />
+                      </div>
+                      <div className="canvas-param-field">
+                        <span>尾帧</span>
+                        <Select
+                          size="small"
+                          allowClear
+                          showSearch
+                          value={lastFrameNodeId || undefined}
+                          options={frameImageOptions}
+                          optionFilterProp="label"
+                          placeholder={canUseLastFrame ? undefined : '当前模型仅 1 张图'}
+                          disabled={running || !canUseLastFrame}
+                          onChange={(value) => {
+                            const next = value == null ? '' : String(value)
+                            setLastFrameNodeId(next && next !== firstFrameNodeId ? next : '')
+                            if (next)
+                              setReferenceFrameNodeIds((prev) => prev.filter((id) => id !== next))
+                          }}
+                        />
+                      </div>
+                    </div>
+                    {videoFrameMaxImages > 2 && (
+                      <div className="canvas-param-field">
+                        <span>参考图</span>
+                        <Select
+                          mode="multiple"
+                          size="small"
+                          allowClear
+                          showSearch
+                          value={referenceFrameNodeIds}
+                          options={frameImageOptions.filter(
+                            (option) =>
+                              option.value !== firstFrameNodeId && option.value !== lastFrameNodeId,
+                          )}
+                          optionFilterProp="label"
+                          placeholder={
+                            referenceFrameCapacity > 0
+                              ? `最多再选 ${referenceFrameCapacity} 张`
+                              : '已达上限'
+                          }
+                          disabled={running || referenceFrameCapacity <= 0}
+                          onChange={(value) => {
+                            const values = value.map(String)
+                            setReferenceFrameNodeIds(
+                              values
+                                .filter((id) => id !== firstFrameNodeId && id !== lastFrameNodeId)
+                                .slice(0, referenceFrameCapacity),
+                            )
+                          }}
+                        />
+                      </div>
+                    )}
+                    <div className="canvas-operation-panel-hint canvas-frame-role-hint">
+                      未手动指定时，第一张图片作为首帧，第二张作为尾帧，后续作为参考图；建议显式选择以避免顺序变化。
+                      当前模型最多使用 {videoFrameMaxImages} 张图片，已显式选择{' '}
+                      {Math.min(selectedFrameCount, videoFrameMaxImages)} 张。
+                      {operation === 'video_edit'
+                        ? ' 可同时选择输入视频节点，并为参考帧指定角色。'
+                        : ''}
+                    </div>
+                  </div>
+                )}
+              </>
             )}
             {mediaInputs.length > 0 ? (
               <div className="canvas-operation-panel-inputs">
@@ -395,8 +610,14 @@ export function CanvasOperationPanel({
             {textInputs.length > 0 && (
               <div className="canvas-operation-panel-text-inputs">
                 {textInputs.map((n) => (
-                  <div key={n.id} className="canvas-operation-panel-text-input" title={n.title ?? ''}>
-                    <span className="canvas-operation-panel-text-input-title">{n.title ?? '文本'}</span>
+                  <div
+                    key={n.id}
+                    className="canvas-operation-panel-text-input"
+                    title={n.title ?? ''}
+                  >
+                    <span className="canvas-operation-panel-text-input-title">
+                      {n.title ?? '文本'}
+                    </span>
                     <span className="canvas-operation-panel-text-input-content">
                       {(n.data.text ?? '').slice(0, 80) || '(空)'}
                     </span>
@@ -619,7 +840,9 @@ export function CanvasOperationPanel({
           重试
         </Button>
         <div className="canvas-operation-panel-footer-spacer" />
-        <Button size="small" onClick={onClose}>取消</Button>
+        <Button size="small" onClick={onClose}>
+          取消
+        </Button>
         <Button
           size="small"
           type="primary"
@@ -635,7 +858,10 @@ export function CanvasOperationPanel({
   )
 }
 
-function expandOperationInputNodes(sourceNodes: CanvasNode[], allNodes: CanvasNode[]): CanvasNode[] {
+function expandOperationInputNodes(
+  sourceNodes: CanvasNode[],
+  allNodes: CanvasNode[],
+): CanvasNode[] {
   const byId = new Map(allNodes.map((item) => [item.id, item]))
   const seen = new Set<string>()
   const result: CanvasNode[] = []
@@ -670,10 +896,7 @@ function expandOperationInputNodes(sourceNodes: CanvasNode[], allNodes: CanvasNo
   return result
 }
 
-function isSupportedMediaInputNode(
-  node: CanvasNode,
-  inputTypes: readonly string[],
-): boolean {
+function isSupportedMediaInputNode(node: CanvasNode, inputTypes: readonly string[]): boolean {
   if (node.type === 'image') return inputTypes.includes('image')
   if (node.type === 'video') return inputTypes.includes('video')
   return false
@@ -684,6 +907,62 @@ function inferCustomParamType(value: unknown): CustomParamType {
   if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'number'
   if (value && typeof value === 'object') return 'json'
   return 'string'
+}
+
+function operationSupportsVideoFrameRoles(operation: CanvasOperationType): boolean {
+  return operation === 'image_to_video' || operation === 'video_edit'
+}
+
+function videoImageLimitForCapability(
+  operation: CanvasOperationType,
+  capability: CanvasMediaModelSummary['capabilities'][number] | null,
+): number {
+  const maxImages = capability?.input?.maxImages
+  if (typeof maxImages === 'number' && Number.isFinite(maxImages) && maxImages > 0) {
+    return Math.max(1, Math.floor(maxImages))
+  }
+  if (operation === 'video_edit') return 2
+  if (operation === 'image_to_video') return 1
+  return 1
+}
+
+function buildVideoFrameInputRoles(
+  imageNodeIds: string[],
+  firstFrameNodeId: string,
+  lastFrameNodeId: string,
+  referenceFrameNodeIds: string[],
+): Record<string, CanvasTaskInputRole> {
+  const roles: Record<string, CanvasTaskInputRole> = {}
+  const referenceIds = new Set(referenceFrameNodeIds)
+  for (const nodeId of imageNodeIds) {
+    if (nodeId === firstFrameNodeId) {
+      roles[nodeId] = 'first_frame'
+      continue
+    }
+    if (nodeId === lastFrameNodeId) {
+      roles[nodeId] = 'last_frame'
+      continue
+    }
+    if (referenceIds.has(nodeId)) roles[nodeId] = 'reference'
+  }
+  return roles
+}
+
+function normalizeVideoFrameNodeIds(
+  firstFrameNodeId: string,
+  lastFrameNodeId: string,
+  referenceFrameNodeIds: string[],
+  maxImages: number,
+): string[] {
+  const result: string[] = []
+  const push = (id: string) => {
+    if (!id || result.includes(id) || result.length >= maxImages) return
+    result.push(id)
+  }
+  push(firstFrameNodeId)
+  push(lastFrameNodeId)
+  for (const id of referenceFrameNodeIds) push(id)
+  return result
 }
 
 function operationStatusLabel(status: CanvasTask['status']): string {

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -9,7 +9,9 @@
   --canvas-node-head-bg: color-mix(in srgb, var(--panel-elev) 90%, var(--bg-soft));
   --canvas-node-body-bg: color-mix(in srgb, var(--panel-elev) 88%, var(--bg));
   --canvas-node-shadow: 0 14px 34px rgba(0, 0, 0, 0.28), 0 2px 8px rgba(0, 0, 0, 0.24);
-  --canvas-node-shadow-selected: 0 0 0 1px color-mix(in srgb, var(--primary) 55%, transparent), 0 0 0 4px color-mix(in srgb, var(--primary) 16%, transparent), 0 18px 46px rgba(0, 0, 0, 0.34);
+  --canvas-node-shadow-selected:
+    0 0 0 1px color-mix(in srgb, var(--primary) 55%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--primary) 16%, transparent), 0 18px 46px rgba(0, 0, 0, 0.34);
   display: flex;
   flex: 1;
   min-height: 0;
@@ -26,7 +28,10 @@
   --canvas-node-head-bg: color-mix(in srgb, #ffffff 92%, var(--bg-sunken));
   --canvas-node-body-bg: color-mix(in srgb, #ffffff 94%, var(--bg-sunken));
   --canvas-node-shadow: 0 16px 32px rgba(31, 28, 24, 0.08), 0 2px 8px rgba(31, 28, 24, 0.06);
-  --canvas-node-shadow-selected: 0 0 0 1px color-mix(in srgb, var(--primary) 48%, transparent), 0 0 0 4px color-mix(in srgb, var(--primary) 12%, transparent), 0 18px 44px rgba(31, 28, 24, 0.12);
+  --canvas-node-shadow-selected:
+    0 0 0 1px color-mix(in srgb, var(--primary) 48%, transparent),
+    0 0 0 4px color-mix(in srgb, var(--primary) 12%, transparent),
+    0 18px 44px rgba(31, 28, 24, 0.12);
 }
 
 .canvas-workspace-loading {
@@ -42,8 +47,11 @@
   gap: 12px;
   padding: 10px 12px 10px 14px;
   border-bottom: 1px solid var(--divider);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--panel-elev) 88%, transparent), var(--panel));
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--panel-elev) 88%, transparent),
+    var(--panel)
+  );
   flex-shrink: 0;
   // macOS：header 自身作为窗口拖拽区（替代独立 MacWindowDragHeader，省 20px）。
   // 交互元素（按钮/chip）需单独设 no-drag 才能点击。
@@ -144,12 +152,25 @@
   --canvas-side-panel-width: 360px;
   --canvas-left-panel-width: 264px;
   // 三列布局：左工作台 | 主画布 | 右信息面板（文档 §6）
-  grid-template-columns: var(--canvas-left-panel-width) minmax(0, 1fr) var(--canvas-side-panel-width);
+  grid-template-columns: var(--canvas-left-panel-width) minmax(0, 1fr) var(
+      --canvas-side-panel-width
+    );
   background:
-    linear-gradient(90deg, color-mix(in srgb, var(--border) 58%, transparent) 0 1px, transparent 1px),
-    linear-gradient(180deg, color-mix(in srgb, var(--border) 42%, transparent) 0 1px, transparent 1px),
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--border) 58%, transparent) 0 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--border) 42%, transparent) 0 1px,
+      transparent 1px
+    ),
     var(--bg-sunken);
-  background-size: 48px 48px, 48px 48px, auto;
+  background-size:
+    48px 48px,
+    48px 48px,
+    auto;
 }
 
 // 左工作台折叠时保留窄列（44px）只显示展开按钮，避免展开入口丢失
@@ -326,8 +347,16 @@
   min-width: 0;
   min-height: 0;
   background:
-    repeating-linear-gradient(0deg, transparent 0 23px, color-mix(in srgb, var(--text-muted) 6%, transparent) 23px 24px),
-    repeating-linear-gradient(90deg, transparent 0 23px, color-mix(in srgb, var(--text-muted) 6%, transparent) 23px 24px),
+    repeating-linear-gradient(
+      0deg,
+      transparent 0 23px,
+      color-mix(in srgb, var(--text-muted) 6%, transparent) 23px 24px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent 0 23px,
+      color-mix(in srgb, var(--text-muted) 6%, transparent) 23px 24px
+    ),
     var(--bg-sunken);
 }
 
@@ -447,11 +476,19 @@
 }
 
 .canvas-node.canvas-node-text::before {
-  background: linear-gradient(90deg, var(--canvas-accent-cyan), color-mix(in srgb, var(--canvas-accent-cyan) 22%, transparent));
+  background: linear-gradient(
+    90deg,
+    var(--canvas-accent-cyan),
+    color-mix(in srgb, var(--canvas-accent-cyan) 22%, transparent)
+  );
 }
 
 .canvas-node.canvas-node-prompt::before {
-  background: linear-gradient(90deg, var(--canvas-accent-amber), color-mix(in srgb, var(--canvas-accent-amber) 22%, transparent));
+  background: linear-gradient(
+    90deg,
+    var(--canvas-accent-amber),
+    color-mix(in srgb, var(--canvas-accent-amber) 22%, transparent)
+  );
 }
 
 .canvas-node.canvas-node-image::before,
@@ -466,13 +503,21 @@
 .canvas-node.canvas-node-text_to_video::before,
 .canvas-node.canvas-node-image_to_video::before,
 .canvas-node.canvas-node-video_edit::before {
-  background: linear-gradient(90deg, var(--canvas-accent-rose), color-mix(in srgb, var(--canvas-accent-rose) 18%, transparent));
+  background: linear-gradient(
+    90deg,
+    var(--canvas-accent-rose),
+    color-mix(in srgb, var(--canvas-accent-rose) 18%, transparent)
+  );
 }
 
 .canvas-node.canvas-node-audio::before,
 .canvas-node.canvas-node-text_to_audio::before,
 .canvas-node.canvas-node-audio_transcribe::before {
-  background: linear-gradient(90deg, var(--canvas-accent-lime), color-mix(in srgb, var(--canvas-accent-lime) 18%, transparent));
+  background: linear-gradient(
+    90deg,
+    var(--canvas-accent-lime),
+    color-mix(in srgb, var(--canvas-accent-lime) 18%, transparent)
+  );
 }
 
 .canvas-node:hover {
@@ -648,7 +693,11 @@
   line-height: 1.55;
   white-space: pre-wrap;
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--canvas-field-bg) 46%, transparent), transparent 42px),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--canvas-field-bg) 46%, transparent),
+      transparent 42px
+    ),
     var(--canvas-node-body-bg);
 }
 
@@ -799,7 +848,11 @@
   overflow: hidden;
   border-left: 1px solid color-mix(in srgb, var(--divider) 84%, transparent);
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--panel-elev) 60%, transparent), transparent 220px),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-elev) 60%, transparent),
+      transparent 220px
+    ),
     var(--panel);
 }
 
@@ -880,7 +933,9 @@ body.canvas-side-panel-resizing {
   background:
     linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent 120px),
     var(--canvas-float-bg);
-  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.34), 0 4px 14px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 26px 70px rgba(0, 0, 0, 0.34),
+    0 4px 14px rgba(0, 0, 0, 0.22);
   transform: translateX(-50%);
   backdrop-filter: blur(22px) saturate(1.18);
   -webkit-backdrop-filter: blur(22px) saturate(1.18);
@@ -1411,7 +1466,9 @@ body.canvas-side-panel-resizing {
   background:
     linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent 120px),
     var(--canvas-float-bg);
-  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.34), 0 4px 14px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 26px 70px rgba(0, 0, 0, 0.34),
+    0 4px 14px rgba(0, 0, 0, 0.22);
   transform: translateX(-50%);
   backdrop-filter: blur(22px) saturate(1.18);
   -webkit-backdrop-filter: blur(22px) saturate(1.18);
@@ -1564,7 +1621,10 @@ body.canvas-side-panel-resizing {
   color: inherit;
   cursor: pointer;
   text-align: left;
-  transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .canvas-node-edit-prompt-entry:hover {
@@ -2065,7 +2125,11 @@ body.canvas-side-panel-resizing {
   min-width: 0;
   min-height: 0;
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--panel-elev) 56%, transparent), transparent 220px),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--panel-elev) 56%, transparent),
+      transparent 220px
+    ),
     var(--panel);
   border-right: 1px solid color-mix(in srgb, var(--divider) 84%, transparent);
   overflow: hidden;
@@ -2086,7 +2150,9 @@ body.canvas-side-panel-resizing {
     font-size: 12px;
     font-weight: 600;
     cursor: pointer;
-    transition: color 0.15s, background 0.15s;
+    transition:
+      color 0.15s,
+      background 0.15s;
 
     &:hover {
       color: var(--text);
@@ -2464,7 +2530,9 @@ body.canvas-side-panel-resizing {
   border: 1px solid var(--divider);
   border-radius: var(--r-md);
   cursor: pointer;
-  transition: border-color 0.12s, background 0.12s;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
 
   &:hover {
     border-color: var(--primary);
@@ -2533,7 +2601,9 @@ body.canvas-side-panel-resizing {
   background:
     linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent 120px),
     var(--canvas-float-bg);
-  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.34), 0 4px 14px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 26px 70px rgba(0, 0, 0, 0.34),
+    0 4px 14px rgba(0, 0, 0, 0.22);
   pointer-events: auto;
   backdrop-filter: blur(22px) saturate(1.18);
   -webkit-backdrop-filter: blur(22px) saturate(1.18);
@@ -2645,7 +2715,9 @@ body.canvas-side-panel-resizing {
   background:
     linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent),
     var(--canvas-float-bg);
-  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.28), 0 2px 8px rgba(0, 0, 0, 0.18);
+  box-shadow:
+    0 18px 44px rgba(0, 0, 0, 0.28),
+    0 2px 8px rgba(0, 0, 0, 0.18);
   backdrop-filter: blur(18px) saturate(1.25);
   -webkit-backdrop-filter: blur(18px) saturate(1.25);
 }
@@ -2687,8 +2759,11 @@ body.canvas-side-panel-resizing {
 // dock 内工具激活态：主色高亮
 .canvas-dock-tool-active {
   color: var(--text-strong) !important;
-  background:
-    linear-gradient(135deg, color-mix(in srgb, var(--canvas-accent-cyan) 24%, transparent), color-mix(in srgb, var(--primary) 22%, transparent)) !important;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--canvas-accent-cyan) 24%, transparent),
+    color-mix(in srgb, var(--primary) 22%, transparent)
+  ) !important;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--canvas-accent-cyan) 28%, transparent);
 }
 
@@ -2726,7 +2801,9 @@ body.canvas-side-panel-resizing {
   background:
     linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent),
     var(--canvas-float-bg);
-  box-shadow: 0 22px 56px rgba(0, 0, 0, 0.32), 0 4px 12px rgba(0, 0, 0, 0.2);
+  box-shadow:
+    0 22px 56px rgba(0, 0, 0, 0.32),
+    0 4px 12px rgba(0, 0, 0, 0.2);
   backdrop-filter: blur(20px) saturate(1.25);
   -webkit-backdrop-filter: blur(20px) saturate(1.25);
 }
@@ -2756,7 +2833,9 @@ body.canvas-side-panel-resizing {
   background: var(--bg-sunken);
   color: var(--text);
   cursor: pointer;
-  transition: border-color 0.12s, background 0.12s;
+  transition:
+    border-color 0.12s,
+    background 0.12s;
 
   &:hover {
     border-color: var(--primary);
@@ -2777,11 +2856,21 @@ body.canvas-side-panel-resizing {
 // ─── AI 操作 / 节点类型 配色（Phase 4 视觉统一）─────────────────────────
 // 4 类语义色 + 资源色：image=蓝、text=绿、audio=紫、video=橙、resource=灰
 // 应用范围：add-node 菜单按钮 + 底部 dock 按钮
-.canvas-op-color-image { --canvas-op-tint: #1677ff; }
-.canvas-op-color-text { --canvas-op-tint: #16a34a; }
-.canvas-op-color-audio { --canvas-op-tint: #9333ea; }
-.canvas-op-color-video { --canvas-op-tint: #ea580c; }
-.canvas-op-color-resource { --canvas-op-tint: #64748b; }
+.canvas-op-color-image {
+  --canvas-op-tint: #1677ff;
+}
+.canvas-op-color-text {
+  --canvas-op-tint: #16a34a;
+}
+.canvas-op-color-audio {
+  --canvas-op-tint: #9333ea;
+}
+.canvas-op-color-video {
+  --canvas-op-tint: #ea580c;
+}
+.canvas-op-color-resource {
+  --canvas-op-tint: #64748b;
+}
 
 .canvas-add-node-item {
   &.canvas-op-color-image,
@@ -2789,7 +2878,9 @@ body.canvas-side-panel-resizing {
   &.canvas-op-color-audio,
   &.canvas-op-color-video,
   &.canvas-op-color-resource {
-    .canvas-add-node-icon { color: var(--canvas-op-tint); }
+    .canvas-add-node-icon {
+      color: var(--canvas-op-tint);
+    }
     &:hover {
       border-color: var(--canvas-op-tint);
       background: color-mix(in srgb, var(--canvas-op-tint) 8%, var(--bg-sunken));
@@ -3436,7 +3527,9 @@ body.canvas-side-panel-resizing {
   background: var(--panel);
   transition: border-color 0.12s;
 
-  &:hover { border-color: var(--primary); }
+  &:hover {
+    border-color: var(--primary);
+  }
 }
 
 .canvas-film-asset-card-thumb {
@@ -3521,7 +3614,9 @@ body.canvas-side-panel-resizing {
   font-size: 12px;
   color: var(--text-muted);
 
-  > span { font-weight: 600; }
+  > span {
+    font-weight: 600;
+  }
 }
 
 .canvas-film-editor-field-row {
@@ -3640,7 +3735,10 @@ body.canvas-side-panel-resizing {
   justify-content: space-between;
   margin-bottom: 12px;
 
-  strong { font-size: 14px; color: var(--text); }
+  strong {
+    font-size: 14px;
+    color: var(--text);
+  }
 }
 
 .canvas-film-segments-desc {
@@ -3722,7 +3820,10 @@ body.canvas-side-panel-resizing {
   gap: 4px;
   margin-top: 6px;
 
-  .ant-tag { margin: 0; font-size: 10px !important; }
+  .ant-tag {
+    margin: 0;
+    font-size: 10px !important;
+  }
 }
 
 .canvas-film-segment-actions {
@@ -3801,8 +3902,15 @@ body.canvas-side-panel-resizing {
   text-align: center;
   gap: 8px;
 
-  p { margin: 0; font-size: 13px; }
-  .canvas-agent-empty-hint { font-size: 11px; max-width: 360px; line-height: 1.5; }
+  p {
+    margin: 0;
+    font-size: 13px;
+  }
+  .canvas-agent-empty-hint {
+    font-size: 11px;
+    max-width: 360px;
+    line-height: 1.5;
+  }
 }
 
 .canvas-agent-message {
@@ -3851,8 +3959,14 @@ body.canvas-side-panel-resizing {
 }
 
 @keyframes canvas-agent-blink {
-  0%, 50% { opacity: 1; }
-  51%, 100% { opacity: 0; }
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
 }
 
 .canvas-agent-input-area {
@@ -3880,11 +3994,14 @@ body.canvas-side-panel-resizing {
     outline: none;
     border-color: var(--primary);
   }
-  &::placeholder { color: var(--text-muted); }
+  &::placeholder {
+    color: var(--text-muted);
+  }
 }
 
 // dock 里 agent 按钮（仅作为兼容选择器保留；样式继承 dock 默认黑白）
-.canvas-dock-agent-btn {}
+.canvas-dock-agent-btn {
+}
 
 // ─── 项目资源中心 v2：多图多描述 / 标签 / 搜索 / 排序 / 引用可视化 ──────
 
@@ -3976,7 +4093,11 @@ body.canvas-side-panel-resizing {
   overflow: hidden;
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--canvas-film-cyan) 12%, transparent), transparent),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--canvas-film-cyan) 12%, transparent),
+      transparent
+    ),
     var(--bg-sunken);
   display: flex;
   align-items: center;
@@ -3998,7 +4119,9 @@ body.canvas-side-panel-resizing {
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
 }
-.canvas-film-asset-card-refcount { left: 4px; }
+.canvas-film-asset-card-refcount {
+  left: 4px;
+}
 .canvas-film-asset-card-usage {
   right: 4px;
   background: color-mix(in srgb, var(--primary) 82%, rgba(0, 0, 0, 0.48));
@@ -4037,7 +4160,9 @@ body.canvas-side-panel-resizing {
   opacity: 0.85;
   margin-bottom: 4px;
 }
-.canvas-film-editor-attributes { margin-top: 4px; }
+.canvas-film-editor-attributes {
+  margin-top: 4px;
+}
 .canvas-film-editor-attr-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -4142,9 +4267,15 @@ body.canvas-side-panel-resizing {
   border-radius: var(--r-md);
   background: var(--canvas-film-card-strong);
 }
-.canvas-film-usage-groupname { color: var(--text-muted); }
-.canvas-film-usage-separator { color: var(--text-muted); }
-.canvas-film-usage-segmenttitle { color: var(--text); }
+.canvas-film-usage-groupname {
+  color: var(--text-muted);
+}
+.canvas-film-usage-separator {
+  color: var(--text-muted);
+}
+.canvas-film-usage-segmenttitle {
+  color: var(--text);
+}
 .canvas-film-usage-nodetype {
   margin-left: auto;
   font-size: 10px !important;
@@ -4177,7 +4308,11 @@ body.canvas-side-panel-resizing {
   border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
   border-radius: var(--r-lg);
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--canvas-film-cyan) 10%, transparent), transparent),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--canvas-film-cyan) 10%, transparent),
+      transparent
+    ),
     var(--canvas-film-card);
 }
 .canvas-film-save-node-preview {
@@ -4197,10 +4332,23 @@ body.canvas-side-panel-resizing {
   align-items: center;
   justify-content: center;
 }
-.canvas-film-save-node-thumb-fallback { color: var(--text-muted); }
-.canvas-film-save-node-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-.canvas-film-save-node-title { font-size: 14px; font-weight: 600; }
-.canvas-film-save-node-type { font-size: 11px; color: var(--text-muted); }
+.canvas-film-save-node-thumb-fallback {
+  color: var(--text-muted);
+}
+.canvas-film-save-node-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.canvas-film-save-node-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+.canvas-film-save-node-type {
+  font-size: 11px;
+  color: var(--text-muted);
+}
 .canvas-film-save-field {
   display: flex;
   flex-direction: column;
@@ -4252,7 +4400,9 @@ body.canvas-side-panel-resizing {
   background:
     linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent 120px),
     var(--canvas-float-bg);
-  box-shadow: 0 26px 70px rgba(0, 0, 0, 0.34), 0 4px 14px rgba(0, 0, 0, 0.22);
+  box-shadow:
+    0 26px 70px rgba(0, 0, 0, 0.34),
+    0 4px 14px rgba(0, 0, 0, 0.22);
   backdrop-filter: blur(22px) saturate(1.18);
   -webkit-backdrop-filter: blur(22px) saturate(1.18);
 }
@@ -4351,7 +4501,11 @@ body.canvas-side-panel-resizing {
   height: 100%;
   object-fit: contain;
   background:
-    linear-gradient(135deg, color-mix(in srgb, var(--canvas-accent-cyan) 8%, transparent), transparent),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--canvas-accent-cyan) 8%, transparent),
+      transparent
+    ),
     var(--bg-sunken);
 }
 
@@ -4407,7 +4561,9 @@ body.canvas-side-panel-resizing {
   font-size: 10px;
   color: var(--text-muted);
 
-  > span { font-weight: 600; }
+  > span {
+    font-weight: 600;
+  }
 
   .ant-input,
   .ant-select {
@@ -4426,6 +4582,12 @@ body.canvas-side-panel-resizing {
   font-size: 11px;
   line-height: 1.45;
   color: var(--text-muted);
+}
+
+.canvas-operation-panel-frame-roles {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .canvas-operation-panel-custom-params {

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -195,18 +195,10 @@ function positionNodeInViewport(
 
   return {
     x: Math.round(
-      clampPosition(
-        centerX - size.width / 2,
-        visibleLeft + 24,
-        visibleRight - size.width - 24,
-      ),
+      clampPosition(centerX - size.width / 2, visibleLeft + 24, visibleRight - size.width - 24),
     ),
     y: Math.round(
-      clampPosition(
-        centerY - size.height / 2,
-        visibleTop + 24,
-        visibleBottom - size.height - 24,
-      ),
+      clampPosition(centerY - size.height / 2, visibleTop + 24, visibleBottom - size.height - 24),
     ),
   }
 }
@@ -404,10 +396,15 @@ function expandCanvasInputNodes(selectedNodes: CanvasNode[], allNodes: CanvasNod
   return result
 }
 
-function resolveCanvasInputNodes(nodeIds: string[] | undefined, allNodes: CanvasNode[]): CanvasNode[] {
+function resolveCanvasInputNodes(
+  nodeIds: string[] | undefined,
+  allNodes: CanvasNode[],
+): CanvasNode[] {
   if (!nodeIds || nodeIds.length === 0) return []
   const byId = new Map(allNodes.map((node) => [node.id, node]))
-  const orderedNodes = nodeIds.map((id) => byId.get(id)).filter((node): node is CanvasNode => Boolean(node))
+  const orderedNodes = nodeIds
+    .map((id) => byId.get(id))
+    .filter((node): node is CanvasNode => Boolean(node))
   return expandCanvasInputNodes(orderedNodes, allNodes)
 }
 
@@ -449,13 +446,19 @@ function buildScriptBreakdownDraft(asset: CanvasAsset): ScriptBreakdownDraft {
   let currentGroupName = `${title} - 自动分镜`
 
   const pushScene = (name: string, description: string) => {
-    const normalized = name.replace(/^#+\s*/, '').trim().slice(0, 40)
+    const normalized = name
+      .replace(/^#+\s*/, '')
+      .trim()
+      .slice(0, 40)
     if (!normalized || sceneMap.has(normalized)) return
     sceneMap.set(normalized, { name: normalized, description })
   }
 
   const pushCharacter = (name: string, line: string) => {
-    const normalized = name.trim().replace(/[（）()【】\[\]\s]/g, '').slice(0, 16)
+    const normalized = name
+      .trim()
+      .replace(/[（）()【】\[\]\s]/g, '')
+      .slice(0, 16)
     if (!normalized || normalized.length < 2 || characterMap.has(normalized)) return
     characterMap.set(normalized, {
       name: normalized,
@@ -504,23 +507,27 @@ function buildScriptBreakdownDraft(asset: CanvasAsset): ScriptBreakdownDraft {
   }
 
   if (sceneMap.size === 0) {
-    pushScene(`${title} - 默认场景`, '根据剧本文本自动生成的默认场景，请后续补充地点、光线和美术风格。')
+    pushScene(
+      `${title} - 默认场景`,
+      '根据剧本文本自动生成的默认场景，请后续补充地点、光线和美术风格。',
+    )
   }
 
   return {
     characters: [...characterMap.values()].slice(0, 16),
     scenes: [...sceneMap.values()].slice(0, 12),
-    segments: segments.length > 0
-      ? segments
-      : [
-          {
-            groupName: currentGroupName,
-            title: '镜1 - 剧情开场',
-            description: text.slice(0, 160) || '请补充分镜画面描述。',
-            characterNames: [],
-            shotPrompt: '电影感开场镜头，建立场景氛围。',
-          },
-        ],
+    segments:
+      segments.length > 0
+        ? segments
+        : [
+            {
+              groupName: currentGroupName,
+              title: '镜1 - 剧情开场',
+              description: text.slice(0, 160) || '请补充分镜画面描述。',
+              characterNames: [],
+              shotPrompt: '电影感开场镜头，建立场景氛围。',
+            },
+          ],
   }
 }
 
@@ -554,11 +561,19 @@ function buildShotSegmentVideoPrompt(input: {
   const characterText = characters
     .map((asset) => {
       const refs = readReferences(asset.metadata)
-      const refText = refs.map((ref) => ref.description).filter(Boolean).join('；')
+      const refText = refs
+        .map((ref) => ref.description)
+        .filter(Boolean)
+        .join('；')
       return `${asset.title ?? '角色'}：${asset.contentText ?? ''}${refText ? `；参考：${refText}` : ''}`
     })
     .join('\n')
-  const sceneRefs = scene ? readReferences(scene.metadata).map((ref) => ref.description).filter(Boolean).join('；') : ''
+  const sceneRefs = scene
+    ? readReferences(scene.metadata)
+        .map((ref) => ref.description)
+        .filter(Boolean)
+        .join('；')
+    : ''
   return [
     `请生成一段影视分镜视频。`,
     `分组：${group.name}`,
@@ -566,11 +581,15 @@ function buildShotSegmentVideoPrompt(input: {
     segment.description ? `画面/动作：${segment.description}` : '',
     segment.dialogue ? `对白：${segment.dialogue}` : '',
     segment.narration ? `旁白：${segment.narration}` : '',
-    scene ? `场景：${scene.title ?? ''} ${scene.contentText ?? ''}${sceneRefs ? `；参考：${sceneRefs}` : ''}` : '',
+    scene
+      ? `场景：${scene.title ?? ''} ${scene.contentText ?? ''}${sceneRefs ? `；参考：${sceneRefs}` : ''}`
+      : '',
     characterText ? `角色设定：\n${characterText}` : '',
     segment.shotPrompt ? `镜头语言：${segment.shotPrompt}` : '',
     '生成要求：动作自然，角色一致，场景连贯，电影感光影，避免字幕、水印和畸变。',
-  ].filter(Boolean).join('\n\n')
+  ]
+    .filter(Boolean)
+    .join('\n\n')
 }
 
 type PromptLibraryEntry = {
@@ -708,7 +727,10 @@ export function CanvasWorkspaceView({
   const [inlineAiOpen, setInlineAiOpen] = useState(false)
   const [saveToLibraryNodeId, setSaveToLibraryNodeId] = useState<string | null>(null)
   const saveToLibraryNode = useMemo(
-    () => (saveToLibraryNodeId ? snapshot?.nodes.find((n) => n.id === saveToLibraryNodeId) ?? null : null),
+    () =>
+      saveToLibraryNodeId
+        ? (snapshot?.nodes.find((n) => n.id === saveToLibraryNodeId) ?? null)
+        : null,
     [saveToLibraryNodeId, snapshot],
   )
   const [sidePanelTab, setSidePanelTab] = useState<'details' | 'project'>('details')
@@ -989,23 +1011,26 @@ export function CanvasWorkspaceView({
     )
   }, [])
 
-  const handleNodeSelectIntent = useCallback((nodeId: string) => {
-    const node = snapshot?.nodes.find((item) => item.id === nodeId)
-    if (!node) return
+  const handleNodeSelectIntent = useCallback(
+    (nodeId: string) => {
+      const node = snapshot?.nodes.find((item) => item.id === nodeId)
+      if (!node) return
 
-    if (isOperationNode(node)) {
-      closeCanvasFloatPanels('operation')
-      setActiveOperationPanelNodeId(nodeId)
-      return
-    }
+      if (isOperationNode(node)) {
+        closeCanvasFloatPanels('operation')
+        setActiveOperationPanelNodeId(nodeId)
+        return
+      }
 
-    if (node.type === 'text' || node.type === 'prompt') {
-      closeCanvasFloatPanels('node-edit')
-      setEditingNodeId(nodeId)
-      return
-    }
-    closeCanvasFloatPanels()
-  }, [closeCanvasFloatPanels, snapshot?.nodes])
+      if (node.type === 'text' || node.type === 'prompt') {
+        closeCanvasFloatPanels('node-edit')
+        setEditingNodeId(nodeId)
+        return
+      }
+      closeCanvasFloatPanels()
+    },
+    [closeCanvasFloatPanels, snapshot?.nodes],
+  )
 
   const handleCanvasViewportChange = useCallback((viewport: CanvasStageViewport) => {
     canvasViewportRef.current = viewport
@@ -1092,11 +1117,14 @@ export function CanvasWorkspaceView({
     [closeCanvasFloatPanels, selectedNodeIds],
   )
 
-  const handleEditNode = useCallback((nodeId: string) => {
-    closeCanvasFloatPanels('node-edit')
-    setSelectedNodeIds([nodeId])
-    setEditingNodeId(nodeId)
-  }, [closeCanvasFloatPanels])
+  const handleEditNode = useCallback(
+    (nodeId: string) => {
+      closeCanvasFloatPanels('node-edit')
+      setSelectedNodeIds([nodeId])
+      setEditingNodeId(nodeId)
+    },
+    [closeCanvasFloatPanels],
+  )
 
   const handleSaveNodeEdit = useCallback(
     async (node: CanvasNode, patch: Partial<CanvasNode>, data: CanvasNode['data']) => {
@@ -1388,14 +1416,10 @@ export function CanvasWorkspaceView({
       }
       const groupPosition = preferredPosition
         ? { x: Math.round(preferredPosition.x), y: Math.round(preferredPosition.y) }
-        : positionNodeInViewport(
-            canvasViewportRef.current,
-            groupSize,
-            {
-              x: 220,
-              y: 180,
-            },
-          )
+        : positionNodeInViewport(canvasViewportRef.current, groupSize, {
+            x: 220,
+            y: 180,
+          })
       const placedImages = layoutGroupedImages(preparedImages, groupPosition)
       const createdNodeIds: string[] = []
       for (const image of placedImages) {
@@ -1495,7 +1519,9 @@ export function CanvasWorkspaceView({
     })
   }
 
-  const handleBreakdownScriptAsset: NonNullable<FilmCenterHandlers['onBreakdownScriptAsset']> = async (asset) => {
+  const handleBreakdownScriptAsset: NonNullable<
+    FilmCenterHandlers['onBreakdownScriptAsset']
+  > = async (asset) => {
     const scriptText = asset.contentText?.trim() ?? ''
     if (!scriptText) {
       message.warning('请先补充剧本内容，再执行拆解')
@@ -1537,16 +1563,20 @@ export function CanvasWorkspaceView({
       }
 
       const createdCharacters = await Promise.all(
-        draft.characters.map((character) => ensureAsset('character', {
-          name: character.name,
-          text: character.description,
-        })),
+        draft.characters.map((character) =>
+          ensureAsset('character', {
+            name: character.name,
+            text: character.description,
+          }),
+        ),
       )
       const createdScenes = await Promise.all(
-        draft.scenes.map((scene) => ensureAsset('scene', {
-          name: scene.name,
-          text: scene.description,
-        })),
+        draft.scenes.map((scene) =>
+          ensureAsset('scene', {
+            name: scene.name,
+            text: scene.description,
+          }),
+        ),
       )
       const characterIdByName = new Map(
         createdCharacters.map((item) => [(item.title ?? '').trim().toLowerCase(), item.id]),
@@ -1601,7 +1631,9 @@ export function CanvasWorkspaceView({
     }
   }
 
-  const handleGenerateAssetReference: NonNullable<FilmCenterHandlers['onGenerateAssetReference']> = (asset) => {
+  const handleGenerateAssetReference: NonNullable<
+    FilmCenterHandlers['onGenerateAssetReference']
+  > = (asset) => {
     void handleCreateTask({
       operation: 'text_to_image',
       prompt: buildFilmAssetReferencePrompt(asset),
@@ -1610,7 +1642,9 @@ export function CanvasWorkspaceView({
     message.info('已发起参考图生成任务，结果会出现在画布上')
   }
 
-  const handleGenerateSegmentVideo: NonNullable<FilmCenterHandlers['onGenerateSegmentVideo']> = (input) => {
+  const handleGenerateSegmentVideo: NonNullable<FilmCenterHandlers['onGenerateSegmentVideo']> = (
+    input,
+  ) => {
     void handleCreateTask({
       operation: 'text_to_video',
       prompt: buildShotSegmentVideoPrompt(input),
@@ -1817,25 +1851,41 @@ export function CanvasWorkspaceView({
           )}
           {!leftPanelCollapsed && (
             <div className="canvas-left-workbench-footer">
-              <button type="button" className="canvas-left-utility-btn" onClick={() => {
-                closeCanvasFloatPanels()
-                setHistoryOpen(true)
-              }}>
+              <button
+                type="button"
+                className="canvas-left-utility-btn"
+                onClick={() => {
+                  closeCanvasFloatPanels()
+                  setHistoryOpen(true)
+                }}
+              >
                 <Icons.Clock size={16} />
                 <span>历史</span>
               </button>
-              <button type="button" className="canvas-left-utility-btn" onClick={() => void handleOpenProjectFolder()}>
+              <button
+                type="button"
+                className="canvas-left-utility-btn"
+                onClick={() => void handleOpenProjectFolder()}
+              >
                 <Icons.Folder size={16} />
                 <span>目录</span>
               </button>
-              <button type="button" className="canvas-left-utility-btn" onClick={() => {
-                closeCanvasFloatPanels()
-                setTemplateOpen(true)
-              }}>
+              <button
+                type="button"
+                className="canvas-left-utility-btn"
+                onClick={() => {
+                  closeCanvasFloatPanels()
+                  setTemplateOpen(true)
+                }}
+              >
                 <Icons.Layers size={16} />
                 <span>模板</span>
               </button>
-              <button type="button" className="canvas-left-utility-btn" onClick={() => message.info('帮助与快捷键')}>
+              <button
+                type="button"
+                className="canvas-left-utility-btn"
+                onClick={() => message.info('帮助与快捷键')}
+              >
                 <Icons.HelpCircle size={16} />
                 <span>帮助</span>
               </button>
@@ -1844,216 +1894,224 @@ export function CanvasWorkspaceView({
         </aside>
 
         <div className="canvas-stage-area">
-        {toolSwitchHint && (
-          <div
-            key={toolSwitchHint.nonce}
-            className={`canvas-tool-switch-hint canvas-tool-switch-hint-${toolSwitchHint.tool}`}
-            role="status"
-            aria-live="polite"
-          >
-            <span className="canvas-tool-switch-key">Tab</span>
-            <span>已切换为 {toolLabel(toolSwitchHint.tool)}</span>
-          </div>
-        )}
-        <CanvasStage
-          snapshot={snapshot}
-          activeTool={activeTool === 'pan' ? 'pan' : 'select'}
-          selectedNodeIds={selectedNodeIds}
-          onSelectionChange={handleSelectionChange}
-          onNodesPersist={(nodes) => void updateNodes(nodes)}
-          onConnectNodes={(input) => void connectNodes(input)}
-          onDuplicateNode={handleDuplicateNode}
-          onDeleteNode={handleDeleteNode}
-          onToggleLockNode={handleToggleLockNode}
-          onBringNodeToFront={handleBringNodeToFront}
-          onCreateGroupFromSelection={handleCreateGroup}
-          onAddSelectionToGroup={handleAddSelectionToGroup}
-          onRemoveNodeFromGroup={(nodeId) => handleRemoveFromGroup([nodeId])}
-          onDissolveGroup={handleDissolveGroup}
-          onOpenAiComposer={handleOpenInlineAi}
-          onEditNode={handleEditNode}
-          onSaveNodeToLibrary={(nodeId) => setSaveToLibraryNodeId(nodeId)}
-          onCreateOperationChild={(parentId, operation) => {
-            const parent = snapshot.nodes.find((n) => n.id === parentId)
-            if (!parent) return
-            void createOperationNode({
-              boardId: snapshot.board.id,
-              operation,
-              inputNodeIds: [parentId],
-              x: parent.x + parent.width + 60,
-              y: parent.y,
-            })
-          }}
-          onAddTextAtPosition={(position) => void addText(position)}
-          onAddImageAtPosition={uploadFirstImage}
-          onAddPromptAtPosition={(position) => void addText(position)}
-          onInsertAssetFromPane={() => setLeftPanelTab('assets')}
-          onCreateBoardFromPane={() => void createBoard()}
-          onNodeSelectIntent={handleNodeSelectIntent}
-          onViewportChange={handleCanvasViewportChange}
-        />
-        <CanvasBottomDock
-          activeTool={activeTool}
-          onToolChange={handleToolChange}
-          onAddNodeItem={handleAddNodeItem}
-          onOpenAddMenu={() => closeCanvasFloatPanels()}
-          onOpenAiComposer={() => handleOpenInlineAi()}
-          onOpenFilmCenter={() => {
-            closeCanvasFloatPanels('film-center')
-            setFilmCenterOpen(true)
-          }}
-          onOpenAgent={() => {
-            closeCanvasFloatPanels('agent')
-            setAgentOpen(true)
-          }}
-          onToggleGrid={handleToggleGrid}
-          gridVisible={snapshot.board.settings.grid !== false}
-          collapsed={bottomToolbarCollapsed}
-          onToggleCollapsed={() => setBottomToolbarCollapsed(!bottomToolbarCollapsed)}
-        />
-        <CanvasInlineAiComposer
-          open={inlineAiOpen}
-          selectedNodes={aiInputNodes}
-          allNodes={snapshot.nodes}
-          {...(snapshot.project.settings ? { projectSettings: snapshot.project.settings } : {})}
-          onUploadImage={() => uploadFirstImage()}
-          onClose={() => setInlineAiOpen(false)}
-          onCreateTask={(input) => {
-            void handleCreateTask(input)
-            setInlineAiOpen(false)
-          }}
-        />
-        {(() => {
-          const opNode = activeOperationPanelNodeId
-            ? snapshot.nodes.find((n) => n.id === activeOperationPanelNodeId && isOperationNode(n))
-            : null
-          if (!opNode) return null
-          const opTask = opNode.taskId ? snapshot.tasks.find((t) => t.id === opNode.taskId) : null
-          return (
-            <CanvasOperationPanel
-              node={opNode}
-              snapshot={snapshot}
-              {...(opTask ? { task: opTask } : {})}
-              onClose={() => {
-                setActiveOperationPanelNodeId(null)
-                setSelectedNodeIds([])
-              }}
-              onRun={(params) => {
-                void (async () => {
-                  if (!(await ensureCanvasWorkflowLogin())) return
-                  const taskInputNodes = resolveCanvasInputNodes(
-                    params.inputNodeIds,
-                    snapshot.nodes,
-                  )
-                  const inputFiles = await buildCloudTaskInputFiles(
-                    taskInputNodes,
-                    params.inputTransport,
-                  )
-                  const mergedPrompt = mergePromptWithNodeContext(params.prompt, taskInputNodes)
-                  const effectivePrompt =
-                    mergedPrompt ||
-                    (inputFiles.length > 0
-                      ? fallbackPromptForOperation((opNode.data.operation ?? opNode.type) as CanvasOperationType)
-                      : '')
-                  await runOperationNode(opNode.id, {
-                    prompt: effectivePrompt,
-                    ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
-                    inputNodeIds: taskInputNodes.map((item) => item.id),
-                    inputAssetIds: taskInputNodes
-                      .map((item) => item.assetId)
-                      .filter((id): id is string => Boolean(id)),
-                    ...(inputFiles.length > 0 ? { inputFiles } : {}),
-                    ...(params.providerProfileId ? { providerProfileId: params.providerProfileId } : {}),
-                    ...(params.manifestId ? { manifestId: params.manifestId } : {}),
-                    ...(params.modelId ? { modelId: params.modelId } : {}),
-                    ...(params.modelParams ? { modelParams: params.modelParams } : {}),
-                  })
-                })()
-              }}
-              onRetry={() => void retryOperationNode(opNode.id)}
-            />
-          )
-        })()}
-        <CanvasAgentModal
-          open={agentOpen}
-          onClose={() => setAgentOpen(false)}
-          snapshot={snapshot}
-          workspace={{
-            createTextNode,
-            createImageNode,
-            uploadImageAsset,
-            createGroupNode,
-            dissolveGroupNode,
-            addNodesToGroup,
-            removeNodesFromGroup,
-            deleteNodes,
-            duplicateNodes,
-            patchNodes,
-            updateNodeData,
-            connectNodes,
-            createBoard,
-            renameBoard,
-            deleteBoard,
-            duplicateBoard,
-            switchBoard,
-            copyNodesToBoard,
-            insertAsset,
-            createFilmAsset,
-            updateFilmAsset,
-            deleteFilmAsset,
-            createShotGroup,
-            updateShotGroup,
-            deleteShotGroup,
-            createShotSegment,
-            updateShotSegment,
-            deleteShotSegment,
-            createOperationNode,
-            retryOperationNode,
-            runOperationNode,
-            cancelTask,
-            updateProjectSettings,
-            refresh,
-          }}
-        />
-        <CanvasNodeEditModal
-          node={editingNode}
-          open={Boolean(editingNodeId)}
-          assets={snapshot.assets}
-          onClose={() => setEditingNodeId(null)}
-          onSave={handleSaveNodeEdit}
-          onCreatePromptTask={(input) => void handleCreateTask({ ...input, inputNodeIds: [] })}
-        />
-        <CanvasFilmAssetCenter
-          open={filmCenterOpen}
-          onClose={() => setFilmCenterOpen(false)}
-          snapshot={snapshot}
-          onUploadImage={uploadImageAsset}
-          handlers={{
-            createFilmAsset,
-            updateFilmAsset,
-            deleteFilmAsset,
-            getFilmAssetUsage,
-            onOptimizeAsset: (asset) => {
-              // AI 优化：用 text_rewrite 触发平台 agent 优化资产文本
-              void handleCreateTask({
-                operation: 'text_rewrite',
-                prompt: asset.contentText ?? asset.title ?? '请优化以下内容，使其更专业、更精炼。',
-                inputNodeIds: [],
+          {toolSwitchHint && (
+            <div
+              key={toolSwitchHint.nonce}
+              className={`canvas-tool-switch-hint canvas-tool-switch-hint-${toolSwitchHint.tool}`}
+              role="status"
+              aria-live="polite"
+            >
+              <span className="canvas-tool-switch-key">Tab</span>
+              <span>已切换为 {toolLabel(toolSwitchHint.tool)}</span>
+            </div>
+          )}
+          <CanvasStage
+            snapshot={snapshot}
+            activeTool={activeTool === 'pan' ? 'pan' : 'select'}
+            selectedNodeIds={selectedNodeIds}
+            onSelectionChange={handleSelectionChange}
+            onNodesPersist={(nodes) => void updateNodes(nodes)}
+            onConnectNodes={(input) => void connectNodes(input)}
+            onDuplicateNode={handleDuplicateNode}
+            onDeleteNode={handleDeleteNode}
+            onToggleLockNode={handleToggleLockNode}
+            onBringNodeToFront={handleBringNodeToFront}
+            onCreateGroupFromSelection={handleCreateGroup}
+            onAddSelectionToGroup={handleAddSelectionToGroup}
+            onRemoveNodeFromGroup={(nodeId) => handleRemoveFromGroup([nodeId])}
+            onDissolveGroup={handleDissolveGroup}
+            onOpenAiComposer={handleOpenInlineAi}
+            onEditNode={handleEditNode}
+            onSaveNodeToLibrary={(nodeId) => setSaveToLibraryNodeId(nodeId)}
+            onCreateOperationChild={(parentId, operation) => {
+              const parent = snapshot.nodes.find((n) => n.id === parentId)
+              if (!parent) return
+              void createOperationNode({
+                boardId: snapshot.board.id,
+                operation,
+                inputNodeIds: [parentId],
+                x: parent.x + parent.width + 60,
+                y: parent.y,
               })
-              message.info('已发起 AI 优化任务，结果将生成在画布上')
-            },
-            onBreakdownScriptAsset: handleBreakdownScriptAsset,
-            onGenerateAssetReference: handleGenerateAssetReference,
-            onGenerateSegmentVideo: handleGenerateSegmentVideo,
-            onInsertAssetToCanvas: (assetId) => void handleInsertAsset(assetId),
-            createShotGroup,
-            updateShotGroup,
-            deleteShotGroup,
-            createShotSegment,
-            updateShotSegment,
-            deleteShotSegment,
-          }}
-        />
+            }}
+            onAddTextAtPosition={(position) => void addText(position)}
+            onAddImageAtPosition={uploadFirstImage}
+            onAddPromptAtPosition={(position) => void addText(position)}
+            onInsertAssetFromPane={() => setLeftPanelTab('assets')}
+            onCreateBoardFromPane={() => void createBoard()}
+            onNodeSelectIntent={handleNodeSelectIntent}
+            onViewportChange={handleCanvasViewportChange}
+          />
+          <CanvasBottomDock
+            activeTool={activeTool}
+            onToolChange={handleToolChange}
+            onAddNodeItem={handleAddNodeItem}
+            onOpenAddMenu={() => closeCanvasFloatPanels()}
+            onOpenAiComposer={() => handleOpenInlineAi()}
+            onOpenFilmCenter={() => {
+              closeCanvasFloatPanels('film-center')
+              setFilmCenterOpen(true)
+            }}
+            onOpenAgent={() => {
+              closeCanvasFloatPanels('agent')
+              setAgentOpen(true)
+            }}
+            onToggleGrid={handleToggleGrid}
+            gridVisible={snapshot.board.settings.grid !== false}
+            collapsed={bottomToolbarCollapsed}
+            onToggleCollapsed={() => setBottomToolbarCollapsed(!bottomToolbarCollapsed)}
+          />
+          <CanvasInlineAiComposer
+            open={inlineAiOpen}
+            selectedNodes={aiInputNodes}
+            allNodes={snapshot.nodes}
+            {...(snapshot.project.settings ? { projectSettings: snapshot.project.settings } : {})}
+            onUploadImage={() => uploadFirstImage()}
+            onClose={() => setInlineAiOpen(false)}
+            onCreateTask={(input) => {
+              void handleCreateTask(input)
+              setInlineAiOpen(false)
+            }}
+          />
+          {(() => {
+            const opNode = activeOperationPanelNodeId
+              ? snapshot.nodes.find(
+                  (n) => n.id === activeOperationPanelNodeId && isOperationNode(n),
+                )
+              : null
+            if (!opNode) return null
+            const opTask = opNode.taskId ? snapshot.tasks.find((t) => t.id === opNode.taskId) : null
+            return (
+              <CanvasOperationPanel
+                node={opNode}
+                snapshot={snapshot}
+                {...(opTask ? { task: opTask } : {})}
+                onClose={() => {
+                  setActiveOperationPanelNodeId(null)
+                  setSelectedNodeIds([])
+                }}
+                onRun={(params) => {
+                  void (async () => {
+                    if (!(await ensureCanvasWorkflowLogin())) return
+                    const taskInputNodes = resolveCanvasInputNodes(
+                      params.inputNodeIds,
+                      snapshot.nodes,
+                    )
+                    const inputFiles = await buildCloudTaskInputFiles(
+                      taskInputNodes,
+                      params.inputTransport,
+                      params.inputRoles,
+                    )
+                    const mergedPrompt = mergePromptWithNodeContext(params.prompt, taskInputNodes)
+                    const effectivePrompt =
+                      mergedPrompt ||
+                      (inputFiles.length > 0
+                        ? fallbackPromptForOperation(
+                            (opNode.data.operation ?? opNode.type) as CanvasOperationType,
+                          )
+                        : '')
+                    await runOperationNode(opNode.id, {
+                      prompt: effectivePrompt,
+                      ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
+                      inputNodeIds: taskInputNodes.map((item) => item.id),
+                      inputAssetIds: taskInputNodes
+                        .map((item) => item.assetId)
+                        .filter((id): id is string => Boolean(id)),
+                      ...(inputFiles.length > 0 ? { inputFiles } : {}),
+                      ...(params.providerProfileId
+                        ? { providerProfileId: params.providerProfileId }
+                        : {}),
+                      ...(params.manifestId ? { manifestId: params.manifestId } : {}),
+                      ...(params.modelId ? { modelId: params.modelId } : {}),
+                      ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                    })
+                  })()
+                }}
+                onRetry={() => void retryOperationNode(opNode.id)}
+              />
+            )
+          })()}
+          <CanvasAgentModal
+            open={agentOpen}
+            onClose={() => setAgentOpen(false)}
+            snapshot={snapshot}
+            workspace={{
+              createTextNode,
+              createImageNode,
+              uploadImageAsset,
+              createGroupNode,
+              dissolveGroupNode,
+              addNodesToGroup,
+              removeNodesFromGroup,
+              deleteNodes,
+              duplicateNodes,
+              patchNodes,
+              updateNodeData,
+              connectNodes,
+              createBoard,
+              renameBoard,
+              deleteBoard,
+              duplicateBoard,
+              switchBoard,
+              copyNodesToBoard,
+              insertAsset,
+              createFilmAsset,
+              updateFilmAsset,
+              deleteFilmAsset,
+              createShotGroup,
+              updateShotGroup,
+              deleteShotGroup,
+              createShotSegment,
+              updateShotSegment,
+              deleteShotSegment,
+              createOperationNode,
+              retryOperationNode,
+              runOperationNode,
+              cancelTask,
+              updateProjectSettings,
+              refresh,
+            }}
+          />
+          <CanvasNodeEditModal
+            node={editingNode}
+            open={Boolean(editingNodeId)}
+            assets={snapshot.assets}
+            onClose={() => setEditingNodeId(null)}
+            onSave={handleSaveNodeEdit}
+            onCreatePromptTask={(input) => void handleCreateTask({ ...input, inputNodeIds: [] })}
+          />
+          <CanvasFilmAssetCenter
+            open={filmCenterOpen}
+            onClose={() => setFilmCenterOpen(false)}
+            snapshot={snapshot}
+            onUploadImage={uploadImageAsset}
+            handlers={{
+              createFilmAsset,
+              updateFilmAsset,
+              deleteFilmAsset,
+              getFilmAssetUsage,
+              onOptimizeAsset: (asset) => {
+                // AI 优化：用 text_rewrite 触发平台 agent 优化资产文本
+                void handleCreateTask({
+                  operation: 'text_rewrite',
+                  prompt:
+                    asset.contentText ?? asset.title ?? '请优化以下内容，使其更专业、更精炼。',
+                  inputNodeIds: [],
+                })
+                message.info('已发起 AI 优化任务，结果将生成在画布上')
+              },
+              onBreakdownScriptAsset: handleBreakdownScriptAsset,
+              onGenerateAssetReference: handleGenerateAssetReference,
+              onGenerateSegmentVideo: handleGenerateSegmentVideo,
+              onInsertAssetToCanvas: (assetId) => void handleInsertAsset(assetId),
+              createShotGroup,
+              updateShotGroup,
+              deleteShotGroup,
+              createShotSegment,
+              updateShotSegment,
+              deleteShotSegment,
+            }}
+          />
         </div>
         <aside className="canvas-side-panel" style={{ width: sidePanelWidth }}>
           <div
@@ -2366,22 +2424,26 @@ function CanvasNodeEditModal({
       })
       .filter((entry) => entry.text.trim())
     const cameraEntries = CAMERA_PROMPT_LIBRARY.flatMap((group) =>
-      group.items.map((item): PromptLibraryEntry => ({
-        id: `camera:${item.id}`,
-        source: 'camera',
-        group: group.label,
-        label: item.label,
-        text: item.promptFragment,
-      })),
+      group.items.map(
+        (item): PromptLibraryEntry => ({
+          id: `camera:${item.id}`,
+          source: 'camera',
+          group: group.label,
+          label: item.label,
+          text: item.promptFragment,
+        }),
+      ),
     )
     const performanceEntries = PERFORMANCE_PROMPT_LIBRARY.flatMap((group) =>
-      group.items.map((item): PromptLibraryEntry => ({
-        id: `performance:${item.id}`,
-        source: 'performance',
-        group: group.label,
-        label: item.label,
-        text: item.promptFragment,
-      })),
+      group.items.map(
+        (item): PromptLibraryEntry => ({
+          id: `performance:${item.id}`,
+          source: 'performance',
+          group: group.label,
+          label: item.label,
+          text: item.promptFragment,
+        }),
+      ),
     )
     return [...projectEntries, ...cameraEntries, ...performanceEntries]
   }, [assets])
@@ -2489,10 +2551,17 @@ function CanvasNodeEditModal({
               onOptimizePrompt={runPromptOptimize}
             />
             <div className="canvas-node-edit-agent-actions">
-              <Button size="small" icon={<Icons.Sparkles size={14} />} onClick={runRelatedPromptGenerate}>
+              <Button
+                size="small"
+                icon={<Icons.Sparkles size={14} />}
+                onClick={runRelatedPromptGenerate}
+              >
                 Agent 生成相关提示词
               </Button>
-              <Button size="small" onClick={() => insertPromptText('电影感构图，主体清晰，光影自然，细节丰富。')}>
+              <Button
+                size="small"
+                onClick={() => insertPromptText('电影感构图，主体清晰，光影自然，细节丰富。')}
+              >
                 插入基础质量词
               </Button>
             </div>
@@ -2521,7 +2590,16 @@ function CanvasNodeEditModal({
                     onClick={() => insertPromptText(entry.text)}
                   >
                     <span className="canvas-node-edit-prompt-entry-top">
-                      <Tag color={entry.source === 'project' ? 'blue' : entry.source === 'camera' ? 'purple' : 'orange'} bordered>
+                      <Tag
+                        color={
+                          entry.source === 'project'
+                            ? 'blue'
+                            : entry.source === 'camera'
+                              ? 'purple'
+                              : 'orange'
+                        }
+                        bordered
+                      >
                         {entry.group}
                       </Tag>
                       <strong>{entry.label}</strong>


### PR DESCRIPTION
### Motivation
- Support video-oriented workflows (`image_to_video`, `video_edit`) by letting users explicitly mark which image nodes are `first_frame`, `last_frame`, or `reference` instead of relying only on positional ordering. 
- Surface these frame-role choices in the operation node panel so generated tasks receive correct semantic roles for multi-image / single-image video models and video-edit scenarios. 
- Ensure the runtime receives explicit role mappings so `buildCloudTaskInputFiles` can produce correctly labeled `inputFiles` for cloud providers and multi-image models. 

### Description
- Extended `OperationRunParams` with `inputRoles?: Record<string, CanvasTaskInputRole>` and introduced `type CanvasTaskInputRole = NonNullable<CanvasMediaTaskInputFile['role']>`. 
- Added UI selectors and logic to `CanvasOperationPanel.tsx` for `首帧`/`尾帧`/`参考图` (first/last/reference) when `operation` supports video frame roles, including derived helper functions `operationSupportsVideoFrameRoles`, `videoImageLimitForCapability`, `buildVideoFrameInputRoles`, and `normalizeVideoFrameNodeIds` (logic mirrored from `CanvasInlineAiComposer`). 
- When running an operation the panel now builds `explicitFrameNodeIds` and `inputRoles` and merges explicit frame node ids into `inputNodeIds` so `onRun` receives both the nodes and role mapping. 
- Forwarded `params.inputRoles` from `CanvasOperationPanel` through `CanvasWorkspaceView` into `buildCloudTaskInputFiles(...)` so cloud upload/URL building preserves roles; also added CSS (`CanvasWorkspaceView.less`) for the new controls and adjusted `mediaInputOptions` to tag items with `type` for image/video separation. 
- UI copy documents the default fallback rule: when not manually specified, the first image is treated as `first_frame`, the second as `last_frame`, and subsequent images as `reference`, while recommending users explicitly choose roles. 

### Testing
- Ran type checking with `pnpm --filter @spark/desktop typecheck` and it completed successfully. 
- Ran formatting checks with `pnpm exec prettier --check` and applied `prettier --write` to fix style warnings; verified style afterwards. 
- Executed `npx gitnexus detect_changes --scope compare --base_ref master` to surface change impact mapping. 
- Attempted `npx gitnexus impact` during development (no detailed blast-radius output was produced in this environment); no HIGH/CRITICAL risk was observed in subsequent typecheck and local validation steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3391e555dc8325a5ea17f32693f432)