### PR TITLE
Remote: richer command handling, selection caching, audit log, capabilities and Settings UI

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1777,6 +1777,115 @@ function formatRows(
     .join('\n')
 }
 
+type RemoteSelectionRow = { id: string; label: string; meta?: string }
+type RemoteSelectionKind = 'providers' | 'models' | 'agents' | 'sessions' | 'workspaces' | 'windows'
+
+const REMOTE_SELECTION_CACHE_TTL_MS = 10 * 60_000
+const remoteSelectionCache = new Map<string, { expiresAt: number; rows: RemoteSelectionRow[] }>()
+const remoteAuditLog: Array<{
+  at: string
+  connectionId: string
+  command: string
+  ok: boolean
+  target?: string
+  error?: string
+}> = []
+
+function cacheRemoteSelection(
+  connectionId: string,
+  kind: RemoteSelectionKind,
+  rows: RemoteSelectionRow[],
+): void {
+  remoteSelectionCache.set(`${connectionId}:${kind}`, {
+    expiresAt: Date.now() + REMOTE_SELECTION_CACHE_TTL_MS,
+    rows,
+  })
+  if (remoteSelectionCache.size > 200) {
+    for (const [key, value] of remoteSelectionCache) {
+      if (value.expiresAt < Date.now()) remoteSelectionCache.delete(key)
+    }
+  }
+}
+
+function getCachedRemoteSelection(
+  connectionId: string,
+  kind: RemoteSelectionKind,
+): RemoteSelectionRow[] | null {
+  const cached = remoteSelectionCache.get(`${connectionId}:${kind}`)
+  if (cached == null || cached.expiresAt < Date.now()) return null
+  return cached.rows
+}
+
+function quoteRemoteRows(rows: RemoteSelectionRow[]): string {
+  return rows.map((row, index) => `${index + 1}. ${row.label} (${row.id})`).join('\n')
+}
+
+function resolveRemoteSelection(
+  input: string,
+  rows: RemoteSelectionRow[],
+  options: { kindLabel: string; cachedRows?: RemoteSelectionRow[] | null },
+): { ok: true; row: RemoteSelectionRow } | { ok: false; title: string; text: string } {
+  const value = input.trim()
+  if (value.length === 0) {
+    return { ok: false, title: `缺少${options.kindLabel}`, text: `请输入序号、名称或 ID。` }
+  }
+
+  if (/^\d+$/.test(value)) {
+    const index = Number(value) - 1
+    const source = options.cachedRows ?? rows
+    if (options.cachedRows == null) {
+      return {
+        ok: false,
+        title: '序号已过期',
+        text: `请先发送 /${options.kindLabel === 'Provider' ? 'providers' : 'help'} 重新查看列表，再使用序号。`,
+      }
+    }
+    const row = source[index]
+    if (row == null) {
+      return { ok: false, title: '序号不存在', text: `可用范围：1-${source.length}` }
+    }
+    return { ok: true, row }
+  }
+
+  const idMatch = rows.find((row) => row.id === value)
+  if (idMatch != null) return { ok: true, row: idMatch }
+
+  const normalized = value.toLocaleLowerCase()
+  const nameMatches = rows.filter((row) => row.label.trim().toLocaleLowerCase() === normalized)
+  const onlyNameMatch = nameMatches[0]
+  if (nameMatches.length === 1 && onlyNameMatch != null) return { ok: true, row: onlyNameMatch }
+  if (nameMatches.length > 1) {
+    return {
+      ok: false,
+      title: `${options.kindLabel} 名称不唯一`,
+      text: `请改用序号或 ID：\n${quoteRemoteRows(nameMatches)}`,
+    }
+  }
+
+  const partialMatches = rows.filter((row) => row.label.toLocaleLowerCase().includes(normalized))
+  const onlyPartialMatch = partialMatches[0]
+  if (partialMatches.length === 1 && onlyPartialMatch != null)
+    return { ok: true, row: onlyPartialMatch }
+  if (partialMatches.length > 1) {
+    return {
+      ok: false,
+      title: `${options.kindLabel} 匹配不唯一`,
+      text: `请改用更完整名称、序号或 ID：\n${quoteRemoteRows(partialMatches.slice(0, 10))}`,
+    }
+  }
+
+  return {
+    ok: false,
+    title: `未找到${options.kindLabel}`,
+    text: `未找到：${value}。请发送对应列表命令查看可用项。`,
+  }
+}
+
+function appendRemoteAudit(entry: Omit<(typeof remoteAuditLog)[number], 'at'>): void {
+  remoteAuditLog.push({ at: new Date().toISOString(), ...entry })
+  if (remoteAuditLog.length > 200) remoteAuditLog.splice(0, remoteAuditLog.length - 200)
+}
+
 async function createRemoteSession(
   connectionId: string,
   workspaceId?: string,
@@ -1833,21 +1942,58 @@ async function executeRemoteCommand(
   }
 
   if (command.name === 'help') {
+    const commands = remoteService.getCommandCatalog()
+    const grouped = [
+      ['会话', ['sessions', 'use-session', 'new-session']],
+      ['模型', ['providers', 'use-provider', 'models', 'use-model']],
+      ['Agent', ['agents', 'use-agent']],
+      ['工作区', ['workspaces', 'open-workspace']],
+      ['远程桌面', ['screen', 'windows', 'focus', 'click', 'type', 'hotkey']],
+      ['运行时', ['progress', 'queue', 'history', 'cancel', 'stop']],
+      ['消息', ['send']],
+      ['系统', ['status', 'help']],
+    ] as const
+    const byName = new Map(commands.map((cmd) => [cmd.name, cmd]))
     return {
       ok: true,
       title: '远程命令',
-      text: remoteService
-        .getCommandCatalog()
-        .map((cmd) => `${cmd.usage} - ${cmd.description}`)
-        .join('\n'),
+      text:
+        grouped
+          .map(([group, names]) => {
+            const lines = names
+              .map((name) => byName.get(name))
+              .filter((cmd): cmd is NonNullable<ReturnType<typeof byName.get>> => cmd != null)
+              .map((cmd) => {
+                const enabled =
+                  cmd.capability === 'system' || connection.capabilities[cmd.capability]
+                return `${enabled ? '·' : '·（未授权）'} ${cmd.usage} - ${cmd.description}`
+              })
+            return `${group}\n${lines.join('\n')}`
+          })
+          .join('\n\n') +
+        '\n\n示例：/providers 后发送 /use-provider 2；也可发送 /use-provider 智谱 GLM Coding Plan 或完整 ID。',
     }
   }
 
   if (command.name === 'status') {
+    const providers = await getProviderService().listProviders()
+    const provider = providers.find((item) => item.id === connection.defaultProviderProfileId)
+    const models = getModelService().list()
+    const model = models.find((item) => item.id === connection.defaultModelId)
+    const agent =
+      connection.defaultAgentId != null ? getAgentRepository().get(connection.defaultAgentId) : null
     return {
       ok: true,
       title: connection.name,
-      text: `渠道：${connection.channel}\n状态：${connection.status}\n配对设备：${connection.pairedDevices.length}\n默认会话：${connection.defaultSessionId ?? '未设置'}`,
+      text: [
+        `渠道：${connection.channel}`,
+        `状态：${connection.status}`,
+        `配对设备：${connection.pairedDevices.length}`,
+        `默认会话：${connection.defaultSessionId ?? '未设置'}`,
+        `默认 Provider：${provider != null ? `${provider.name} (${provider.id})` : (connection.defaultProviderProfileId ?? '未设置')}`,
+        `默认模型：${model != null ? `${model.name} (${model.id})` : (connection.defaultModelId ?? '未设置')}`,
+        `默认 Agent：${agent != null ? `${agent.name} (${agent.id})` : (connection.defaultAgentId ?? '未设置')}`,
+      ].join('\n'),
     }
   }
 
@@ -1855,45 +2001,54 @@ async function executeRemoteCommand(
     const blocked = requireCapability('switchSession')
     if (blocked != null) return blocked
     const result = await getSessionService().listSessions({ includeArchived: false, limit: 12 })
+    const rows = result.sessions.map((item) => ({
+      id: item.id,
+      label: item.title || '新会话',
+      meta: `${item.status} · ${item.messageCount} 条消息`,
+    }))
+    cacheRemoteSelection(connection.id, 'sessions', rows)
     return {
       ok: true,
       title: '最近会话',
-      text: formatRows(
-        result.sessions.map((item) => ({
-          id: item.id,
-          label: item.title || '新会话',
-          meta: `${item.status} · ${item.messageCount} 条消息`,
-        })),
-        '暂无会话',
-      ),
+      text: formatRows(rows, '暂无会话'),
     }
   }
 
   if (command.name === 'use-session') {
     const blocked = requireCapability('switchSession')
     if (blocked != null) return blocked
-    const target = command.args[0]
+    const target = command.args.join(' ')
     if (target == null)
       return { ok: false, title: '缺少 sessionId', text: '用法：/use-session <sessionId>' }
-    remoteService.updateConnectionDefaults(connection.id, { defaultSessionId: target })
-    return { ok: true, title: '已切换默认会话', text: target }
+    const result = await getSessionService().listSessions({ includeArchived: false, limit: 12 })
+    const rows = result.sessions.map((item) => ({
+      id: item.id,
+      label: item.title || '新会话',
+      meta: `${item.status} · ${item.messageCount} 条消息`,
+    }))
+    const resolved = resolveRemoteSelection(target, rows, {
+      kindLabel: '会话',
+      cachedRows: getCachedRemoteSelection(connection.id, 'sessions'),
+    })
+    if (!resolved.ok) return resolved
+    remoteService.updateConnectionDefaults(connection.id, { defaultSessionId: resolved.row.id })
+    return { ok: true, title: '已切换默认会话', text: `${resolved.row.label}\n${resolved.row.id}` }
   }
 
   if (command.name === 'models') {
     const blocked = requireCapability('switchModel')
     if (blocked != null) return blocked
     const models = getModelService().list()
+    const rows = models.map((item) => ({
+      id: item.id,
+      label: item.name,
+      meta: item.enabled ? 'enabled' : 'disabled',
+    }))
+    cacheRemoteSelection(connection.id, 'models', rows)
     return {
       ok: true,
       title: '模型配置',
-      text: formatRows(
-        models.map((item) => ({
-          id: item.id,
-          label: item.name,
-          meta: item.enabled ? 'enabled' : 'disabled',
-        })),
-        '暂无模型配置',
-      ),
+      text: formatRows(rows, '暂无模型配置'),
     }
   }
 
@@ -1901,13 +2056,12 @@ async function executeRemoteCommand(
     const blocked = requireCapability('switchModel')
     if (blocked != null) return blocked
     const providers = await getProviderService().listProviders()
+    const rows = providers.map((item) => ({ id: item.id, label: item.name, meta: item.provider }))
+    cacheRemoteSelection(connection.id, 'providers', rows)
     return {
       ok: true,
       title: 'Provider 配置',
-      text: formatRows(
-        providers.map((item) => ({ id: item.id, label: item.name, meta: item.provider })),
-        '暂无 Provider',
-      ),
+      text: formatRows(rows, '暂无 Provider'),
     }
   }
 
@@ -1915,13 +2069,12 @@ async function executeRemoteCommand(
     const blocked = requireCapability('switchAgent')
     if (blocked != null) return blocked
     const agents = getAgentRepository().list({ includeDisabled: false }).map(toManagedAgent)
+    const rows = agents.map((item) => ({ id: item.id, label: item.name, meta: item.agentAdapter }))
+    cacheRemoteSelection(connection.id, 'agents', rows)
     return {
       ok: true,
       title: 'Agent',
-      text: formatRows(
-        agents.map((item) => ({ id: item.id, label: item.name, meta: item.agentAdapter })),
-        '暂无 Agent',
-      ),
+      text: formatRows(rows, '暂无 Agent'),
     }
   }
 
@@ -1931,20 +2084,32 @@ async function executeRemoteCommand(
     const list = getWorkspaceService()
       .listWorkspaces(12, 0, { includeArchived: false })
       .map(toWorkspaceInfo)
+    const rows = list.map((item) => ({ id: item.id, label: item.name, meta: item.rootPath }))
+    cacheRemoteSelection(connection.id, 'workspaces', rows)
     return {
       ok: true,
       title: '工作区',
-      text: formatRows(
-        list.map((item) => ({ id: item.id, label: item.name, meta: item.rootPath })),
-        '暂无工作区',
-      ),
+      text: formatRows(rows, '暂无工作区'),
     }
   }
 
   if (command.name === 'new-session') {
     const blocked = requireCapability('switchSession')
     if (blocked != null) return blocked
-    const workspaceId = command.args[0]
+    const workspaceInput = command.args.join(' ')
+    let workspaceId: string | undefined
+    if (workspaceInput.length > 0) {
+      const rows = getWorkspaceService()
+        .listWorkspaces(12, 0, { includeArchived: false })
+        .map(toWorkspaceInfo)
+        .map((item) => ({ id: item.id, label: item.name, meta: item.rootPath }))
+      const resolved = resolveRemoteSelection(workspaceInput, rows, {
+        kindLabel: '工作区',
+        cachedRows: getCachedRemoteSelection(connection.id, 'workspaces'),
+      })
+      if (!resolved.ok) return resolved
+      workspaceId = resolved.row.id
+    }
     const created = await createRemoteSession(connection.id, workspaceId)
     return { ok: true, title: '已新建默认会话', text: created.sessionId }
   }
@@ -1973,23 +2138,138 @@ async function executeRemoteCommand(
     const capability = command.name === 'use-agent' ? 'switchAgent' : 'switchModel'
     const blocked = requireCapability(capability)
     if (blocked != null) return blocked
-    const target = command.args[0]
-    if (target == null)
+    const target = command.args.join(' ')
+    if (target.length === 0)
       return { ok: false, title: '缺少目标 ID', text: `用法：/${command.name} <id>` }
+    let resolved: { ok: true; row: RemoteSelectionRow } | { ok: false; title: string; text: string }
+    if (command.name === 'use-provider') {
+      const rows = (await getProviderService().listProviders()).map((item) => ({
+        id: item.id,
+        label: item.name,
+        meta: item.provider,
+      }))
+      resolved = resolveRemoteSelection(target, rows, {
+        kindLabel: 'Provider',
+        cachedRows: getCachedRemoteSelection(connection.id, 'providers'),
+      })
+    } else if (command.name === 'use-model') {
+      const rows = getModelService()
+        .list()
+        .map((item) => ({
+          id: item.id,
+          label: item.name,
+          meta: item.enabled ? 'enabled' : 'disabled',
+        }))
+      resolved = resolveRemoteSelection(target, rows, {
+        kindLabel: '模型',
+        cachedRows: getCachedRemoteSelection(connection.id, 'models'),
+      })
+    } else {
+      const rows = getAgentRepository()
+        .list({ includeDisabled: false })
+        .map(toManagedAgent)
+        .map((item) => ({
+          id: item.id,
+          label: item.name,
+          meta: item.agentAdapter,
+        }))
+      resolved = resolveRemoteSelection(target, rows, {
+        kindLabel: 'Agent',
+        cachedRows: getCachedRemoteSelection(connection.id, 'agents'),
+      })
+    }
+    if (!resolved.ok) return resolved
     if (sessionId != null) {
       await getSessionService().updateSession({
         sessionId,
-        ...(command.name === 'use-model' ? { modelId: target } : {}),
-        ...(command.name === 'use-provider' ? { providerProfileId: target } : {}),
-        ...(command.name === 'use-agent' ? { agentId: target } : {}),
+        ...(command.name === 'use-model' ? { modelId: resolved.row.id } : {}),
+        ...(command.name === 'use-provider' ? { providerProfileId: resolved.row.id } : {}),
+        ...(command.name === 'use-agent' ? { agentId: resolved.row.id } : {}),
       })
     }
     remoteService.updateConnectionDefaults(connection.id, {
-      ...(command.name === 'use-model' ? { defaultModelId: target } : {}),
-      ...(command.name === 'use-provider' ? { defaultProviderProfileId: target } : {}),
-      ...(command.name === 'use-agent' ? { defaultAgentId: target } : {}),
+      ...(command.name === 'use-model' ? { defaultModelId: resolved.row.id } : {}),
+      ...(command.name === 'use-provider' ? { defaultProviderProfileId: resolved.row.id } : {}),
+      ...(command.name === 'use-agent' ? { defaultAgentId: resolved.row.id } : {}),
     })
-    return { ok: true, title: '已切换', text: target }
+    return { ok: true, title: '已切换', text: `${resolved.row.label}\n${resolved.row.id}` }
+  }
+
+  if (command.name === 'progress' || command.name === 'queue') {
+    const blocked = requireCapability('manageRuntime')
+    if (blocked != null) return blocked
+    if (sessionId == null)
+      return { ok: false, title: '缺少默认会话', text: '请先使用 /use-session 绑定会话。' }
+    const queue = getSessionService().getQueueState({ sessionId })
+    return {
+      ok: true,
+      title: command.name === 'progress' ? '当前进度' : '队列',
+      text: `运行中：${queue.running ? '是' : '否'}\n排队中：${queue.queuedTurns.length}\n${queue.queuedTurns.map((item, index) => `${index + 1}. ${item.turnId} · ${item.message.slice(0, 80)}`).join('\n') || '暂无排队消息'}`,
+    }
+  }
+
+  if (command.name === 'history') {
+    const blocked = requireCapability('manageRuntime')
+    if (blocked != null) return blocked
+    const rows = remoteAuditLog
+      .filter((item) => item.connectionId === connection.id)
+      .slice(-10)
+      .reverse()
+      .map(
+        (item, index) =>
+          `${index + 1}. ${item.at} · /${item.command} · ${item.ok ? '成功' : `失败：${item.error ?? '未知错误'}`}${item.target != null ? ` · ${item.target}` : ''}`,
+      )
+    return { ok: true, title: '远程审计', text: rows.join('\n') || '暂无远程命令记录' }
+  }
+
+  if (command.name === 'cancel' || command.name === 'stop') {
+    const blocked = requireCapability('manageRuntime')
+    if (blocked != null) return blocked
+    if (sessionId == null)
+      return { ok: false, title: '缺少默认会话', text: '请先使用 /use-session 绑定会话。' }
+    const cancelled = await getSessionService().cancelTurn(sessionId)
+    return { ok: true, title: cancelled.cancelled ? '已取消' : '没有可取消任务', text: sessionId }
+  }
+
+  if (command.name === 'screen' || command.name === 'windows') {
+    const blocked = requireCapability('observeDesktop')
+    if (blocked != null) return blocked
+    const mainWindow = getMainWindow()
+    const rows =
+      mainWindow == null
+        ? []
+        : [
+            {
+              id: String(mainWindow.id),
+              label: mainWindow.getTitle() || 'Spark Agent',
+              meta: mainWindow.isFocused() ? 'focused' : 'background',
+            },
+          ]
+    cacheRemoteSelection(connection.id, 'windows', rows)
+    return {
+      ok: true,
+      title: command.name === 'screen' ? '屏幕概览' : '窗口列表',
+      text:
+        rows.length > 0
+          ? formatRows(rows, '暂无窗口')
+          : '当前未找到可观察窗口。远程截图/图像回传将在后续渠道适配中启用。',
+    }
+  }
+
+  if (['focus', 'click', 'type', 'hotkey'].includes(command.name)) {
+    const blocked = requireCapability('controlDesktop')
+    if (blocked != null) return blocked
+    return {
+      ok: false,
+      title: '桌面控制需要原生适配',
+      text: '已预留权限和命令入口；当前版本仅开放 /screen 与 /windows 观察能力，点击/输入/快捷键需接入平台级安全执行器后启用。',
+    }
+  }
+
+  if (command.name === 'confirm') {
+    const blocked = requireCapability('dangerousActions')
+    if (blocked != null) return blocked
+    return { ok: false, title: '暂无待确认动作', text: '当前没有等待远程确认的高危动作。' }
   }
 
   if (command.name === 'send') {
@@ -2019,6 +2299,12 @@ async function executeRemoteCommand(
     }
   }
 
+  appendRemoteAudit({
+    connectionId: connection.id,
+    command: command.name,
+    ok: false,
+    error: 'unknown-command',
+  })
   return { ok: false, title: '未知命令', text: '发送 /help 查看可用命令。' }
 }
 

--- a/apps/desktop/src/main/services/RemoteConnectionService.ts
+++ b/apps/desktop/src/main/services/RemoteConnectionService.ts
@@ -96,22 +96,149 @@ const DEFAULT_CAPABILITIES: RemoteConnectionCapabilities = {
   manageWorkspace: true,
   runCommands: true,
   approvePermissions: false,
+  observeDesktop: true,
+  controlDesktop: false,
+  transferFiles: false,
+  manageRuntime: false,
+  dangerousActions: false,
 }
 
 const COMMAND_CATALOG: RemoteCommandDefinition[] = [
   { name: 'help', usage: '/help', description: '查看远程可用命令', capability: 'system' },
-  { name: 'sessions', usage: '/sessions', description: '列出最近会话', capability: 'switchSession' },
-  { name: 'use-session', usage: '/use-session <sessionId>', description: '切换默认会话', capability: 'switchSession' },
+  {
+    name: 'sessions',
+    usage: '/sessions',
+    description: '列出最近会话',
+    capability: 'switchSession',
+  },
+  {
+    name: 'use-session',
+    usage: '/use-session <序号|名称|sessionId>',
+    description: '切换默认会话',
+    capability: 'switchSession',
+  },
   { name: 'models', usage: '/models', description: '列出可用模型配置', capability: 'switchModel' },
-  { name: 'use-model', usage: '/use-model <modelId>', description: '切换当前会话或连接默认模型', capability: 'switchModel' },
-  { name: 'providers', usage: '/providers', description: '列出 Provider 配置', capability: 'switchModel' },
-  { name: 'use-provider', usage: '/use-provider <providerProfileId>', description: '切换当前会话或连接默认 Provider', capability: 'switchModel' },
+  {
+    name: 'use-model',
+    usage: '/use-model <序号|名称|modelId>',
+    description: '切换当前会话或连接默认模型',
+    capability: 'switchModel',
+  },
+  {
+    name: 'providers',
+    usage: '/providers',
+    description: '列出 Provider 配置',
+    capability: 'switchModel',
+  },
+  {
+    name: 'use-provider',
+    usage: '/use-provider <序号|名称|providerProfileId>',
+    description: '切换当前会话或连接默认 Provider',
+    capability: 'switchModel',
+  },
   { name: 'agents', usage: '/agents', description: '列出 Agent', capability: 'switchAgent' },
-  { name: 'use-agent', usage: '/use-agent <agentId>', description: '切换当前会话或连接默认 Agent', capability: 'switchAgent' },
-  { name: 'workspaces', usage: '/workspaces', description: '列出工作区', capability: 'manageWorkspace' },
-  { name: 'new-session', usage: '/new-session [workspaceId]', description: '新建会话并设为默认会话', capability: 'switchSession' },
-  { name: 'open-workspace', usage: '/open-workspace <path>', description: '打开本地项目目录', capability: 'manageWorkspace' },
-  { name: 'send', usage: '/send <message>', description: '向默认会话发送消息', capability: 'sendMessages' },
+  {
+    name: 'use-agent',
+    usage: '/use-agent <序号|名称|agentId>',
+    description: '切换当前会话或连接默认 Agent',
+    capability: 'switchAgent',
+  },
+  {
+    name: 'workspaces',
+    usage: '/workspaces',
+    description: '列出工作区',
+    capability: 'manageWorkspace',
+  },
+  {
+    name: 'new-session',
+    usage: '/new-session [序号|名称|workspaceId]',
+    description: '新建会话并设为默认会话',
+    capability: 'switchSession',
+  },
+  {
+    name: 'open-workspace',
+    usage: '/open-workspace <path>',
+    description: '打开本地项目目录',
+    capability: 'manageWorkspace',
+  },
+  {
+    name: 'send',
+    usage: '/send <message>',
+    description: '向默认会话发送消息',
+    capability: 'sendMessages',
+  },
+  {
+    name: 'progress',
+    usage: '/progress',
+    description: '查看默认会话当前队列和最近状态',
+    capability: 'manageRuntime',
+  },
+  {
+    name: 'queue',
+    usage: '/queue',
+    description: '查看默认会话排队消息',
+    capability: 'manageRuntime',
+  },
+  {
+    name: 'history',
+    usage: '/history',
+    description: '查看最近远程命令审计',
+    capability: 'manageRuntime',
+  },
+  {
+    name: 'cancel',
+    usage: '/cancel',
+    description: '取消默认会话当前任务',
+    capability: 'manageRuntime',
+  },
+  {
+    name: 'stop',
+    usage: '/stop',
+    description: '停止当前远程任务（等同 /cancel）',
+    capability: 'manageRuntime',
+  },
+  {
+    name: 'screen',
+    usage: '/screen',
+    description: '查看当前桌面/窗口概览',
+    capability: 'observeDesktop',
+  },
+  {
+    name: 'windows',
+    usage: '/windows',
+    description: '列出当前可观察窗口',
+    capability: 'observeDesktop',
+  },
+  {
+    name: 'focus',
+    usage: '/focus <序号|窗口标题>',
+    description: '聚焦窗口（需要桌面控制权限）',
+    capability: 'controlDesktop',
+  },
+  {
+    name: 'click',
+    usage: '/click <x> <y>',
+    description: '远程点击（需要桌面控制权限）',
+    capability: 'controlDesktop',
+  },
+  {
+    name: 'type',
+    usage: '/type <text>',
+    description: '远程输入文本（需要桌面控制权限）',
+    capability: 'controlDesktop',
+  },
+  {
+    name: 'hotkey',
+    usage: '/hotkey <keys>',
+    description: '远程快捷键（需要桌面控制权限）',
+    capability: 'controlDesktop',
+  },
+  {
+    name: 'confirm',
+    usage: '/confirm <code>',
+    description: '确认高危远程动作',
+    capability: 'dangerousActions',
+  },
   { name: 'status', usage: '/status', description: '查看连接与配对状态', capability: 'system' },
 ]
 
@@ -187,7 +314,10 @@ function defaultTelegramCommands(): string[] {
   return COMMAND_CATALOG.map((cmd) => cmd.name).filter((name) => name !== 'send')
 }
 
-function createPairingPayload(connection: RemoteConnectionConfig, pairing: RemotePairingChallenge): string {
+function createPairingPayload(
+  connection: RemoteConnectionConfig,
+  pairing: RemotePairingChallenge,
+): string {
   const params = new URLSearchParams({
     connectionId: connection.id,
     channel: connection.channel,
@@ -208,7 +338,11 @@ function normalizeInboundText(channel: RemoteChannelType, rawText: string): stri
   const trimmed = rawText.trim()
   if (channel === 'telegram') return trimmed.replace(/^@[a-zA-Z0-9_]+\s*/, '').trim()
   if (channel === 'feishu') return trimmed.replace(/@_user_\d+\s*/g, '').trim()
-  if (channel === 'qq') return trimmed.replace(/<@[^>]+>\s*/g, '').replace(/^@\S+\s*/, '').trim()
+  if (channel === 'qq')
+    return trimmed
+      .replace(/<@[^>]+>\s*/g, '')
+      .replace(/^@\S+\s*/, '')
+      .trim()
   return trimmed.replace(/^@\S+\s*/, '').trim()
 }
 
@@ -226,13 +360,19 @@ function parseJsonContent(value: unknown): string | undefined {
   }
 }
 
-function parseWebhookBody(channel: RemoteChannelType, body: unknown): {
-  kind: 'message'
-  externalId: string
-  senderName: string
-  text: string
-  messageId?: string
-} | { kind: 'challenge'; responseBody: unknown } | { kind: 'ignore' } {
+function parseWebhookBody(
+  channel: RemoteChannelType,
+  body: unknown,
+):
+  | {
+      kind: 'message'
+      externalId: string
+      senderName: string
+      text: string
+      messageId?: string
+    }
+  | { kind: 'challenge'; responseBody: unknown }
+  | { kind: 'ignore' } {
   if (!isRecord(body)) return { kind: 'ignore' }
 
   if (channel === 'telegram') {
@@ -247,17 +387,24 @@ function parseWebhookBody(channel: RemoteChannelType, body: unknown): {
     return {
       kind: 'message',
       externalId,
-      senderName: username != null ? `${firstName ?? username}(@${username})` : (firstName ?? 'Telegram 用户'),
+      senderName:
+        username != null
+          ? `${firstName ?? username}(@${username})`
+          : (firstName ?? 'Telegram 用户'),
       text: normalizeInboundText(channel, text),
-      ...(message?.message_id != null ? { messageId: `telegram:${String(message.message_id)}` } : {}),
+      ...(message?.message_id != null
+        ? { messageId: `telegram:${String(message.message_id)}` }
+        : {}),
     }
   }
 
   if (channel === 'feishu') {
-    if (body.challenge != null) return { kind: 'challenge', responseBody: { challenge: body.challenge } }
+    if (body.challenge != null)
+      return { kind: 'challenge', responseBody: { challenge: body.challenge } }
     const event = isRecord(body.event) ? body.event : body
     const message = isRecord(event.message) ? event.message : event
-    const externalId = readString(message.chat_id) ?? readString(message.open_chat_id) ?? readString(event.chat_id)
+    const externalId =
+      readString(message.chat_id) ?? readString(message.open_chat_id) ?? readString(event.chat_id)
     const text = parseJsonContent(message.content) ?? readString(message.text)
     if (!externalId || !text) return { kind: 'ignore' }
     const sender = isRecord(event.sender) ? event.sender : undefined
@@ -267,7 +414,9 @@ function parseWebhookBody(channel: RemoteChannelType, body: unknown): {
       externalId,
       senderName: readString(senderId?.open_id) ?? readString(senderId?.user_id) ?? '飞书用户',
       text: normalizeInboundText(channel, text),
-      ...(readString(message.message_id) ? { messageId: `feishu:${String(message.message_id)}` } : {}),
+      ...(readString(message.message_id)
+        ? { messageId: `feishu:${String(message.message_id)}` }
+        : {}),
     }
   }
 
@@ -276,7 +425,11 @@ function parseWebhookBody(channel: RemoteChannelType, body: unknown): {
       return { kind: 'ignore' }
     }
     const data = isRecord(body.d) ? body.d : body
-    const externalId = readString(data.group_openid) ?? readString(data.guild_id) ?? readString(data.channel_id) ?? readString(data.author_id)
+    const externalId =
+      readString(data.group_openid) ??
+      readString(data.guild_id) ??
+      readString(data.channel_id) ??
+      readString(data.author_id)
     const text = readString(data.content)
     if (!externalId || !text) return { kind: 'ignore' }
     const author = isRecord(data.author) ? data.author : undefined
@@ -321,7 +474,9 @@ function plainText(markdown: string): string {
     .trim()
 }
 
-function resolveFeishuReceiveIdType(externalId: string): 'chat_id' | 'open_id' | 'user_id' | 'union_id' {
+function resolveFeishuReceiveIdType(
+  externalId: string,
+): 'chat_id' | 'open_id' | 'user_id' | 'union_id' {
   if (externalId.startsWith('ou_')) return 'open_id'
   if (externalId.startsWith('on_')) return 'union_id'
   if (externalId.startsWith('user_')) return 'user_id'
@@ -329,11 +484,8 @@ function resolveFeishuReceiveIdType(externalId: string): 'chat_id' | 'open_id' |
 }
 
 function parseFeishuMessageTimestamp(value: unknown): number | null {
-  const numeric = typeof value === 'number'
-    ? value
-    : typeof value === 'string'
-      ? Number(value)
-      : NaN
+  const numeric =
+    typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
   if (!Number.isFinite(numeric) || numeric <= 0) return null
   return numeric < 10_000_000_000 ? numeric * 1000 : numeric
 }
@@ -341,20 +493,24 @@ function parseFeishuMessageTimestamp(value: unknown): number | null {
 function sanitizeConnection(input: unknown): RemoteConnectionConfig | null {
   if (!isRecord(input)) return null
   const channel = input.channel
-  if (channel !== 'telegram' && channel !== 'feishu' && channel !== 'qq' && channel !== 'wechat-claw') {
+  if (
+    channel !== 'telegram' &&
+    channel !== 'feishu' &&
+    channel !== 'qq' &&
+    channel !== 'wechat-claw'
+  ) {
     return null
   }
   const createdAt = typeof input.createdAt === 'string' ? input.createdAt : nowIso()
   const updatedAt = typeof input.updatedAt === 'string' ? input.updatedAt : createdAt
-  const status = (
+  const status =
     input.status === 'disabled' ||
     input.status === 'draft' ||
     input.status === 'pending-pairing' ||
     input.status === 'connected' ||
     input.status === 'error'
-  )
-    ? input.status
-    : 'draft'
+      ? input.status
+      : 'draft'
 
   return {
     id: typeof input.id === 'string' ? input.id : createId('remote'),
@@ -366,21 +522,32 @@ function sanitizeConnection(input: unknown): RemoteConnectionConfig | null {
     commandPrefix: typeof input.commandPrefix === 'string' ? input.commandPrefix : '/',
     allowedUserIds: normalizeStringArray(input.allowedUserIds),
     allowedChatIds: normalizeStringArray(input.allowedChatIds),
-    ...(typeof input.defaultSessionId === 'string' ? { defaultSessionId: input.defaultSessionId } : {}),
-    ...(typeof input.defaultProviderProfileId === 'string' ? { defaultProviderProfileId: input.defaultProviderProfileId } : {}),
+    ...(typeof input.defaultSessionId === 'string'
+      ? { defaultSessionId: input.defaultSessionId }
+      : {}),
+    ...(typeof input.defaultProviderProfileId === 'string'
+      ? { defaultProviderProfileId: input.defaultProviderProfileId }
+      : {}),
     ...(typeof input.defaultModelId === 'string' ? { defaultModelId: input.defaultModelId } : {}),
     ...(typeof input.defaultAgentId === 'string' ? { defaultAgentId: input.defaultAgentId } : {}),
-    telegramCommands: normalizeStringArray(input.telegramCommands).length > 0
-      ? normalizeStringArray(input.telegramCommands)
-      : defaultTelegramCommands(),
+    telegramCommands:
+      normalizeStringArray(input.telegramCommands).length > 0
+        ? normalizeStringArray(input.telegramCommands)
+        : defaultTelegramCommands(),
     capabilities: isRecord(input.capabilities)
       ? { ...DEFAULT_CAPABILITIES, ...input.capabilities }
       : { ...DEFAULT_CAPABILITIES },
-    ...(isRecord(input.pairing) ? { pairing: input.pairing as unknown as RemotePairingChallenge } : {}),
-    pairedDevices: Array.isArray(input.pairedDevices) ? (input.pairedDevices as RemoteConnectionConfig['pairedDevices']) : [],
+    ...(isRecord(input.pairing)
+      ? { pairing: input.pairing as unknown as RemotePairingChallenge }
+      : {}),
+    pairedDevices: Array.isArray(input.pairedDevices)
+      ? (input.pairedDevices as RemoteConnectionConfig['pairedDevices'])
+      : [],
     createdAt,
     updatedAt,
-    ...(typeof input.lastConnectedAt === 'string' ? { lastConnectedAt: input.lastConnectedAt } : {}),
+    ...(typeof input.lastConnectedAt === 'string'
+      ? { lastConnectedAt: input.lastConnectedAt }
+      : {}),
     ...(typeof input.lastError === 'string' ? { lastError: input.lastError } : {}),
   }
 }
@@ -411,9 +578,12 @@ export class RemoteConnectionService {
     return COMMAND_CATALOG
   }
 
-  save(patch: Partial<RemoteConnectionConfig> & Pick<RemoteConnectionConfig, 'channel' | 'name'>): RemoteConnectionConfig {
+  save(
+    patch: Partial<RemoteConnectionConfig> & Pick<RemoteConnectionConfig, 'channel' | 'name'>,
+  ): RemoteConnectionConfig {
     const store = this.readStore()
-    const existing = patch.id != null ? store.connections.find((item) => item.id === patch.id) : undefined
+    const existing =
+      patch.id != null ? store.connections.find((item) => item.id === patch.id) : undefined
     const timestamp = nowIso()
     const base: RemoteConnectionConfig = existing ?? {
       id: patch.id ?? createId('remote'),
@@ -485,12 +655,14 @@ export class RemoteConnectionService {
       const value = connection.credentials[field]
       return typeof value !== 'string' || value.trim().length === 0
     })
-    const status: RemoteConnectionStatus = missing.length > 0
-      ? 'error'
-      : connection.pairedDevices.length > 0
-        ? 'connected'
-        : 'pending-pairing'
-    const patch: Partial<RemoteConnectionConfig> & Pick<RemoteConnectionConfig, 'channel' | 'name'> = {
+    const status: RemoteConnectionStatus =
+      missing.length > 0
+        ? 'error'
+        : connection.pairedDevices.length > 0
+          ? 'connected'
+          : 'pending-pairing'
+    const patch: Partial<RemoteConnectionConfig> &
+      Pick<RemoteConnectionConfig, 'channel' | 'name'> = {
       ...connection,
       status,
       enabled: status !== 'error' ? connection.enabled : false,
@@ -501,11 +673,15 @@ export class RemoteConnectionService {
     return {
       ok: missing.length === 0,
       status: next.status,
-      message: missing.length === 0 ? '配置完整，等待远程用户配对' : `缺少字段：${missing.join(', ')}`,
+      message:
+        missing.length === 0 ? '配置完整，等待远程用户配对' : `缺少字段：${missing.join(', ')}`,
     }
   }
 
-  generatePairing(id: string, mode: RemotePairingMode): { connection: RemoteConnectionConfig; pairing: RemotePairingChallenge } {
+  generatePairing(
+    id: string,
+    mode: RemotePairingMode,
+  ): { connection: RemoteConnectionConfig; pairing: RemotePairingChallenge } {
     const store = this.readStore()
     const connection = store.connections.find((item) => item.id === id)
     if (connection == null) throw new Error('Remote connection not found')
@@ -564,7 +740,15 @@ export class RemoteConnectionService {
     return { ok: true, connection: next }
   }
 
-  updateConnectionDefaults(id: string, patch: Partial<Pick<RemoteConnectionConfig, 'defaultSessionId' | 'defaultProviderProfileId' | 'defaultModelId' | 'defaultAgentId'>>): RemoteConnectionConfig {
+  updateConnectionDefaults(
+    id: string,
+    patch: Partial<
+      Pick<
+        RemoteConnectionConfig,
+        'defaultSessionId' | 'defaultProviderProfileId' | 'defaultModelId' | 'defaultAgentId'
+      >
+    >,
+  ): RemoteConnectionConfig {
     const connection = this.readStore().connections.find((item) => item.id === id)
     if (connection == null) throw new Error('Remote connection not found')
     return this.save({ ...connection, ...patch })
@@ -647,7 +831,12 @@ export class RemoteConnectionService {
     port: number | null
     localBaseUrl: string | null
     polling: Array<{ connectionId: string; running: boolean; lastError?: string }>
-    longConnections: Array<{ connectionId: string; channel: 'feishu'; running: boolean; lastError?: string }>
+    longConnections: Array<{
+      connectionId: string
+      channel: 'feishu'
+      running: boolean
+      lastError?: string
+    }>
   } {
     return {
       running: this.server != null,
@@ -669,7 +858,10 @@ export class RemoteConnectionService {
 
   private async ensureWebhookServer(preferredPort: number): Promise<void> {
     if (this.server != null) return
-    const port = Number.isFinite(preferredPort) && preferredPort > 0 ? preferredPort : DEFAULT_GLOBAL.localWebhookPort
+    const port =
+      Number.isFinite(preferredPort) && preferredPort > 0
+        ? preferredPort
+        : DEFAULT_GLOBAL.localWebhookPort
     try {
       await this.listenWebhookServer(port)
     } catch (err) {
@@ -682,7 +874,10 @@ export class RemoteConnectionService {
   private async listenWebhookServer(port: number): Promise<void> {
     const server = http.createServer((req, res) => {
       void this.handleHttpRequest(req, res).catch((err) => {
-        const body = JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) })
+        const body = JSON.stringify({
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        })
         res.writeHead(500, { 'Content-Type': 'application/json; charset=utf-8' })
         res.end(body)
       })
@@ -707,7 +902,10 @@ export class RemoteConnectionService {
     this.runtimePort = typeof address === 'object' && address != null ? address.port : port
   }
 
-  private async handleHttpRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  private async handleHttpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
     const requestUrl = new URL(req.url ?? '/', `http://${req.headers.host ?? '127.0.0.1'}`)
     if (req.method === 'GET' && requestUrl.pathname === '/remote/health') {
       this.writeJson(res, 200, { ok: true, ...this.getRuntimeStatus() })
@@ -722,7 +920,9 @@ export class RemoteConnectionService {
 
     const [, channelRaw, id] = match
     const channel = channelRaw as RemoteChannelType
-    const connection = this.readStore().connections.find((item) => item.id === id && item.channel === channel)
+    const connection = this.readStore().connections.find(
+      (item) => item.id === id && item.channel === channel,
+    )
     if (connection == null) {
       this.writeJson(res, 404, { ok: false, error: 'remote connection not found' })
       return
@@ -734,7 +934,10 @@ export class RemoteConnectionService {
     this.writeJson(res, 200, responseBody)
   }
 
-  private async handleInboundWebhook(connection: RemoteConnectionConfig, body: unknown): Promise<unknown> {
+  private async handleInboundWebhook(
+    connection: RemoteConnectionConfig,
+    body: unknown,
+  ): Promise<unknown> {
     const parsed = parseWebhookBody(connection.channel, body)
     if (parsed.kind === 'challenge') return parsed.responseBody
     if (parsed.kind === 'ignore') return { ok: true, ignored: true }
@@ -768,7 +971,8 @@ export class RemoteConnectionService {
       return
     }
 
-    const latest = this.readStore().connections.find((item) => item.id === connection.id) ?? connection
+    const latest =
+      this.readStore().connections.find((item) => item.id === connection.id) ?? connection
     if (!latest.enabled) return
     if (!this.isAuthorized(latest, message.externalId)) {
       await this.sendDirectMessage(
@@ -782,7 +986,11 @@ export class RemoteConnectionService {
     this.markSeen(latest.id, message.externalId)
     await this.sendProcessingFeedback(latest, message.externalId, message.messageId)
     if (this.inboundHandler == null) {
-      await this.sendDirectMessage(latest, message.externalId, '远程连接运行时尚未就绪，请稍后重试。')
+      await this.sendDirectMessage(
+        latest,
+        message.externalId,
+        '远程连接运行时尚未就绪，请稍后重试。',
+      )
       return
     }
 
@@ -795,10 +1003,18 @@ export class RemoteConnectionService {
         ...(message.messageId != null ? { messageId: message.messageId } : {}),
       })
       if (response != null) {
-        await this.sendDirectMessage(latest, message.externalId, `${response.title}\n${response.text}`.trim())
+        await this.sendDirectMessage(
+          latest,
+          message.externalId,
+          `${response.title}\n${response.text}`.trim(),
+        )
       }
     } catch (err) {
-      await this.sendDirectMessage(latest, message.externalId, `处理失败：${err instanceof Error ? err.message : String(err)}`)
+      await this.sendDirectMessage(
+        latest,
+        message.externalId,
+        `处理失败：${err instanceof Error ? err.message : String(err)}`,
+      )
     }
   }
 
@@ -808,7 +1024,8 @@ export class RemoteConnectionService {
     externalId: string,
     senderName: string,
   ): Promise<void> {
-    const latest = this.readStore().connections.find((item) => item.id === connection.id) ?? connection
+    const latest =
+      this.readStore().connections.find((item) => item.id === connection.id) ?? connection
     try {
       this.confirmPairing({
         id: latest.id,
@@ -817,20 +1034,33 @@ export class RemoteConnectionService {
         displayName: senderName,
         channelThreadId: externalId,
       })
-      await this.sendDirectMessage(latest, externalId, '已绑定 Spark Agent。后续消息会进入该连接的默认会话，发送 /help 查看命令。')
+      await this.sendDirectMessage(
+        latest,
+        externalId,
+        '已绑定 Spark Agent。后续消息会进入该连接的默认会话，发送 /help 查看命令。',
+      )
     } catch (err) {
-      await this.sendDirectMessage(latest, externalId, `绑定失败：${err instanceof Error ? err.message : String(err)}`)
+      await this.sendDirectMessage(
+        latest,
+        externalId,
+        `绑定失败：${err instanceof Error ? err.message : String(err)}`,
+      )
     }
   }
 
   private isAuthorized(connection: RemoteConnectionConfig, externalId: string): boolean {
-    const paired = connection.pairedDevices.some((device) => (
-      device.remoteUserId === externalId || device.channelThreadId === externalId
-    ))
+    const paired = connection.pairedDevices.some(
+      (device) => device.remoteUserId === externalId || device.channelThreadId === externalId,
+    )
     if (paired) return true
-    if (connection.allowedChatIds.includes(externalId) || connection.allowedUserIds.includes(externalId)) return true
+    if (
+      connection.allowedChatIds.includes(externalId) ||
+      connection.allowedUserIds.includes(externalId)
+    )
+      return true
     const global = this.readStore().global
-    const hasAllowList = connection.allowedChatIds.length > 0 || connection.allowedUserIds.length > 0
+    const hasAllowList =
+      connection.allowedChatIds.length > 0 || connection.allowedUserIds.length > 0
     return !global.requirePairing && !hasAllowList
   }
 
@@ -839,11 +1069,11 @@ export class RemoteConnectionService {
     const connection = store.connections.find((item) => item.id === id)
     if (connection == null) return
     const timestamp = nowIso()
-    const pairedDevices = connection.pairedDevices.map((device) => (
+    const pairedDevices = connection.pairedDevices.map((device) =>
       device.remoteUserId === externalId || device.channelThreadId === externalId
         ? { ...device, lastSeenAt: timestamp }
-        : device
-    ))
+        : device,
+    )
     this.writeConnections(store, {
       ...connection,
       pairedDevices,
@@ -894,7 +1124,11 @@ export class RemoteConnectionService {
     this.telegramCommandSignatures.delete(connectionId)
   }
 
-  private startFeishuWs(connection: RemoteConnectionConfig, appId: string, appSecret: string): void {
+  private startFeishuWs(
+    connection: RemoteConnectionConfig,
+    appId: string,
+    appSecret: string,
+  ): void {
     const existing = this.feishuWsStates.get(connection.id)
     if (existing?.running && existing.appId === appId && existing.appSecret === appSecret) return
     this.stopFeishuWs(connection.id)
@@ -931,7 +1165,9 @@ export class RemoteConnectionService {
           onError?: (error: unknown) => void
         }) => { start: (input: { eventDispatcher: unknown }) => Promise<void>; close: () => void }
         EventDispatcher: new (options: Record<string, unknown>) => {
-          register: (handlers: Record<string, (data: FeishuMessageReceiveEvent) => Promise<void>>) => unknown
+          register: (
+            handlers: Record<string, (data: FeishuMessageReceiveEvent) => Promise<void>>,
+          ) => unknown
         }
       }
       const dispatcher = new lark.EventDispatcher({}).register({
@@ -973,7 +1209,11 @@ export class RemoteConnectionService {
     }
   }
 
-  private async handleFeishuWsEvent(connectionId: string, state: FeishuWsState, event: FeishuMessageReceiveEvent): Promise<void> {
+  private async handleFeishuWsEvent(
+    connectionId: string,
+    state: FeishuWsState,
+    event: FeishuMessageReceiveEvent,
+  ): Promise<void> {
     const connection = this.readStore().connections.find((item) => item.id === connectionId)
     if (connection == null || !connection.enabled || connection.channel !== 'feishu') return
     const message = event.message
@@ -1015,7 +1255,7 @@ export class RemoteConnectionService {
         const text = await response.text().catch(() => '')
         throw new Error(`Telegram polling failed: ${response.status} ${text.slice(0, 200)}`)
       }
-      const payload = await response.json() as {
+      const payload = (await response.json()) as {
         ok?: boolean
         result?: Array<{ update_id: number; message?: unknown }>
       }
@@ -1034,7 +1274,10 @@ export class RemoteConnectionService {
     }
   }
 
-  private async syncTelegramCommands(connection: RemoteConnectionConfig, token: string): Promise<void> {
+  private async syncTelegramCommands(
+    connection: RemoteConnectionConfig,
+    token: string,
+  ): Promise<void> {
     const signature = JSON.stringify(connection.telegramCommands)
     if (this.telegramCommandSignatures.get(connection.id) === signature) return
     const catalog = new Map(COMMAND_CATALOG.map((cmd) => [cmd.name, cmd]))
@@ -1047,18 +1290,25 @@ export class RemoteConnectionService {
       }))
     if (commands.length === 0) return
     try {
-      const response = await fetch(`https://api.telegram.org/bot${encodeURIComponent(token)}/setMyCommands`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ commands }),
-      })
+      const response = await fetch(
+        `https://api.telegram.org/bot${encodeURIComponent(token)}/setMyCommands`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ commands }),
+        },
+      )
       if (response.ok) this.telegramCommandSignatures.set(connection.id, signature)
     } catch {
       // 命令同步失败不影响消息桥接。
     }
   }
 
-  private async sendDirectMessage(connection: RemoteConnectionConfig, externalId: string, text: string): Promise<void> {
+  private async sendDirectMessage(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    text: string,
+  ): Promise<void> {
     if (connection.channel === 'telegram') {
       await this.sendTelegramMessage(connection, externalId, text)
       return
@@ -1074,7 +1324,11 @@ export class RemoteConnectionService {
     await this.sendClawMessage(connection, externalId, text)
   }
 
-  private async sendTelegramMessage(connection: RemoteConnectionConfig, externalId: string, text: string): Promise<void> {
+  private async sendTelegramMessage(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    text: string,
+  ): Promise<void> {
     const token = readString(connection.credentials.botToken)
     if (token == null) throw new Error('Telegram bot token 未配置')
     for (const chunk of splitText(text, 3900)) {
@@ -1086,33 +1340,63 @@ export class RemoteConnectionService {
     }
   }
 
-  private async sendTelegramChatAction(connection: RemoteConnectionConfig, externalId: string, action: 'typing' | 'upload_photo' | 'record_video' | 'upload_video' | 'record_voice' | 'upload_voice' | 'upload_document' | 'find_location' | 'record_video_note' | 'upload_video_note' | 'choose_sticker' = 'typing'): Promise<void> {
+  private async sendTelegramChatAction(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    action:
+      | 'typing'
+      | 'upload_photo'
+      | 'record_video'
+      | 'upload_video'
+      | 'record_voice'
+      | 'upload_voice'
+      | 'upload_document'
+      | 'find_location'
+      | 'record_video_note'
+      | 'upload_video_note'
+      | 'choose_sticker' = 'typing',
+  ): Promise<void> {
     const token = readString(connection.credentials.botToken)
     if (token == null) return
     try {
-      await this.postJson(`https://api.telegram.org/bot${encodeURIComponent(token)}/sendChatAction`, {
-        chat_id: externalId,
-        action,
-      })
+      await this.postJson(
+        `https://api.telegram.org/bot${encodeURIComponent(token)}/sendChatAction`,
+        {
+          chat_id: externalId,
+          action,
+        },
+      )
     } catch {
       // Chat action 发送失败不阻断主流程
     }
   }
 
-  private async sendFeishuMessage(connection: RemoteConnectionConfig, externalId: string, text: string): Promise<void> {
+  private async sendFeishuMessage(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    text: string,
+  ): Promise<void> {
     const appId = readString(connection.credentials.appId)
     const appSecret = readString(connection.credentials.appSecret)
     if (appId == null || appSecret == null) throw new Error('飞书 App ID 或 App Secret 未配置')
     const token = await this.getFeishuToken(connection.id, appId, appSecret)
     const receiveIdType = resolveFeishuReceiveIdType(externalId)
-    await this.postJson(`https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=${receiveIdType}`, {
-      receive_id: externalId,
-      msg_type: 'text',
-      content: JSON.stringify({ text }),
-    }, { Authorization: `Bearer ${token}` })
+    await this.postJson(
+      `https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=${receiveIdType}`,
+      {
+        receive_id: externalId,
+        msg_type: 'text',
+        content: JSON.stringify({ text }),
+      },
+      { Authorization: `Bearer ${token}` },
+    )
   }
 
-  private async sendProcessingFeedback(connection: RemoteConnectionConfig, externalId: string, messageId?: string): Promise<void> {
+  private async sendProcessingFeedback(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    messageId?: string,
+  ): Promise<void> {
     if (connection.channel === 'telegram') {
       await this.sendTelegramChatAction(connection, externalId, 'typing')
     }
@@ -1124,27 +1408,45 @@ export class RemoteConnectionService {
       if (appId == null || appSecret == null) return
       try {
         const token = await this.getFeishuToken(connection.id, appId, appSecret)
-        await this.postJson(`https://open.feishu.cn/open-apis/im/v1/messages/${encodeURIComponent(feishuMessageId)}/reactions`, {
-          reaction_type: { emoji_type: 'Typing' },
-        }, { Authorization: `Bearer ${token}` })
+        await this.postJson(
+          `https://open.feishu.cn/open-apis/im/v1/messages/${encodeURIComponent(feishuMessageId)}/reactions`,
+          {
+            reaction_type: { emoji_type: 'Typing' },
+          },
+          { Authorization: `Bearer ${token}` },
+        )
       } catch {
         // 反馈表情失败只影响体验，不阻断消息处理。
       }
     }
   }
 
-  private async sendQqMessage(connection: RemoteConnectionConfig, externalId: string, text: string): Promise<void> {
+  private async sendQqMessage(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    text: string,
+  ): Promise<void> {
     const appId = readString(connection.credentials.qqBotAppId)
-    const clientSecret = readString(connection.credentials.qqBotSecret) ?? readString(connection.credentials.qqBotToken)
+    const clientSecret =
+      readString(connection.credentials.qqBotSecret) ??
+      readString(connection.credentials.qqBotToken)
     if (appId == null || clientSecret == null) throw new Error('QQ 机器人 AppID 或 Secret 未配置')
     const token = await this.getQqToken(connection.id, appId, clientSecret)
-    await this.postJson(`https://api.sgroup.qq.com/v2/groups/${encodeURIComponent(externalId)}/messages`, {
-      msg_type: 0,
-      content: plainText(text).slice(0, 1900),
-    }, { Authorization: `QQBot ${token}` })
+    await this.postJson(
+      `https://api.sgroup.qq.com/v2/groups/${encodeURIComponent(externalId)}/messages`,
+      {
+        msg_type: 0,
+        content: plainText(text).slice(0, 1900),
+      },
+      { Authorization: `QQBot ${token}` },
+    )
   }
 
-  private async sendClawMessage(connection: RemoteConnectionConfig, externalId: string, text: string): Promise<void> {
+  private async sendClawMessage(
+    connection: RemoteConnectionConfig,
+    externalId: string,
+    text: string,
+  ): Promise<void> {
     const endpoint = readString(connection.credentials.clawEndpoint)
     if (endpoint == null) throw new Error('Claw Endpoint 未配置')
     const token = readString(connection.credentials.clawAccessToken)
@@ -1159,30 +1461,46 @@ export class RemoteConnectionService {
     }
   }
 
-  private async getFeishuToken(connectionId: string, appId: string, appSecret: string): Promise<string> {
+  private async getFeishuToken(
+    connectionId: string,
+    appId: string,
+    appSecret: string,
+  ): Promise<string> {
     const cacheKey = `feishu:${connectionId}`
     const cached = this.readCachedToken(cacheKey)
     if (cached != null) return cached
-    const data = await this.postJson('https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal', {
-      app_id: appId,
-      app_secret: appSecret,
-    }) as { tenant_access_token?: string; expire?: number }
+    const data = (await this.postJson(
+      'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal',
+      {
+        app_id: appId,
+        app_secret: appSecret,
+      },
+    )) as { tenant_access_token?: string; expire?: number }
     if (data.tenant_access_token == null) throw new Error('飞书 token 响应缺少 tenant_access_token')
     this.writeCachedToken(cacheKey, data.tenant_access_token, data.expire ?? 3600)
     return data.tenant_access_token
   }
 
-  private async getQqToken(connectionId: string, appId: string, clientSecret: string): Promise<string> {
+  private async getQqToken(
+    connectionId: string,
+    appId: string,
+    clientSecret: string,
+  ): Promise<string> {
     const cacheKey = `qq:${connectionId}`
     const cached = this.readCachedToken(cacheKey)
     if (cached != null) return cached
-    const data = await this.postJson('https://bots.qq.com/app/getAppAccessToken', {
+    const data = (await this.postJson('https://bots.qq.com/app/getAppAccessToken', {
       appId,
       clientSecret,
-    }) as { access_token?: string; expires_in?: string | number }
+    })) as { access_token?: string; expires_in?: string | number }
     if (data.access_token == null) throw new Error('QQ token 响应缺少 access_token')
-    const expires = typeof data.expires_in === 'string' ? Number.parseInt(data.expires_in, 10) : data.expires_in
-    this.writeCachedToken(cacheKey, data.access_token, Number.isFinite(expires) ? Number(expires) : 3600)
+    const expires =
+      typeof data.expires_in === 'string' ? Number.parseInt(data.expires_in, 10) : data.expires_in
+    this.writeCachedToken(
+      cacheKey,
+      data.access_token,
+      Number.isFinite(expires) ? Number(expires) : 3600,
+    )
     return data.access_token
   }
 
@@ -1203,7 +1521,11 @@ export class RemoteConnectionService {
     })
   }
 
-  private async postJson(url: string, body: unknown, headers?: Record<string, string>): Promise<unknown> {
+  private async postJson(
+    url: string,
+    body: unknown,
+    headers?: Record<string, string>,
+  ): Promise<unknown> {
     const response = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', ...(headers ?? {}) },
@@ -1240,9 +1562,13 @@ export class RemoteConnectionService {
   private readStore(): RemoteConnectionStore {
     const raw = this.settingsService.get(SETTINGS_CATEGORY, SETTINGS_KEY)
     if (!isRecord(raw)) return { global: { ...DEFAULT_GLOBAL }, connections: [] }
-    const global = isRecord(raw.global) ? { ...DEFAULT_GLOBAL, ...raw.global } : { ...DEFAULT_GLOBAL }
+    const global = isRecord(raw.global)
+      ? { ...DEFAULT_GLOBAL, ...raw.global }
+      : { ...DEFAULT_GLOBAL }
     const connections = Array.isArray(raw.connections)
-      ? raw.connections.map(sanitizeConnection).filter((item): item is RemoteConnectionConfig => item != null)
+      ? raw.connections
+          .map(sanitizeConnection)
+          .filter((item): item is RemoteConnectionConfig => item != null)
       : []
     return { global, connections }
   }

--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -95,7 +95,9 @@
   min-height: 110px;
 }
 /* 带 onClick 的快捷入口卡片，鼠标进入后应表现为可点击 */
-.qs-card.qs-card-default { cursor: pointer; }
+.qs-card.qs-card-default {
+  cursor: pointer;
+}
 .qs-card:hover {
   border-color: var(--primary);
   background: var(--bg-soft);
@@ -175,7 +177,9 @@
 }
 /* 带 onClick 的列表项（会话、健康行等），鼠标进入后应表现为可点击 */
 .list-item.session-item-default,
-.list-item.health-row { cursor: pointer; }
+.list-item.health-row {
+  cursor: pointer;
+}
 .list-item + .list-item {
   border-top: 1px solid var(--divider);
   border-radius: 0;
@@ -565,7 +569,9 @@ body.sidebar-resizing {
   cursor: pointer;
   color: var(--text-faint);
   border-radius: var(--r-xs);
-  transition: background 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 .proj-toggle:hover {
   background: color-mix(in srgb, var(--text) 8%, transparent);
@@ -698,8 +704,17 @@ body.sidebar-resizing {
   display: none;
 }
 @keyframes session-waiting-pulse {
-  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-primary-6, rgb(var(--primary-6))) 40%, transparent); }
-  50% { opacity: 0.8; box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary-6, rgb(var(--primary-6))) 0%, transparent); }
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--color-primary-6, rgb(var(--primary-6))) 40%, transparent);
+  }
+  50% {
+    opacity: 0.8;
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--color-primary-6, rgb(var(--primary-6))) 0%, transparent);
+  }
 }
 .proj-session-empty {
   display: flex;
@@ -731,7 +746,9 @@ body.sidebar-resizing {
   color: var(--text-faint);
   font-size: 11.5px;
   cursor: pointer;
-  transition: color 0.12s, background 0.12s;
+  transition:
+    color 0.12s,
+    background 0.12s;
 }
 .proj-show-more-btn:hover {
   color: var(--primary);
@@ -914,7 +931,7 @@ body.sidebar-resizing {
 .proj-head:hover .item-menu-btn,
 .chat-item:hover .item-menu-btn,
 .item-menu-btn:focus-visible,
-.item-menu-btn[data-state="open"],
+.item-menu-btn[data-state='open'],
 .item-menu-wrap.menu-open .item-menu-btn,
 .proj-head:hover .proj-add-session-btn {
   opacity: 1;
@@ -1526,7 +1543,9 @@ body.sidebar-resizing {
   background: var(--bg-soft);
   /* 重要：覆盖 .md-surface img 的 margin，避免双重间距 */
   margin: 0;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .md-image-img:hover {
@@ -1547,7 +1566,9 @@ body.sidebar-resizing {
   border-radius: var(--r-sm);
   opacity: 0;
   transform: translateY(-2px);
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
   pointer-events: none;
 }
 
@@ -1800,7 +1821,9 @@ body.sidebar-resizing {
   background: transparent;
   border-color: var(--divider);
 }
-.md-code-block.no-syntax .md-code { font-family: var(--font-sans); }
+.md-code-block.no-syntax .md-code {
+  font-family: var(--font-sans);
+}
 .md-code-header {
   display: flex;
   align-items: center;
@@ -2639,8 +2662,12 @@ body.sidebar-resizing {
   background-image:
     linear-gradient(to right, var(--hero-grid-color, rgba(36, 32, 27, 0.07)) 1px, transparent 1px),
     linear-gradient(to bottom, var(--hero-grid-color, rgba(36, 32, 27, 0.07)) 1px, transparent 1px);
-  background-size: 56px 56px, 56px 56px;
-  background-position: -1px -1px, -1px -1px;
+  background-size:
+    56px 56px,
+    56px 56px;
+  background-position:
+    -1px -1px,
+    -1px -1px;
   -webkit-mask-image: radial-gradient(
     ellipse 70% 60% at 50% 50%,
     #000 0%,
@@ -2675,7 +2702,7 @@ body.sidebar-resizing {
   position: relative;
   z-index: 1;
 }
-.chat-main-empty .chat-hero-span{
+.chat-main-empty .chat-hero-span {
   font-size: 12px;
   color: #999;
   line-height: 1;
@@ -3589,7 +3616,9 @@ body.sidebar-resizing {
   white-space: nowrap;
   cursor: pointer;
   border-radius: var(--r-sm);
-  transition: background 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 }
 .context-meter:hover {
   background: var(--hover);
@@ -4287,7 +4316,7 @@ body.inspector-resizing {
   cursor: col-resize;
   user-select: none;
 }
- .inspector-section {
+.inspector-section {
   padding: var(--pad-md) var(--pad-lg);
   border-bottom: 1px solid var(--divider);
 }
@@ -4455,7 +4484,9 @@ body.inspector-resizing {
   border-radius: var(--r-xs);
   background: var(--bg-soft);
   border: 1px solid transparent;
-  transition: background-color 0.12s ease, border-color 0.12s ease;
+  transition:
+    background-color 0.12s ease,
+    border-color 0.12s ease;
 }
 .inspector-plan-item:hover {
   background: var(--bg);
@@ -6065,7 +6096,10 @@ body.inspector-resizing {
   overflow: hidden;
   box-sizing: border-box;
   box-shadow: var(--shadow-xs);
-  transition: border-color 0.12s, box-shadow 0.12s, transform 0.12s;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s,
+    transform 0.12s;
 }
 .skill-card.selected {
   border-color: var(--primary);
@@ -6224,7 +6258,9 @@ body.inspector-resizing {
   border-radius: var(--r-lg);
   overflow: hidden;
   background: var(--bg-soft);
-  box-shadow: inset 0 0 0 1px var(--border), var(--shadow-xs);
+  box-shadow:
+    inset 0 0 0 1px var(--border),
+    var(--shadow-xs);
   flex-shrink: 0;
 }
 .avatar-picker-preview img,
@@ -6306,7 +6342,9 @@ body.inspector-resizing {
   position: absolute;
   inset: 0;
   border-radius: var(--r-lg);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.42), inset 0 0 0 999px rgba(0, 0, 0, 0.02);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.42),
+    inset 0 0 0 999px rgba(0, 0, 0, 0.02);
   pointer-events: none;
 }
 .avatar-crop-controls {
@@ -6352,11 +6390,7 @@ body.inspector-resizing {
 .avatar-crop-circle-mask {
   position: absolute;
   inset: 0;
-  background: radial-gradient(
-    circle 120px at center,
-    transparent 118px,
-    rgba(0, 0, 0, 0.5) 120px
-  );
+  background: radial-gradient(circle 120px at center, transparent 118px, rgba(0, 0, 0, 0.5) 120px);
   pointer-events: none;
   border-radius: var(--r-lg);
 }
@@ -6483,7 +6517,10 @@ body.inspector-resizing {
   gap: 10px;
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    box-shadow 0.15s;
 }
 .remote-connection-card:hover {
   border-color: var(--border-strong);
@@ -6512,6 +6549,8 @@ body.inspector-resizing {
 }
 .remote-editor {
   min-width: 0;
+  display: grid;
+  gap: 14px;
 }
 .remote-editor-modal .ant-modal {
   width: min(860px, calc(100vw - 32px));
@@ -6536,7 +6575,19 @@ body.inspector-resizing {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 18px 0 4px;
+  margin: 0;
+}
+.remote-actions-sticky {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 10px 0 12px;
+  background: linear-gradient(
+    180deg,
+    var(--panel) 72%,
+    color-mix(in srgb, var(--panel) 0%, transparent)
+  );
+  border-bottom: 1px solid var(--divider);
 }
 .remote-pairing-panel {
   border: 1px solid var(--border);
@@ -7074,7 +7125,8 @@ body.inspector-resizing {
   border-bottom: 0;
   border-radius: var(--r-lg) var(--r-lg) 0 0;
   background: var(--panel);
-  box-shadow: 0 -8px 28px color-mix(in srgb, var(--shadow-color, rgba(0,0,0,.12)) 48%, transparent);
+  box-shadow: 0 -8px 28px
+    color-mix(in srgb, var(--shadow-color, rgba(0, 0, 0, 0.12)) 48%, transparent);
   overflow: hidden;
   flex-shrink: 0;
   animation: user-question-slide-up 0.28s cubic-bezier(0.22, 1, 0.36, 1);
@@ -7211,7 +7263,10 @@ body.inspector-resizing {
   border: 0;
   background: color-mix(in srgb, var(--primary) 7%, var(--bg-soft));
   color: var(--text);
-  transition: background 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+  transition:
+    background 0.15s ease,
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
   cursor: pointer;
   overflow: hidden;
 }
@@ -7339,7 +7394,11 @@ body.inspector-resizing {
   white-space: nowrap;
   flex-shrink: 0;
   cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease, opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease,
+    transform 0.15s ease;
 }
 
 .user-question-btn.secondary {
@@ -7518,7 +7577,9 @@ body.inspector-resizing {
   font-family: inherit;
   outline: none;
   width: 100%;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 .form-grid > textarea:not(.ant-input) {
   height: auto;
@@ -7529,7 +7590,9 @@ body.inspector-resizing {
 }
 .form-grid > input:not(.ant-input):hover,
 .form-grid > select:hover,
-.form-grid > textarea:not(.ant-input):hover { border-color: var(--text-faint); }
+.form-grid > textarea:not(.ant-input):hover {
+  border-color: var(--text-faint);
+}
 .form-grid > input:not(.ant-input):focus,
 .form-grid > select:focus,
 .form-grid > textarea:not(.ant-input):focus {
@@ -7566,7 +7629,9 @@ body.inspector-resizing {
   animation: slideRight 0.2s;
 }
 @media (min-width: 1600px) {
-  .slide-panel { width: min(1120px, 80vw); }
+  .slide-panel {
+    width: min(1120px, 80vw);
+  }
 }
 @keyframes slideRight {
   from {
@@ -10845,7 +10910,9 @@ body.inspector-resizing {
   border: 1px solid var(--border);
   border-radius: var(--r-sm);
   outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   box-sizing: border-box;
   width: 100%;
 }
@@ -10876,7 +10943,9 @@ body.inspector-resizing {
   resize: vertical;
   outline: none;
   box-sizing: border-box;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   font-family: var(--font-sans, inherit);
 }
 
@@ -11014,7 +11083,10 @@ body.inspector-resizing {
   text-align: left;
   cursor: pointer;
   box-shadow: var(--shadow-xs);
-  transition: border-color 0.12s, box-shadow 0.12s, transform 0.12s;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s,
+    transform 0.12s;
 }
 .agents-card:hover {
   border-color: color-mix(in srgb, var(--primary) 36%, transparent);
@@ -11075,7 +11147,6 @@ body.inspector-resizing {
   font-size: 12px;
   line-height: 1.5;
   overflow: hidden;
-  
 }
 .agents-card-meta {
   display: flex;
@@ -11520,7 +11591,10 @@ body.inspector-resizing {
   text-align: left;
   cursor: pointer;
   box-shadow: var(--shadow-xs);
-  transition: border-color 0.12s, box-shadow 0.12s, transform 0.12s;
+  transition:
+    border-color 0.12s,
+    box-shadow 0.12s,
+    transform 0.12s;
 }
 .workflow-card:hover {
   border-color: color-mix(in srgb, var(--primary) 36%, transparent);
@@ -11546,7 +11620,11 @@ body.inspector-resizing {
   background: color-mix(in srgb, var(--bg) 86%, transparent);
   color: var(--text-muted);
   opacity: 0;
-  transition: opacity 0.12s, color 0.12s, border-color 0.12s, background 0.12s;
+  transition:
+    opacity 0.12s,
+    color 0.12s,
+    border-color 0.12s,
+    background 0.12s;
 }
 .workflow-card:hover .workflow-card-delete,
 .workflow-card:focus-within .workflow-card-delete {
@@ -11650,13 +11728,17 @@ body.inspector-resizing {
   background: var(--panel);
   min-height: 48px;
 }
-.workflow-builder-v2 .wf-toolbar-spacer { flex: 1; }
+.workflow-builder-v2 .wf-toolbar-spacer {
+  flex: 1;
+}
 .workflow-builder-v2 .wf-title-input {
   position: static;
   width: 240px;
   font-weight: 650;
 }
-.workflow-builder-v2 .wf-status-select { width: 110px; }
+.workflow-builder-v2 .wf-status-select {
+  width: 110px;
+}
 .workflow-builder-v2 .wf-canvas-wrap {
   flex: 1;
   display: flex;
@@ -11693,7 +11775,10 @@ body.inspector-resizing {
   background: var(--panel);
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.12s, transform 0.12s, box-shadow 0.12s;
+  transition:
+    border-color 0.12s,
+    transform 0.12s,
+    box-shadow 0.12s;
 }
 .workflow-builder-v2 .wf-palette-item:hover {
   border-color: var(--node-accent, var(--primary));
@@ -11726,8 +11811,15 @@ body.inspector-resizing {
   font-size: 11px;
   color: var(--text-muted);
 }
-.workflow-builder-v2 .wf-flow { flex: 1; min-width: 0; min-height: 0; position: relative; }
-.workflow-builder-v2 .wf-flow .react-flow__attribution { display: none; }
+.workflow-builder-v2 .wf-flow {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+}
+.workflow-builder-v2 .wf-flow .react-flow__attribution {
+  display: none;
+}
 .workflow-builder-v2 .wf-flow .react-flow__minimap {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -11759,7 +11851,9 @@ body.inspector-resizing {
 }
 .spark-wf-node.selected {
   border-color: var(--node-accent, var(--primary));
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--node-accent, var(--primary)) 22%, transparent), var(--shadow-md);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--node-accent, var(--primary)) 22%, transparent),
+    var(--shadow-md);
 }
 .spark-wf-node-head {
   display: flex;
@@ -11852,8 +11946,7 @@ body.inspector-resizing {
   overflow: auto;
   background:
     linear-gradient(var(--border) 1px, transparent 1px),
-    linear-gradient(90deg, var(--border) 1px, transparent 1px),
-    var(--bg);
+    linear-gradient(90deg, var(--border) 1px, transparent 1px), var(--bg);
   background-size: 24px 24px;
 }
 .wf-title-input {
@@ -11943,9 +12036,15 @@ body.inspector-resizing {
   user-select: none;
 }
 
-.provider-logo-rounded .lobe-flex { border-radius: var(--r-sm) !important; }
-.provider-logo-rounded { border-radius: var(--r-sm) !important; }
-.provider-logo-circle { border-radius: 50% !important; }
+.provider-logo-rounded .lobe-flex {
+  border-radius: var(--r-sm) !important;
+}
+.provider-logo-rounded {
+  border-radius: var(--r-sm) !important;
+}
+.provider-logo-circle {
+  border-radius: 50% !important;
+}
 .provider-logo-img {
   width: 100%;
   height: 100%;
@@ -11973,10 +12072,14 @@ body.inspector-resizing {
   background: var(--panel);
   padding: 8px;
   gap: 8px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   cursor: text;
 }
-.chip-list:hover { border-color: var(--text-faint); }
+.chip-list:hover {
+  border-color: var(--text-faint);
+}
 .chip-list:focus-within {
   border-color: var(--primary);
   box-shadow: 0 0 0 3px var(--primary-soft);
@@ -11998,11 +12101,20 @@ body.inspector-resizing {
   font-size: var(--font-sm);
   font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
   outline: none;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
-.chip-list-input::placeholder { color: var(--text-faint); }
-.chip-list-input:hover { background: var(--hover); }
-.chip-list-input:focus { background: var(--bg-soft); border-color: var(--border); }
+.chip-list-input::placeholder {
+  color: var(--text-faint);
+}
+.chip-list-input:hover {
+  background: var(--hover);
+}
+.chip-list-input:focus {
+  background: var(--bg-soft);
+  border-color: var(--border);
+}
 .chip-list-add {
   display: inline-flex;
   align-items: center;
@@ -12016,10 +12128,14 @@ body.inspector-resizing {
   font-size: var(--font-xs);
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.12s, opacity 0.12s;
+  transition:
+    background 0.12s,
+    opacity 0.12s;
   flex-shrink: 0;
 }
-.chip-list-add:hover:not(:disabled) { background: var(--primary-hover); }
+.chip-list-add:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
 .chip-list-add:disabled {
   opacity: 0.4;
   cursor: not-allowed;
@@ -12057,11 +12173,20 @@ body.inspector-resizing {
   color: var(--text);
   font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
   max-width: 100%;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
-.chip:hover { background: var(--hover); }
-.chip-clickable { cursor: pointer; user-select: none; }
-.chip-clickable.chip-locked { cursor: default; }
+.chip:hover {
+  background: var(--hover);
+}
+.chip-clickable {
+  cursor: pointer;
+  user-select: none;
+}
+.chip-clickable.chip-locked {
+  cursor: default;
+}
 .chip-clickable:focus-visible {
   outline: 2px solid var(--primary);
   outline-offset: 2px;
@@ -12094,12 +12219,26 @@ body.inspector-resizing {
   color: var(--text-faint);
   cursor: pointer;
   padding: 0;
-  transition: background 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
-.chip-remove:hover { background: var(--danger-bg); color: var(--danger); }
-.chip-list-compact { padding: 6px; gap: 6px; }
-.chip-list-compact .chip { height: 22px; font-size: 10.5px; padding: 0 4px 0 6px; }
-.chip-list-compact .chip-list-input { height: 26px; }
+.chip-remove:hover {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+.chip-list-compact {
+  padding: 6px;
+  gap: 6px;
+}
+.chip-list-compact .chip {
+  height: 22px;
+  font-size: 10.5px;
+  padding: 0 4px 0 6px;
+}
+.chip-list-compact .chip-list-input {
+  height: 26px;
+}
 
 /* ============================================================
    PROVIDER EDIT FORM — slide panel 的 C 端版式
@@ -12114,7 +12253,10 @@ body.inspector-resizing {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
 }
-.provider-form-hero .provider-form-hero-info { flex: 1; min-width: 0; }
+.provider-form-hero .provider-form-hero-info {
+  flex: 1;
+  min-width: 0;
+}
 .provider-form-hero .provider-form-hero-title {
   font-size: 15px;
   font-weight: 600;
@@ -12147,7 +12289,9 @@ body.inspector-resizing {
   background: var(--panel);
   transition: border-color 0.15s;
 }
-.provider-form-section:hover { border-color: var(--border-strong); }
+.provider-form-section:hover {
+  border-color: var(--border-strong);
+}
 .provider-form-section-title {
   display: flex;
   align-items: center;
@@ -12175,7 +12319,10 @@ body.inspector-resizing {
 .provider-form-row + .provider-form-row {
   border-top: 1px solid var(--divider);
 }
-.provider-form-row-info { flex: 1; min-width: 0; }
+.provider-form-row-info {
+  flex: 1;
+  min-width: 0;
+}
 .provider-form-row-label {
   font-size: var(--font-sm);
   font-weight: 500;
@@ -12229,14 +12376,24 @@ body.inspector-resizing {
   margin-bottom: 16px;
   border: 1px solid color-mix(in srgb, var(--danger) 25%, transparent);
 }
-.alert-banner-icon { flex-shrink: 0; display: inline-flex; align-items: center; padding-top: 1px; }
-.alert-banner-content { flex: 1; line-height: 1.5; }
+.alert-banner-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding-top: 1px;
+}
+.alert-banner-content {
+  flex: 1;
+  line-height: 1.5;
+}
 
 /* Provider card logo：使用真实 logo 后 fallback 改为纯色字母 */
 .provider-card .provider-logo {
   border: 1px solid var(--border);
 }
-.provider-card .provider-info .name { font-size: 14px; }
+.provider-card .provider-info .name {
+  font-size: 14px;
+}
 .provider-card .provider-default-badge {
   display: inline-flex;
   align-items: center;
@@ -12284,7 +12441,9 @@ body.inspector-resizing {
   color: var(--text-muted);
   overflow: hidden;
 }
-.preset-card.preset-added .preset-card-logo { opacity: 0.5; }
+.preset-card.preset-added .preset-card-logo {
+  opacity: 0.5;
+}
 
 /* ============================================================
    PROVIDER 多选 / 导入导出 样式（import-export task）
@@ -12293,7 +12452,9 @@ body.inspector-resizing {
 /* Provider card 多选态 */
 .provider-card.multi-select {
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
 .provider-card.multi-select:hover {
   background: var(--bg-soft);
@@ -12310,7 +12471,7 @@ body.inspector-resizing {
   cursor: pointer;
   flex-shrink: 0;
 }
-.provider-card-checkbox input[type="checkbox"] {
+.provider-card-checkbox input[type='checkbox'] {
   width: 16px;
   height: 16px;
   cursor: pointer;
@@ -12363,8 +12524,14 @@ body.inspector-resizing {
   animation: modalIn 0.18s;
 }
 @keyframes modalIn {
-  from { transform: scale(0.96); opacity: 0; }
-  to   { transform: scale(1);    opacity: 1; }
+  from {
+    transform: scale(0.96);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 .modal-header {
   display: flex;
@@ -12426,7 +12593,9 @@ body.inspector-resizing {
   font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
   font-size: 11px;
 }
-.import-meta .muted { color: var(--text-muted); }
+.import-meta .muted {
+  color: var(--text-muted);
+}
 
 .import-mode-row {
   display: flex;
@@ -12446,7 +12615,7 @@ body.inspector-resizing {
 .import-mode-row .radio-row:hover {
   background: var(--bg-soft);
 }
-.import-mode-row .radio-row input[type="radio"] {
+.import-mode-row .radio-row input[type='radio'] {
   accent-color: var(--primary);
   margin: 0;
 }
@@ -12479,7 +12648,9 @@ body.inspector-resizing {
   border-bottom: 1px solid var(--divider);
   font-size: var(--font-sm);
 }
-.import-list-row:last-child { border-bottom: none; }
+.import-list-row:last-child {
+  border-bottom: none;
+}
 .import-list-row.conflict {
   background: rgba(245, 158, 11, 0.05);
 }
@@ -12518,8 +12689,12 @@ body.inspector-resizing {
   overflow: hidden;
   user-select: none;
 }
-.provider-logo-rounded { border-radius: var(--r-sm) !important; }
-.provider-logo-circle { border-radius: 50% !important; }
+.provider-logo-rounded {
+  border-radius: var(--r-sm) !important;
+}
+.provider-logo-circle {
+  border-radius: 50% !important;
+}
 .provider-logo-img {
   width: 100%;
   height: 100%;
@@ -12547,10 +12722,14 @@ body.inspector-resizing {
   background: var(--panel);
   padding: 8px;
   gap: 8px;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
   cursor: text;
 }
-.chip-list:hover { border-color: var(--text-faint); }
+.chip-list:hover {
+  border-color: var(--text-faint);
+}
 .chip-list:focus-within {
   border-color: var(--primary);
   box-shadow: 0 0 0 3px var(--primary-soft);
@@ -12572,11 +12751,20 @@ body.inspector-resizing {
   font-size: var(--font-sm);
   font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
   outline: none;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
-.chip-list-input::placeholder { color: var(--text-faint); }
-.chip-list-input:hover { background: var(--hover); }
-.chip-list-input:focus { background: var(--bg-soft); border-color: var(--border); }
+.chip-list-input::placeholder {
+  color: var(--text-faint);
+}
+.chip-list-input:hover {
+  background: var(--hover);
+}
+.chip-list-input:focus {
+  background: var(--bg-soft);
+  border-color: var(--border);
+}
 .chip-list-add {
   display: inline-flex;
   align-items: center;
@@ -12590,10 +12778,14 @@ body.inspector-resizing {
   font-size: var(--font-xs);
   font-weight: 500;
   cursor: pointer;
-  transition: background 0.12s, opacity 0.12s;
+  transition:
+    background 0.12s,
+    opacity 0.12s;
   flex-shrink: 0;
 }
-.chip-list-add:hover:not(:disabled) { background: var(--primary-hover); }
+.chip-list-add:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
 .chip-list-add:disabled {
   opacity: 0.4;
   cursor: not-allowed;
@@ -12631,11 +12823,20 @@ body.inspector-resizing {
   color: var(--text);
   font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
   max-width: 100%;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
-.chip:hover { background: var(--hover); }
-.chip-clickable { cursor: pointer; user-select: none; }
-.chip-clickable.chip-locked { cursor: default; }
+.chip:hover {
+  background: var(--hover);
+}
+.chip-clickable {
+  cursor: pointer;
+  user-select: none;
+}
+.chip-clickable.chip-locked {
+  cursor: default;
+}
 .chip-clickable:focus-visible {
   outline: 2px solid var(--primary);
   outline-offset: 2px;
@@ -12668,12 +12869,26 @@ body.inspector-resizing {
   color: var(--text-faint);
   cursor: pointer;
   padding: 0;
-  transition: background 0.12s, color 0.12s;
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
-.chip-remove:hover { background: var(--danger-bg); color: var(--danger); }
-.chip-list-compact { padding: 6px; gap: 6px; }
-.chip-list-compact .chip { height: 22px; font-size: 10.5px; padding: 0 4px 0 6px; }
-.chip-list-compact .chip-list-input { height: 26px; }
+.chip-remove:hover {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+.chip-list-compact {
+  padding: 6px;
+  gap: 6px;
+}
+.chip-list-compact .chip {
+  height: 22px;
+  font-size: 10.5px;
+  padding: 0 4px 0 6px;
+}
+.chip-list-compact .chip-list-input {
+  height: 26px;
+}
 
 /* ============================================================
    PROVIDER EDIT FORM — slide panel 的 C 端版式
@@ -12688,7 +12903,10 @@ body.inspector-resizing {
   border: 1px solid var(--border);
   border-radius: var(--r-lg);
 }
-.provider-form-hero .provider-form-hero-info { flex: 1; min-width: 0; }
+.provider-form-hero .provider-form-hero-info {
+  flex: 1;
+  min-width: 0;
+}
 .provider-form-hero .provider-form-hero-title {
   font-size: 15px;
   font-weight: 600;
@@ -12721,7 +12939,9 @@ body.inspector-resizing {
   background: var(--panel);
   transition: border-color 0.15s;
 }
-.provider-form-section:hover { border-color: var(--border-strong); }
+.provider-form-section:hover {
+  border-color: var(--border-strong);
+}
 .provider-form-section-title {
   display: flex;
   align-items: center;
@@ -12749,7 +12969,10 @@ body.inspector-resizing {
 .provider-form-row + .provider-form-row {
   border-top: 1px solid var(--divider);
 }
-.provider-form-row-info { flex: 1; min-width: 0; }
+.provider-form-row-info {
+  flex: 1;
+  min-width: 0;
+}
 .provider-form-row-label {
   font-size: var(--font-sm);
   font-weight: 500;
@@ -12803,14 +13026,24 @@ body.inspector-resizing {
   margin-bottom: 16px;
   border: 1px solid color-mix(in srgb, var(--danger) 25%, transparent);
 }
-.alert-banner-icon { flex-shrink: 0; display: inline-flex; align-items: center; padding-top: 1px; }
-.alert-banner-content { flex: 1; line-height: 1.5; }
+.alert-banner-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding-top: 1px;
+}
+.alert-banner-content {
+  flex: 1;
+  line-height: 1.5;
+}
 
 /* Provider card logo：使用真实 logo 后 fallback 改为纯色字母 */
 .provider-card .provider-logo {
   border: 1px solid var(--border);
 }
-.provider-card .provider-info .name { font-size: 14px; }
+.provider-card .provider-info .name {
+  font-size: 14px;
+}
 .provider-card .provider-default-badge {
   display: inline-flex;
   align-items: center;
@@ -12858,7 +13091,9 @@ body.inspector-resizing {
   color: var(--text-muted);
   overflow: hidden;
 }
-.preset-card.preset-added .preset-card-logo { opacity: 0.5; }
+.preset-card.preset-added .preset-card-logo {
+  opacity: 0.5;
+}
 
 /* ============================================================
    PROVIDER 多选 / 导入导出 样式（import-export task）
@@ -12867,7 +13102,9 @@ body.inspector-resizing {
 /* Provider card 多选态 */
 .provider-card.multi-select {
   cursor: pointer;
-  transition: background 0.12s, border-color 0.12s;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
 .provider-card.multi-select:hover {
   background: var(--bg-soft);
@@ -12884,7 +13121,7 @@ body.inspector-resizing {
   cursor: pointer;
   flex-shrink: 0;
 }
-.provider-card-checkbox input[type="checkbox"] {
+.provider-card-checkbox input[type='checkbox'] {
   width: 16px;
   height: 16px;
   cursor: pointer;
@@ -12937,8 +13174,14 @@ body.inspector-resizing {
   animation: modalIn 0.18s;
 }
 @keyframes modalIn {
-  from { transform: scale(0.96); opacity: 0; }
-  to   { transform: scale(1);    opacity: 1; }
+  from {
+    transform: scale(0.96);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 .modal-header {
   display: flex;
@@ -13000,7 +13243,9 @@ body.inspector-resizing {
   font-family: var(--font-mono, 'Geist Mono', ui-monospace, monospace);
   font-size: 11px;
 }
-.import-meta .muted { color: var(--text-muted); }
+.import-meta .muted {
+  color: var(--text-muted);
+}
 
 .import-mode-row {
   display: flex;
@@ -13020,7 +13265,7 @@ body.inspector-resizing {
 .import-mode-row .radio-row:hover {
   background: var(--bg-soft);
 }
-.import-mode-row .radio-row input[type="radio"] {
+.import-mode-row .radio-row input[type='radio'] {
   accent-color: var(--primary);
   margin: 0;
 }
@@ -13053,7 +13298,9 @@ body.inspector-resizing {
   border-bottom: 1px solid var(--divider);
   font-size: var(--font-sm);
 }
-.import-list-row:last-child { border-bottom: none; }
+.import-list-row:last-child {
+  border-bottom: none;
+}
 .import-list-row.conflict {
   background: rgba(245, 158, 11, 0.05);
 }
@@ -13221,7 +13468,7 @@ body.inspector-resizing {
   max-width: 52ch;
 }
 .team-dispatch-card-task-preview::before {
-  content: "";
+  content: '';
   display: inline-block;
   width: 1px;
   height: 12px;
@@ -13265,7 +13512,11 @@ body.inspector-resizing {
   border: 1px solid color-mix(in srgb, var(--member-accent, var(--primary)) 22%, var(--border));
   border-radius: 8px;
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--member-accent, var(--primary)) 6%, transparent), transparent 72%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--member-accent, var(--primary)) 6%, transparent),
+      transparent 72%
+    ),
     var(--panel);
   box-shadow: 0 8px 22px rgba(15, 23, 42, 0.05);
 }
@@ -13708,8 +13959,8 @@ body.inspector-resizing {
 .chat-main-active > .builtin-terminal-panel {
   /* 由组件 .less 设置 flex:0 0 auto；这里保留占位以便后续微调 */
 }
-.xterm-scrollable-element{
-  background-color: transparent!important;
+.xterm-scrollable-element {
+  background-color: transparent !important;
 }
 
 /* ============================================================
@@ -13772,7 +14023,7 @@ body.inspector-resizing {
   font-size: var(--font-xs);
   color: var(--text-faint);
   font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
+  font-feature-settings: 'tnum';
 }
 .agent-field-counter.over {
   color: var(--danger, #ef4444);
@@ -13841,7 +14092,9 @@ body.inspector-resizing {
   overflow: hidden;
   margin: 0 auto;
   box-shadow: var(--shadow-xs);
-  transition: box-shadow 0.12s ease, border-color 0.12s ease;
+  transition:
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
 }
 .agent-info-avatar .avatar-picker:hover .avatar-picker-preview {
   border-color: color-mix(in srgb, var(--primary) 40%, transparent);
@@ -13890,7 +14143,9 @@ body.inspector-resizing {
   border-radius: var(--r-md);
   background: var(--code-bg);
   overflow: hidden;
-  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+  transition:
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
 }
 .agent-prompt-editor:focus-within {
   border-color: color-mix(in srgb, var(--primary) 50%, transparent);
@@ -13936,7 +14191,10 @@ body.inspector-resizing {
   border: 1px solid transparent;
   border-radius: var(--r-sm);
   cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease;
 }
 .agent-prompt-toolbar-btn:hover {
   background: var(--hover);
@@ -13965,7 +14223,7 @@ body.inspector-resizing {
 }
 .agent-prompt-line-no {
   font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
+  font-feature-settings: 'tnum';
   font-size: 11px;
   line-height: 1.6;
   color: var(--text-faint);
@@ -14021,7 +14279,9 @@ body.inspector-resizing {
   border: 1px solid var(--border);
   border-radius: var(--r-md);
   background: var(--panel);
-  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+  transition:
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
 }
 .agent-config-section.is-interactive {
   cursor: pointer;
@@ -14062,7 +14322,7 @@ body.inspector-resizing {
   border: 1px solid var(--border);
   border-radius: 999px;
   font-variant-numeric: tabular-nums;
-  font-feature-settings: "tnum";
+  font-feature-settings: 'tnum';
 }
 .agent-config-desc {
   margin: 0;

--- a/apps/desktop/src/renderer/design/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/design/views/SettingsView.tsx
@@ -44,7 +44,6 @@ import type {
   RemoteRuntimeStatusResponse,
 } from '@spark/protocol'
 
-
 // 工作流模板暂未实现，保留类型定义以便后续启用
 type WorkflowTemplate = {
   id: string
@@ -393,7 +392,9 @@ export function SettingsView() {
         {isPlatformDarwin && (
           <div
             className="settings-drag-header"
-            onDoubleClick={() => { window.spark?.invoke('window:maximize', {}).catch(() => {}) }}
+            onDoubleClick={() => {
+              window.spark?.invoke('window:maximize', {}).catch(() => {})
+            }}
           />
         )}
         {SectionBody != null ? <SectionBody /> : <PlaceholderSection name={section} />}
@@ -656,6 +657,11 @@ const DEFAULT_REMOTE_CAPABILITIES: RemoteConnectionCapabilities = {
   manageWorkspace: true,
   runCommands: true,
   approvePermissions: false,
+  observeDesktop: true,
+  controlDesktop: false,
+  transferFiles: false,
+  manageRuntime: false,
+  dangerousActions: false,
 }
 
 function splitCsv(value: string): string[] {
@@ -784,7 +790,13 @@ function RemoteConnectionsSection() {
       const status = await window.spark.invoke('remote:runtime-status', {})
       setRuntimeStatus(status)
     } catch {
-      setRuntimeStatus({ running: false, port: null, localBaseUrl: null, polling: [], longConnections: [] })
+      setRuntimeStatus({
+        running: false,
+        port: null,
+        localBaseUrl: null,
+        polling: [],
+        longConnections: [],
+      })
     }
   }, [])
 
@@ -806,7 +818,8 @@ function RemoteConnectionsSection() {
   const saveDraft = async () => {
     setBusy('save')
     try {
-      const payload: Partial<RemoteConnectionConfig> & Pick<RemoteConnectionConfig, 'channel' | 'name'> = {
+      const payload: Partial<RemoteConnectionConfig> &
+        Pick<RemoteConnectionConfig, 'channel' | 'name'> = {
         ...draft,
         status: draft.enabled ? draft.status : 'disabled',
       }
@@ -879,7 +892,9 @@ function RemoteConnectionsSection() {
     setBusy(`pair:${mode}`)
     try {
       const res = await window.spark.invoke('remote:generate-pairing', { id: draft.id, mode })
-      setConnections((prev) => prev.map((item) => (item.id === res.connection.id ? res.connection : item)))
+      setConnections((prev) =>
+        prev.map((item) => (item.id === res.connection.id ? res.connection : item)),
+      )
       setDraft(res.connection)
       await refreshRuntime()
       toast.success(mode === 'qr' ? '二维码配对负载已生成' : '配对码已生成')
@@ -904,7 +919,9 @@ function RemoteConnectionsSection() {
         remoteUserId: manualPairUser.trim(),
         ...(manualPairName.trim().length > 0 ? { displayName: manualPairName.trim() } : {}),
       })
-      setConnections((prev) => prev.map((item) => (item.id === res.connection.id ? res.connection : item)))
+      setConnections((prev) =>
+        prev.map((item) => (item.id === res.connection.id ? res.connection : item)),
+      )
       setDraft(res.connection)
       await refreshRuntime()
       toast.success('配对已确认')
@@ -942,17 +959,22 @@ function RemoteConnectionsSection() {
     }
   }
 
-  const webhookUrl = runtimeStatus.localBaseUrl != null && draft.id
-    ? `${runtimeStatus.localBaseUrl}/remote/webhook/${draft.channel}/${draft.id}`
-    : ''
+  const webhookUrl =
+    runtimeStatus.localBaseUrl != null && draft.id
+      ? `${runtimeStatus.localBaseUrl}/remote/webhook/${draft.channel}/${draft.id}`
+      : ''
   const polling = runtimeStatus.polling.find((item) => item.connectionId === draft.id)
-  const longConnection = runtimeStatus.longConnections.find((item) => item.connectionId === draft.id)
+  const longConnection = runtimeStatus.longConnections.find(
+    (item) => item.connectionId === draft.id,
+  )
   const selectedSession = sessions.find((item) => item.id === draft.defaultSessionId)
 
   return (
     <div className="settings-section remote-settings">
       <h2>远程连接</h2>
-      <div className="lede">通过 Telegram、飞书、QQ、微信 Claw 从远程桌面或移动端与 Spark Agent 通信。</div>
+      <div className="lede">
+        通过 Telegram、飞书、QQ、微信 Claw 从远程桌面或移动端与 Spark Agent 通信。
+      </div>
 
       <div className="remote-create-strip">
         {(Object.keys(REMOTE_CHANNEL_LABELS) as RemoteChannelType[]).map((channel) => (
@@ -983,45 +1005,47 @@ function RemoteConnectionsSection() {
       </div>
 
       <div className="remote-card-grid">
+        <button
+          className={`remote-connection-card ${draft.id === '' ? 'active' : ''}`}
+          onClick={() => {
+            setSelectedId('')
+            setDraft(createRemoteDraft(lastChannel))
+            setEditorOpen(true)
+          }}
+        >
+          <span className="remote-card-main">
+            <span className="remote-card-title">新建连接</span>
+            <span className="remote-card-desc">上次：{REMOTE_CHANNEL_LABELS[lastChannel]}</span>
+          </span>
+          <Icons.Plus size={14} />
+        </button>
+        {loading && <div className="remote-muted-box">加载中...</div>}
+        {connections.map((item) => (
           <button
-            className={`remote-connection-card ${draft.id === '' ? 'active' : ''}`}
+            key={item.id}
+            className={`remote-connection-card ${selectedId === item.id ? 'active' : ''}`}
             onClick={() => {
-              setSelectedId('')
-              setDraft(createRemoteDraft(lastChannel))
+              setSelectedId(item.id)
+              setDraft(item)
+              setManualPairUser('')
+              setManualPairName('')
               setEditorOpen(true)
             }}
           >
             <span className="remote-card-main">
-              <span className="remote-card-title">新建连接</span>
-              <span className="remote-card-desc">上次：{REMOTE_CHANNEL_LABELS[lastChannel]}</span>
+              <span className="remote-card-title">{item.name}</span>
+              <span className="remote-card-desc">{REMOTE_CHANNEL_LABELS[item.channel]}</span>
             </span>
-            <Icons.Plus size={14} />
-          </button>
-          {loading && <div className="remote-muted-box">加载中...</div>}
-          {connections.map((item) => (
-            <button
-              key={item.id}
-              className={`remote-connection-card ${selectedId === item.id ? 'active' : ''}`}
-              onClick={() => {
-                setSelectedId(item.id)
-                setDraft(item)
-                setManualPairUser('')
-                setManualPairName('')
-                setEditorOpen(true)
-              }}
+            <Tag
+              size="small"
+              color={
+                item.status === 'connected' ? 'green' : item.status === 'error' ? 'red' : 'blue'
+              }
             >
-              <span className="remote-card-main">
-                <span className="remote-card-title">{item.name}</span>
-                <span className="remote-card-desc">{REMOTE_CHANNEL_LABELS[item.channel]}</span>
-              </span>
-              <Tag
-                size="small"
-                color={item.status === 'connected' ? 'green' : item.status === 'error' ? 'red' : 'blue'}
-              >
-                {REMOTE_STATUS_LABELS[item.status]}
-              </Tag>
-            </button>
-          ))}
+              {REMOTE_STATUS_LABELS[item.status]}
+            </Tag>
+          </button>
+        ))}
       </div>
 
       <Modal
@@ -1033,6 +1057,33 @@ function RemoteConnectionsSection() {
         maskClosable={false}
       >
         <div className="remote-editor">
+          <div className="remote-actions remote-actions-sticky">
+            <Button
+              type="primary"
+              size="small"
+              loading={busy === 'save'}
+              onClick={() => void saveDraft()}
+            >
+              保存连接
+            </Button>
+            <Button
+              size="small"
+              loading={busy === 'test'}
+              disabled={!draft.id}
+              onClick={() => void testConnection()}
+            >
+              测试配置
+            </Button>
+            <Button
+              size="small"
+              danger
+              loading={busy === 'delete'}
+              onClick={() => void deleteConnection()}
+            >
+              删除
+            </Button>
+          </div>
+
           <div className="subsec-h">连接配置</div>
           <div className="form-grid remote-form-grid">
             <label>
@@ -1059,12 +1110,18 @@ function RemoteConnectionsSection() {
             <label>
               启用连接<span className="sub">停用后不会接收远程消息</span>
             </label>
-            <div className={`switch ${draft.enabled ? 'on' : ''}`} onClick={() => updateDraft({ enabled: !draft.enabled })} />
+            <div
+              className={`switch ${draft.enabled ? 'on' : ''}`}
+              onClick={() => updateDraft({ enabled: !draft.enabled })}
+            />
 
             <label>
               命令前缀<span className="sub">Telegram 可同步为 bot command</span>
             </label>
-            <Input value={draft.commandPrefix} onChange={(e) => updateDraft({ commandPrefix: e.target.value || '/' })} />
+            <Input
+              value={draft.commandPrefix}
+              onChange={(e) => updateDraft({ commandPrefix: e.target.value || '/' })}
+            />
 
             <label>
               默认会话<span className="sub">普通远程消息会投递到这里</span>
@@ -1144,26 +1201,23 @@ function RemoteConnectionsSection() {
 
           <div className="subsec-h">远程功能</div>
           <div className="remote-cap-grid">
-            {(Object.entries(draft.capabilities) as Array<[keyof RemoteConnectionCapabilities, boolean]>).map(([key, value]) => (
+            {(
+              Object.entries(draft.capabilities) as Array<
+                [keyof RemoteConnectionCapabilities, boolean]
+              >
+            ).map(([key, value]) => (
               <SettingsRow
                 key={key}
                 title={REMOTE_CAPABILITY_LABELS[key]}
                 desc={REMOTE_CAPABILITY_DESCS[key]}
-                right={<div className={`switch ${value ? 'on' : ''}`} onClick={() => updateCapability(key, !value)} />}
+                right={
+                  <div
+                    className={`switch ${value ? 'on' : ''}`}
+                    onClick={() => updateCapability(key, !value)}
+                  />
+                }
               />
             ))}
-          </div>
-
-          <div className="remote-actions">
-            <Button type="primary" size="small" loading={busy === 'save'} onClick={() => void saveDraft()}>
-              保存连接
-            </Button>
-            <Button size="small" loading={busy === 'test'} disabled={!draft.id} onClick={() => void testConnection()}>
-              测试配置
-            </Button>
-            <Button size="small" danger loading={busy === 'delete'} onClick={() => void deleteConnection()}>
-              删除
-            </Button>
           </div>
 
           <div className="subsec-h">配对</div>
@@ -1171,19 +1225,34 @@ function RemoteConnectionsSection() {
             {webhookUrl && draft.channel !== 'telegram' && draft.channel !== 'feishu' && (
               <div className="remote-webhook-box">
                 <span>{webhookUrl}</span>
-                <Button size="small" onClick={() => void navigator.clipboard?.writeText(webhookUrl)}>
+                <Button
+                  size="small"
+                  onClick={() => void navigator.clipboard?.writeText(webhookUrl)}
+                >
                   复制 webhook
                 </Button>
               </div>
             )}
             {selectedSession == null && draft.defaultSessionId != null && (
-              <div className="remote-muted-box">当前默认会话未在最近会话列表中找到：{draft.defaultSessionId}</div>
+              <div className="remote-muted-box">
+                当前默认会话未在最近会话列表中找到：{draft.defaultSessionId}
+              </div>
             )}
             <div className="remote-pairing-actions">
-              <Button size="small" disabled={!draft.id} loading={busy === 'pair:code'} onClick={() => void generatePairing('code')}>
+              <Button
+                size="small"
+                disabled={!draft.id}
+                loading={busy === 'pair:code'}
+                onClick={() => void generatePairing('code')}
+              >
                 生成配对码
               </Button>
-              <Button size="small" disabled={!draft.id} loading={busy === 'pair:qr'} onClick={() => void generatePairing('qr')}>
+              <Button
+                size="small"
+                disabled={!draft.id}
+                loading={busy === 'pair:qr'}
+                onClick={() => void generatePairing('qr')}
+              >
                 生成二维码配对
               </Button>
             </div>
@@ -1192,13 +1261,28 @@ function RemoteConnectionsSection() {
                 <div>
                   <div className="remote-pair-code">{draft.pairing.code}</div>
                   <div className="remote-pair-tip">
-                    在 {REMOTE_CHANNEL_LABELS[draft.channel]} 中发送 <code>/bind {draft.pairing.code}</code> 完成配对。
+                    在 {REMOTE_CHANNEL_LABELS[draft.channel]} 中发送{' '}
+                    <code>/bind {draft.pairing.code}</code> 完成配对。
                   </div>
-                  <div className="muted text-xs-12">过期时间：{new Date(draft.pairing.expiresAt).toLocaleString()}</div>
+                  <div className="muted text-xs-12">
+                    过期时间：{new Date(draft.pairing.expiresAt).toLocaleString()}
+                  </div>
                   <div className="remote-manual-pair">
-                    <Input value={manualPairUser} onChange={(e) => setManualPairUser(e.target.value)} placeholder="远程用户 ID" />
-                    <Input value={manualPairName} onChange={(e) => setManualPairName(e.target.value)} placeholder="显示名称（可选）" />
-                    <Button size="small" loading={busy === 'confirm-pair'} onClick={() => void confirmPairing()}>
+                    <Input
+                      value={manualPairUser}
+                      onChange={(e) => setManualPairUser(e.target.value)}
+                      placeholder="远程用户 ID"
+                    />
+                    <Input
+                      value={manualPairName}
+                      onChange={(e) => setManualPairName(e.target.value)}
+                      placeholder="显示名称（可选）"
+                    />
+                    <Button
+                      size="small"
+                      loading={busy === 'confirm-pair'}
+                      onClick={() => void confirmPairing()}
+                    >
                       手动确认
                     </Button>
                   </div>
@@ -1206,7 +1290,9 @@ function RemoteConnectionsSection() {
                 <QrPayloadPreview payload={draft.pairing.qrPayload} />
               </div>
             ) : (
-              <div className="remote-muted-box">连接保存后生成一次性配对码，然后在远程聊天里发送 /bind 配对码 完成绑定。</div>
+              <div className="remote-muted-box">
+                连接保存后生成一次性配对码，然后在远程聊天里发送 /bind 配对码 完成绑定。
+              </div>
             )}
             {draft.pairedDevices.length > 0 && (
               <div className="remote-paired-list">
@@ -1242,6 +1328,11 @@ const REMOTE_CAPABILITY_LABELS: Record<keyof RemoteConnectionCapabilities, strin
   manageWorkspace: '查看工作区',
   runCommands: '运行内置命令',
   approvePermissions: '远程审批权限',
+  observeDesktop: '观察桌面',
+  controlDesktop: '控制桌面',
+  transferFiles: '传输文件',
+  manageRuntime: '管理运行时',
+  dangerousActions: '高危动作确认',
 }
 
 const REMOTE_CAPABILITY_DESCS: Record<keyof RemoteConnectionCapabilities, string> = {
@@ -1252,6 +1343,11 @@ const REMOTE_CAPABILITY_DESCS: Record<keyof RemoteConnectionCapabilities, string
   manageWorkspace: '允许 /workspaces 查看项目入口',
   runCommands: '允许解析命令前缀并执行命令目录',
   approvePermissions: '预留给远程 allow/deny 审批，默认关闭',
+  observeDesktop: '允许 /screen、/windows 查看桌面与窗口概览',
+  controlDesktop: '允许 /focus、/click、/type、/hotkey 等桌面控制命令，默认关闭',
+  transferFiles: '预留给远程文件上传、下载与摘要读取，默认关闭',
+  manageRuntime: '允许 /progress、/queue、/history、/cancel 管理远程任务',
+  dangerousActions: '允许 /confirm 确认高危动作，仍需二次确认',
 }
 
 function RemoteCredentialFields({
@@ -1265,7 +1361,11 @@ function RemoteCredentialFields({
     return (
       <>
         <label>Bot Token</label>
-        <Input value={draft.credentials.botToken ?? ''} onChange={(e) => updateCredential('botToken', e.target.value)} placeholder="123456:ABC..." />
+        <Input
+          value={draft.credentials.botToken ?? ''}
+          onChange={(e) => updateCredential('botToken', e.target.value)}
+          placeholder="123456:ABC..."
+        />
       </>
     )
   }
@@ -1273,9 +1373,15 @@ function RemoteCredentialFields({
     return (
       <>
         <label>App ID</label>
-        <Input value={draft.credentials.appId ?? ''} onChange={(e) => updateCredential('appId', e.target.value)} />
+        <Input
+          value={draft.credentials.appId ?? ''}
+          onChange={(e) => updateCredential('appId', e.target.value)}
+        />
         <label>App Secret</label>
-        <Input value={draft.credentials.appSecret ?? ''} onChange={(e) => updateCredential('appSecret', e.target.value)} />
+        <Input
+          value={draft.credentials.appSecret ?? ''}
+          onChange={(e) => updateCredential('appSecret', e.target.value)}
+        />
       </>
     )
   }
@@ -1283,20 +1389,36 @@ function RemoteCredentialFields({
     return (
       <>
         <label>机器人 AppID</label>
-        <Input value={draft.credentials.qqBotAppId ?? ''} onChange={(e) => updateCredential('qqBotAppId', e.target.value)} />
+        <Input
+          value={draft.credentials.qqBotAppId ?? ''}
+          onChange={(e) => updateCredential('qqBotAppId', e.target.value)}
+        />
         <label>机器人 Token</label>
-        <Input value={draft.credentials.qqBotToken ?? ''} onChange={(e) => updateCredential('qqBotToken', e.target.value)} />
+        <Input
+          value={draft.credentials.qqBotToken ?? ''}
+          onChange={(e) => updateCredential('qqBotToken', e.target.value)}
+        />
         <label>机器人 Secret</label>
-        <Input value={draft.credentials.qqBotSecret ?? ''} onChange={(e) => updateCredential('qqBotSecret', e.target.value)} />
+        <Input
+          value={draft.credentials.qqBotSecret ?? ''}
+          onChange={(e) => updateCredential('qqBotSecret', e.target.value)}
+        />
       </>
     )
   }
   return (
     <>
       <label>Claw Endpoint</label>
-      <Input value={draft.credentials.clawEndpoint ?? ''} onChange={(e) => updateCredential('clawEndpoint', e.target.value)} placeholder="http://127.0.0.1:..." />
+      <Input
+        value={draft.credentials.clawEndpoint ?? ''}
+        onChange={(e) => updateCredential('clawEndpoint', e.target.value)}
+        placeholder="http://127.0.0.1:..."
+      />
       <label>Access Token</label>
-      <Input value={draft.credentials.clawAccessToken ?? ''} onChange={(e) => updateCredential('clawAccessToken', e.target.value)} />
+      <Input
+        value={draft.credentials.clawAccessToken ?? ''}
+        onChange={(e) => updateCredential('clawAccessToken', e.target.value)}
+      />
     </>
   )
 }
@@ -1308,7 +1430,14 @@ function QrPayloadPreview({ payload }: { payload: string }) {
       title={payload}
       onClick={() => void navigator.clipboard?.writeText(payload)}
     >
-      <QRCodeSVG value={payload} size={128} level="M" includeMargin bgColor="transparent" fgColor="currentColor" />
+      <QRCodeSVG
+        value={payload}
+        size={128}
+        level="M"
+        includeMargin
+        bgColor="transparent"
+        fgColor="currentColor"
+      />
       <small>点击复制二维码负载</small>
     </button>
   )
@@ -1701,14 +1830,7 @@ export function ProfileEditModal({ onClose }: { onClose: () => void }) {
 
             <label>Temperature</label>
             <div className="control">
-              <Input
-                type="range"
-                min="0"
-                max="2"
-                step="0.1"
-                defaultValue="0.7"
-                className="flex1"
-              />
+              <Input type="range" min="0" max="2" step="0.1" defaultValue="0.7" className="flex1" />
               <span className="mono-sm muted range-value">0.7</span>
             </div>
 
@@ -3041,9 +3163,7 @@ function SystemPromptSection() {
       <div className="row section-header-row">
         <div className="flex1">
           <h2 className="section-h2">系统提示词</h2>
-          <div className="lede section-lede">
-            配置全局系统级提示词，作为所有 Agent 的基础指令。
-          </div>
+          <div className="lede section-lede">配置全局系统级提示词，作为所有 Agent 的基础指令。</div>
         </div>
         {isDirty && <span className="badge warning dot">未保存</span>}
       </div>
@@ -3086,7 +3206,6 @@ function SystemPromptSection() {
     </div>
   )
 }
-
 
 /* ───────── WORKFLOW TEMPLATES ───────── */
 // 工作流模板暂未实现，从导航和 Section 映射中移除
@@ -4012,9 +4131,10 @@ function StorageSection() {
       })
       if (selected.canceled || selected.filePath === undefined) return
       const current = await getSetting({ category: 'canvas', key: 'data' })
-      const currentValue = current.value && typeof current.value === 'object'
-        ? current.value as Record<string, unknown>
-        : {}
+      const currentValue =
+        current.value && typeof current.value === 'object'
+          ? (current.value as Record<string, unknown>)
+          : {}
       await setSetting({
         category: 'canvas',
         key: 'data',
@@ -4046,7 +4166,9 @@ function StorageSection() {
         moved += result.movedAssets
         skipped += result.skippedAssets
       }
-      toast.success(`迁移完成：${moved} 个资源已归档到项目目录${skipped > 0 ? `，${skipped} 个跳过` : ''}`)
+      toast.success(
+        `迁移完成：${moved} 个资源已归档到项目目录${skipped > 0 ? `，${skipped} 个跳过` : ''}`,
+      )
       await refreshStats()
     } catch (err) {
       toast.error(err instanceof Error ? err.message : '迁移画布资源失败')
@@ -4089,11 +4211,7 @@ function StorageSection() {
       <div className="form-grid">
         <label>数据目录</label>
         <div className="control">
-          <Input
-            className="flex1"
-            value={stats?.userDataPath ?? '加载中...'}
-            readOnly
-          />
+          <Input className="flex1" value={stats?.userDataPath ?? '加载中...'} readOnly />
           <button className="btn" onClick={handleOpenDataDir}>
             <Icons.Folder size={12} /> 打开
           </button>
@@ -4120,7 +4238,11 @@ function StorageSection() {
           Canvas 项目根目录<span className="sub">新建画布项目默认保存位置</span>
         </label>
         <div className="control">
-          <Input className="flex1" value={canvasProjectsRoot || stats?.canvasProjectsRoot || '加载中...'} readOnly />
+          <Input
+            className="flex1"
+            value={canvasProjectsRoot || stats?.canvasProjectsRoot || '加载中...'}
+            readOnly
+          />
           <button className="btn" onClick={() => void handleChooseCanvasRoot()}>
             <Icons.Folder size={12} /> 选择
           </button>
@@ -4880,7 +5002,10 @@ function UpdatesSection() {
   const handleSettingsChange = (key: keyof UpdatesSettings, value: boolean | string) => {
     set({ [key]: value })
     const patch: Record<string, boolean | string> = {}
-    if ((key === 'autoCheck' || key === 'autoDownload' || key === 'autoInstall') && typeof value === 'boolean') {
+    if (
+      (key === 'autoCheck' || key === 'autoDownload' || key === 'autoInstall') &&
+      typeof value === 'boolean'
+    ) {
       patch[key] = value
     }
     if (key === 'channel' && typeof value === 'string') {
@@ -4899,9 +5024,8 @@ function UpdatesSection() {
   const isDownloaded = state === 'downloaded'
   const isError = state === 'error'
   const currentVersion = status?.currentVersion ?? '0.1.0'
-  const lastChecked = status?.lastCheckedAt != null
-    ? new Date(status.lastCheckedAt).toLocaleString('zh-CN')
-    : null
+  const lastChecked =
+    status?.lastCheckedAt != null ? new Date(status.lastCheckedAt).toLocaleString('zh-CN') : null
 
   // Update card status icon and label
   const getStatusIcon = () => {
@@ -4974,11 +5098,7 @@ function UpdatesSection() {
               下载更新
             </Button>
           ) : isDownloading ? (
-            <Button
-              icon={<Icons.Download size={14} />}
-              className="update-action-btn"
-              disabled
-            >
+            <Button icon={<Icons.Download size={14} />} className="update-action-btn" disabled>
               下载中 {status?.progress != null ? `${Math.round(status.progress.percent)}%` : ''}
             </Button>
           ) : (
@@ -5025,15 +5145,15 @@ function UpdatesSection() {
         <SettingsRow
           title="自动下载"
           desc="为避免误下载，检测到新版本后仅显示更新按钮，需要手动点击下载"
-          right={
-            <div
-              className="switch disabled"
-            />
-          }
+          right={<div className="switch disabled" />}
         />
         <SettingsRow
           title="自动安装"
-          desc={autoInstallSupported ? '退出应用时自动启动安装器' : '当前平台不支持自动安装，下载后需手动打开安装包'}
+          desc={
+            autoInstallSupported
+              ? '退出应用时自动启动安装器'
+              : '当前平台不支持自动安装，下载后需手动打开安装包'
+          }
           right={
             <div
               className={`switch ${s.autoInstall ? 'on' : ''} ${autoInstallSupported ? '' : 'disabled'}`.trim()}
@@ -5353,7 +5473,10 @@ const HOOK_NODE_LABELS: Record<HookNodeType, { label: string; desc: string }> = 
   session_fail: { label: '任务失败', desc: '任务执行出错' },
 }
 
-const HOOK_NODE_ICONS: Record<HookNodeType, (p: { size?: number; className?: string }) => React.JSX.Element> = {
+const HOOK_NODE_ICONS: Record<
+  HookNodeType,
+  (p: { size?: number; className?: string }) => React.JSX.Element
+> = {
   permission_request: Icons.Shield,
   ask_user_question: Icons.Chat,
   session_end: Icons.CheckCircle,
@@ -5442,7 +5565,9 @@ function HooksSection() {
                       </div>
                       <div
                         className={`switch ${nodeConfig.notification ? 'on' : ''}`}
-                        onClick={() => updateNodeConfig(node, 'notification', !nodeConfig.notification)}
+                        onClick={() =>
+                          updateNodeConfig(node, 'notification', !nodeConfig.notification)
+                        }
                       />
                     </div>
                     <div className="hook-toggle-row">

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -3333,6 +3333,11 @@ export interface RemoteConnectionCapabilities {
   manageWorkspace: boolean
   runCommands: boolean
   approvePermissions: boolean
+  observeDesktop: boolean
+  controlDesktop: boolean
+  transferFiles: boolean
+  manageRuntime: boolean
+  dangerousActions: boolean
 }
 
 export interface RemotePairedDevice {

--- a/packages/protocol/src/schemas/index.ts
+++ b/packages/protocol/src/schemas/index.ts
@@ -75,6 +75,11 @@ const RemoteCapabilitiesSchema = z.object({
   manageWorkspace: z.boolean(),
   runCommands: z.boolean(),
   approvePermissions: z.boolean(),
+  observeDesktop: z.boolean().optional(),
+  controlDesktop: z.boolean().optional(),
+  transferFiles: z.boolean().optional(),
+  manageRuntime: z.boolean().optional(),
+  dangerousActions: z.boolean().optional(),
 })
 
 const RemoteConnectionPatchSchema = z.object({


### PR DESCRIPTION
### Motivation
- Improve remote command UX by allowing selection by index/name/ID, caching recent lists, and clearer help/status output. 
- Add basic audit and runtime management commands for visibility into queues/history and surface desktop observation placeholders while keeping dangerous control ops gated. 
- Surface new remote capability flags and controls in the Settings UI and protocol so administrators can enable/disable features like desktop observation and runtime management.

### Description
- Implemented selection helpers and caching in `apps/desktop/src/main/ipc/index.ts`, including `cacheRemoteSelection`, `getCachedRemoteSelection`, `resolveRemoteSelection`, `remoteAuditLog`, and `appendRemoteAudit`, and expanded `executeRemoteCommand` with grouped `help`, `status`, `sessions/models/providers/agents/workspaces` listing that caches rows, and new commands (`progress`, `queue`, `history`, `cancel`, `stop`, `screen`, `windows`, placeholders for `focus/click/type/hotkey`, and `confirm`).
- Expanded `RemoteConnectionService` defaults and command catalog, improved webhook parsing/formatting and token handling, added new capability flags in `DEFAULT_CAPABILITIES` and enriched command metadata in `COMMAND_CATALOG`, and made supporting changes to request/response handling and internal utilities (formatting, caching, and stylistic cleanups). 
- Updated renderer and styles: `apps/desktop/src/renderer/design/views/SettingsView.tsx` adds UI for new capabilities, enhances the remote editor modal (sticky action bar, QR preview, command listing), and many small JSX/formatting improvements; `apps/desktop/src/renderer/design/styles/views.css` introduces layout and style adjustments (new classes like `.remote-actions-sticky`, various CSS formatting changes). 
- Protocol/schema changes: added new capability fields to `packages/protocol/src/ipc/index.ts` and made them available in Zod schemas in `packages/protocol/src/schemas/index.ts` (fields marked optional where appropriate) so settings and IPC types reflect the new permissions.

### Testing
- Built the project with `yarn build` and the build completed successfully. 
- Ran the unit/integration test suite with `yarn test` and all tests passed. 
- Ran static checks with `yarn lint` and formatting checks, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33a72f3de0832eb27208a4960c4630)