### PR TITLE
fix(skills): 内置技能对 agent 不可见/不可用、技能数虚高、skills_list 溢出

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -1112,7 +1112,10 @@ export function initializeAppSkills(): void {
     const manager = getAppSkillsManager()
     const skillService = getSkillService()
 
-    // 1. 宿主机技能自动软链 + 登记
+    // 1. 内置技能登记/刷新（先做，保证 builtin:* 行存在，参与后续去重的"规范名"集合）
+    skillService.ensureBuiltInSkills()
+
+    // 2. 宿主机 Claude/Codex 技能自动软链 + 登记（默认启用）
     const hostLinks = manager.autoImportHostSkills()
     for (const link of hostLinks) {
       try {
@@ -1122,15 +1125,15 @@ export function initializeAppSkills(): void {
       }
     }
 
-    // 2. 内置技能登记/刷新
-    skillService.ensureBuiltInSkills()
+    // 3. 清理重复的宿主软链行（与内置/已装/本地导入同名，或软链彼此同名）
+    const pruned = skillService.pruneDuplicateLinkedSkills()
 
-    // 3. 重建托管插件目录
+    // 4. 重建托管插件目录（仅含去重后的已启用技能）
     rebuildManagedSkillsPlugin()
 
-    // 4. 注入插件目录（Claude 原生渐进式披露）
+    // 5. 注入插件目录（Claude 原生渐进式披露）
     getSessionService().setSkillsPluginDir(manager.managedPluginDir)
-    log.info(`App skills initialized: ${hostLinks.length} host skill(s) linked`)
+    log.info(`App skills initialized: ${hostLinks.length} host skill(s) linked, ${pruned} duplicate(s) pruned`)
   } catch (err) {
     log.warn(`initializeAppSkills failed: ${String(err)}`)
   }

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useCallback, useRef, useState } from 'react'
 import {
   AppProvider,
+  AppDialogHost,
   useApp,
   PRIMARIES,
   FLOATING_SIDEBAR_WIDTH_MIN,
@@ -890,6 +891,7 @@ export function App() {
           <ToastProvider>
             <SessionSidebarProvider>
               <GateAwareShell />
+              <AppDialogHost />
             </SessionSidebarProvider>
           </ToastProvider>
         </AuthProvider>

--- a/apps/desktop/src/renderer/design/AppContext.tsx
+++ b/apps/desktop/src/renderer/design/AppContext.tsx
@@ -8,7 +8,6 @@ import type { ReactNode } from 'react'
 import { ConfirmDialog } from './components/ConfirmDialog'
 import { PromptDialog } from './components/PromptDialog'
 import { applyArcoTheme } from './arcoTheme'
-import { LobeThemeProvider } from './theme/LobeThemeProvider'
 
 export type NavGuard = () => boolean | Promise<boolean>
 
@@ -160,6 +159,7 @@ type AppCtx = {
   registerNavGuard: (guard: NavGuard | null) => void
   requestConfirm: (options: ConfirmOptions) => Promise<boolean>
   requestPrompt: (options: PromptOptions) => Promise<string | null>
+  dialogHost: DialogHostProps
 }
 
 const Ctx = createContext<AppCtx | null>(null)
@@ -253,50 +253,56 @@ export function AppProvider({ children }: { children: ReactNode }) {
     root.classList.add(`density-${t.density}`)
   }, [t.density])
   const value = useMemo<AppCtx>(
-    () => ({ t, setTweak, registerNavGuard, requestConfirm, requestPrompt }),
-    [t, setTweak, registerNavGuard, requestConfirm, requestPrompt],
-  )
-  return (
-    <Ctx.Provider value={value}>
-      {children}
-      {/*
-        ConfirmDialog/PromptDialog 用 @lobehub/ui(antd v6) 的 Modal，antd 的暗色主题
-        只通过 React ConfigProvider context 传递（不读 CSS 变量）。而 AppProvider 位于
-        LobeThemeBridge(ThemeProvider) 的外层，弹窗默认拿不到 darkAlgorithm → 暗色下仍是
-        亮色背景。这里用一个局部 LobeThemeProvider 包裹，使弹窗获得正确的 antd 主题。
-      */}
-      <DialogHost
-        confirmRequest={confirmRequest}
-        promptRequest={promptRequest}
-        themeMode={t.theme}
-        primary={t.primary}
-        onConfirmResolve={(v) => {
+    () => ({
+      t,
+      setTweak,
+      registerNavGuard,
+      requestConfirm,
+      requestPrompt,
+      dialogHost: {
+        confirmRequest,
+        promptRequest,
+        onConfirmResolve: (v) => {
           confirmHandledRef.current = true
           confirmRequest?.resolve(v)
           setConfirmRequest(null)
-        }}
-        onConfirmCancel={() => {
+        },
+        onConfirmCancel: () => {
           if (confirmHandledRef.current) {
             confirmHandledRef.current = false
             return
           }
           confirmRequest?.resolve(false)
           setConfirmRequest(null)
-        }}
-        onPromptResolve={(v) => {
+        },
+        onPromptResolve: (v) => {
           promptHandledRef.current = true
           promptRequest?.resolve(v)
           setPromptRequest(null)
-        }}
-        onPromptCancel={() => {
+        },
+        onPromptCancel: () => {
           if (promptHandledRef.current) {
             promptHandledRef.current = false
             return
           }
           promptRequest?.resolve(null)
           setPromptRequest(null)
-        }}
-      />
+        },
+      },
+    }),
+    [
+      t,
+      setTweak,
+      registerNavGuard,
+      requestConfirm,
+      requestPrompt,
+      confirmRequest,
+      promptRequest,
+    ],
+  )
+  return (
+    <Ctx.Provider value={value}>
+      {children}
     </Ctx.Provider>
   )
 }
@@ -304,35 +310,25 @@ export function AppProvider({ children }: { children: ReactNode }) {
 type ConfirmRequest = ConfirmOptions & { resolve: (value: boolean) => void }
 type PromptRequest = PromptOptions & { resolve: (value: string | null) => void }
 
-/**
- * DialogHost — 渲染 ConfirmDialog/PromptDialog，并用局部 LobeThemeProvider 包裹，
- * 使 antd 组件获得与当前主题匹配的 ConfigProvider（dark/light 算法）。
- */
-function DialogHost({
-  confirmRequest,
-  promptRequest,
-  themeMode,
-  primary,
-  onConfirmResolve,
-  onConfirmCancel,
-  onPromptResolve,
-  onPromptCancel,
-}: {
+type DialogHostProps = {
   confirmRequest: ConfirmRequest | null
   promptRequest: PromptRequest | null
-  themeMode: ThemeMode
-  primary: string
   onConfirmResolve: (v: boolean) => void
   onConfirmCancel: () => void
   onPromptResolve: (v: string | null) => void
   onPromptCancel: () => void
-}) {
-  const resolvedTheme: ResolvedTheme =
-    themeMode === 'system'
-      ? (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-      : themeMode
+}
+
+function DialogHost({
+  confirmRequest,
+  promptRequest,
+  onConfirmResolve,
+  onConfirmCancel,
+  onPromptResolve,
+  onPromptCancel,
+}: DialogHostProps) {
   return (
-    <LobeThemeProvider themeMode={themeMode} resolvedTheme={resolvedTheme} primary={primary}>
+    <>
       <ConfirmDialog
         open={confirmRequest != null}
         title={confirmRequest?.title ?? ''}
@@ -360,8 +356,14 @@ function DialogHost({
         }}
         onConfirm={(value) => onPromptResolve(value)}
       />
-    </LobeThemeProvider>
+    </>
   )
+}
+
+export function AppDialogHost() {
+  const v = useContext(Ctx)
+  if (!v) return null
+  return <DialogHost {...v.dialogHost} />
 }
 
 export function useApp(): AppCtx {

--- a/apps/desktop/src/renderer/design/styles/styles.css
+++ b/apps/desktop/src/renderer/design/styles/styles.css
@@ -176,6 +176,26 @@ body,
   min-height: 100dvh;
   overflow: hidden;
 }
+
+#root > .ant-app:first-child {
+  margin: 0;
+  padding: 0;
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+#root > .ant-app:not(:first-child):empty {
+  pointer-events: none;
+}
 body {
   font-family: var(--font-sans);
   font-size: var(--font-base);

--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -3168,8 +3168,8 @@ body.sidebar-resizing {
 }
 .composer-expand-btn {
   position: absolute;
-  top: 10px;
-  right: 12px;
+  top: 4px;
+  right: 10px;
   z-index: 2;
   width: auto;
   height: 28px;

--- a/apps/desktop/src/renderer/design/utils/skills-data.ts
+++ b/apps/desktop/src/renderer/design/utils/skills-data.ts
@@ -215,6 +215,8 @@ export function useSkills(): UseSkillsResult {
     [removeSkill, refresh]
   )
 
+  // 计数按去重（同名）口径，与下方分区展示一致，避免"宿主软链重复"导致数字虚高。
+  const dedupedSkills = deduplicateSkills(skills)
   return {
     skills,
     loading,
@@ -222,7 +224,7 @@ export function useSkills(): UseSkillsResult {
     refresh,
     toggleSkill,
     deleteSkill,
-    total: skills.length,
-    enabledCount: skills.filter((s) => s.enabled).length,
+    total: dedupedSkills.length,
+    enabledCount: dedupedSkills.filter((s) => s.enabled).length,
   }
 }

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -8114,7 +8114,7 @@ function ComposerV2({
               <span className="composer-team-banner-text">
                 Host：{activeAgent?.name ?? '平台管理'} · 成员 {teamConfig.memberAgentIds.length}
               </span>
-              <button type="button" onClick={onOpenTeamInspector} disabled={isBusy}>
+              <button type="button" style={{paddingRight: 20}} onClick={onOpenTeamInspector} disabled={isBusy}>
                 管理成员
               </button>
             </div>

--- a/apps/desktop/src/renderer/design/views/SkillStoreView.less
+++ b/apps/desktop/src/renderer/design/views/SkillStoreView.less
@@ -386,7 +386,7 @@
 .skill-store-prompt-preview {
   margin: 0;
   padding: var(--pad-md, 12px);
-  max-height: 300px;
+  max-height: 600px;
   overflow: auto;
   border-radius: var(--r-md, 8px);
   border: 1px solid var(--border);

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -21,6 +21,11 @@
   overflow: hidden;
 }
 
+.main-content-canvas-workspace .view-body {
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
+
 [data-theme='light'] .canvas-workspace {
   --canvas-field-bg: color-mix(in srgb, var(--panel) 82%, var(--bg-sunken));
   --canvas-float-bg: color-mix(in srgb, var(--panel) 92%, transparent);

--- a/packages/agent-runtime/src/services/platform-bridge.service.ts
+++ b/packages/agent-runtime/src/services/platform-bridge.service.ts
@@ -265,22 +265,30 @@ export class PlatformBridgeService {
   // ── Skill handlers ──
 
   private skillList(d: PlatformBridgeDeps, _params: Record<string, unknown>) {
-    const rows = d.skillLoader.listAll()
-    return {
-      skills: rows.map((s) => {
-        const def = s.definition
-        const db = s.dbRecord
-        return {
-          id: db?.id ?? def?.id ?? '',
-          name: db?.name ?? def?.name ?? '',
-          description: def?.description ?? '',
-          category: def?.category ?? '',
-          version: db?.version ?? def?.version ?? '',
-          author: def?.author ?? '',
-          enabled: db?.enabled ?? true,
-        }
-      }),
+    // 内置优先排序 → 按名去重 → 截断描述 → 限量，避免大量宿主技能导致结果超出 token 上限。
+    const rows = [...d.skillLoader.listAll()].sort((a, b) => Number(b.builtin) - Number(a.builtin))
+    const seen = new Set<string>()
+    const skills: Array<Record<string, unknown>> = []
+    for (const s of rows) {
+      const def = s.definition
+      const db = s.dbRecord
+      const id = db?.id ?? def?.id ?? ''
+      const name = db?.name ?? def?.name ?? ''
+      if (!id || !name) continue
+      const key = name.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      skills.push({
+        id,
+        name,
+        description: truncateText(def?.description ?? '', 140),
+        category: def?.category ?? '',
+        source: skillSourceLabel(id),
+        enabled: db?.enabled ?? true,
+      })
+      if (skills.length >= 200) break
     }
+    return { skills, total: skills.length }
   }
 
   /**
@@ -1010,6 +1018,23 @@ export class PlatformBridgeService {
     this.writeBoardTasks(filtered)
     return { success: true }
   }
+}
+
+/** 截断文本到指定长度，超出加省略号 */
+function truncateText(text: string, max: number): string {
+  const t = text.replace(/\s+/g, ' ').trim()
+  return t.length <= max ? t : `${t.slice(0, max)}…`
+}
+
+/** 由技能 id 前缀推断来源标签（用于 agent 判断技能层级） */
+function skillSourceLabel(id: string): string {
+  if (id.startsWith('builtin:')) return '内置'
+  if (id.startsWith('local:linked:')) return '宿主软链'
+  if (id.startsWith('local:')) return '本地导入'
+  if (id.startsWith('skill:github:')) return 'GitHub'
+  if (id.startsWith('skill:')) return '市场安装'
+  if (id.startsWith('user:')) return '用户创建'
+  return '其他'
 }
 
 /** 去掉 Markdown 文件开头的 YAML frontmatter，返回正文 */

--- a/packages/agent-runtime/src/services/runtime-composition.service.ts
+++ b/packages/agent-runtime/src/services/runtime-composition.service.ts
@@ -85,12 +85,18 @@ export class RuntimeCompositionService {
     const sessionDisabledSkillIds = refs.sessionId != null ? this.getDisabledSkillIds('session', refs.sessionId) : []
     const disabledIds = new Set([...agentDisabledSkillIds, ...projectDisabledSkillIds, ...sessionDisabledSkillIds])
 
+    // 内置技能（builtin:*）对所有 agent 默认可用，无需显式绑定：把已启用的内置 id
+    // 始终并入 base。仍会经下方 enabledIds/disabledIds 过滤，故用户显式禁用仍生效。
+    const builtinIds = Array.from(enabledIds).filter((id) => id.startsWith('builtin:'))
+
     // The agent's configured skills define the base set.
     // If the agent has no skillIds configured, fall back to all
     // system-enabled skills for backward compatibility. Project and session layers are
-    // always additive on top.
+    // always additive on top. Built-in skills are always included on top.
     const hasAgentSkillConfig = agentSkillIds.length > 0
-    const base = hasAgentSkillConfig ? agentSkillIds : Array.from(enabledIds)
+    const base = hasAgentSkillConfig
+      ? uniqueStrings([...builtinIds, ...agentSkillIds])
+      : Array.from(enabledIds)
     const ordered = uniqueStrings([
       ...base,
       ...projectSkillIds,

--- a/packages/agent-runtime/src/services/skill.service.ts
+++ b/packages/agent-runtime/src/services/skill.service.ts
@@ -50,6 +50,38 @@ export class SkillService {
     return this.repo.deleteById(id)
   }
 
+  /**
+   * 清理重复的「宿主软链」技能行（local:linked:*）：
+   *   - 与任意非软链技能（内置 / 市场 / 本地导入 / 用户创建）同名 → 删除软链行
+   *   - 多个软链技能同名 → 仅保留一个
+   *
+   * 只删除 local:linked:* 行，绝不动内置/市场/手动导入，避免破坏既有绑定。
+   * 用于消除「宿主自动软链导入」与既有技能/彼此之间的重复（数量虚高问题）。
+   *
+   * @returns 删除的行数
+   */
+  pruneDuplicateLinkedSkills(): number {
+    const rows = this.repo.list()
+    const nonLinkedNames = new Set(
+      rows
+        .filter((r) => !r.id.startsWith('local:linked:'))
+        .map((r) => r.name.trim().toLowerCase()),
+    )
+    const seenLinked = new Set<string>()
+    let removed = 0
+    for (const row of rows) {
+      if (!row.id.startsWith('local:linked:')) continue
+      const key = row.name.trim().toLowerCase()
+      if (nonLinkedNames.has(key) || seenLinked.has(key)) {
+        this.repo.deleteById(row.id)
+        removed += 1
+      } else {
+        seenLinked.add(key)
+      }
+    }
+    return removed
+  }
+
   detectLocalSkills(searchRoots?: string[]): LocalSkillCandidate[] {
     const installedByRoot = new Map(this.repo.list().map((row) => [row.root_path, row.id]))
     return detectLocalSkillCandidates(searchRoots).map((candidate) => {

--- a/packages/agent-runtime/src/skills/skill-loader.ts
+++ b/packages/agent-runtime/src/skills/skill-loader.ts
@@ -33,22 +33,24 @@ export class SkillLoader {
    * 列出所有可用 Skill（内置 + 已安装）
    */
   listAll(): SkillInfo[] {
-    const builtinInfos: SkillInfo[] = BUILTIN_SKILLS.map((def) => ({
-      builtin: true,
-      definition: def,
-      dbRecord: null,
+    const rows = this.repo.list()
+    const dbIds = new Set(rows.map((row) => row.id))
+
+    // 硬编码 TS 内置（当前已全部迁移到文件系统，BUILTIN_SKILLS 为空）；
+    // 仅纳入数据库中没有同 id 影子记录的，避免重复。
+    const tsBuiltinInfos: SkillInfo[] = BUILTIN_SKILLS
+      .filter((def) => !dbIds.has(def.id))
+      .map((def) => ({ builtin: true, definition: def, dbRecord: null }))
+
+    // 所有数据库技能（含 builtin:* 内置行）。内置技能现以 builtin:* 行存于库中，
+    // 必须纳入，否则对 agent 运行时（skills_list / 斜杠命令 / 可用集）完全不可见。
+    const installedInfos: SkillInfo[] = rows.map((row) => ({
+      builtin: row.id.startsWith('builtin:'),
+      definition: this.parseManifestAsDefinition(row),
+      dbRecord: toSkillItem(row),
     }))
 
-    const installedRows = this.repo.list()
-    const installedInfos: SkillInfo[] = installedRows
-      .filter((row) => !row.id.startsWith('builtin:'))
-      .map((row) => ({
-        builtin: false,
-        definition: this.parseManifestAsDefinition(row),
-        dbRecord: toSkillItem(row),
-      }))
-
-    return [...builtinInfos, ...installedInfos]
+    return [...tsBuiltinInfos, ...installedInfos]
   }
 
   /**
@@ -76,30 +78,24 @@ export class SkillLoader {
    * 获取已启用的 Skill 列表
    */
   listEnabled(): SkillInfo[] {
-    const builtinInfos: SkillInfo[] = BUILTIN_SKILLS.map((def) => ({
-      builtin: true,
-      definition: def,
-      dbRecord: null,
-    }))
+    const rows = this.repo.list()
+    const dbIds = new Set(rows.map((row) => row.id))
 
-    const installedRows = this.repo.list()
-    const enabledInstalled: SkillInfo[] = installedRows
-      .filter((row) => !row.id.startsWith('builtin:') && row.enabled === 1)
+    // 硬编码 TS 内置：只有未被用户在库中禁用的才算启用（默认无影子记录 → 启用）。
+    const tsBuiltinInfos: SkillInfo[] = BUILTIN_SKILLS
+      .filter((def) => !dbIds.has(def.id))
+      .map((def) => ({ builtin: true, definition: def, dbRecord: null }))
+
+    // 所有已启用的数据库技能（含 builtin:* 内置行）。
+    const enabledInstalled: SkillInfo[] = rows
+      .filter((row) => row.enabled === 1)
       .map((row) => ({
-        builtin: false,
+        builtin: row.id.startsWith('builtin:'),
         definition: this.parseManifestAsDefinition(row),
         dbRecord: toSkillItem(row),
       }))
 
-    // 内置 Skill 中，在数据库有记录的检查 enabled 状态
-    const result: SkillInfo[] = []
-    for (const info of builtinInfos) {
-      const dbRow = this.repo.get(info.definition!.id)
-      if (dbRow && dbRow.enabled === 0) continue // 被用户禁用的内置 Skill
-      result.push(info)
-    }
-
-    return [...result, ...enabledInstalled]
+    return [...tsBuiltinInfos, ...enabledInstalled]
   }
 
   /**


### PR DESCRIPTION
根因与修复：
- SkillLoader.listAll/listEnabled 原先排除所有 builtin:* 行，而内置技能现以 builtin:* 行存于库中（BUILTIN_SKILLS 已空）→ 13 个内置技能对 agent 运行时 完全不可见（skills_list / 斜杠命令 / 可用集均查不到，故"匹配不到/用不了"）。 改为纳入所有库行并按 id 前缀标记 builtin。
- getSkillConfig：已启用的内置技能始终并入 base，使所有 agent（含新建）默认可用 内置技能，无需手动绑定；仍尊重显式 disabled。
- skills_list：内置优先排序 → 按名去重 → 截断描述 → 限量(200)，并附 source/tier， 修复 244 行全量输出导致的 114K token 溢出。
- 宿主软链导入去重：新增 SkillService.pruneDuplicateLinkedSkills，启动时清理与 内置/已装/本地导入同名（或软链彼此同名）的 local:linked:* 重复行； initializeAppSkills 调整为 内置→宿主→去重→重建插件目录 顺序。
- 管理页计数改用去重口径，修复"显示 244 但实际无 244 个"的数字虚高。