### PR TITLE
feat(canvas): screenplay-to-video pipeline modules

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -2753,12 +2753,20 @@ export function registerAllIpcHandlers(): void {
       // 候选文本 provider：有密钥(keystoreRef + secret)，且非纯媒体(image/voice/video)
       const isTextProvider = (p: (typeof profiles)[number]) =>
         p.modelType === undefined || p.modelType === 'text' || p.modelType === 'multimodal'
-      const ordered = req.providerProfileId
-        ? profiles.filter((p) => p.id === req.providerProfileId)
+      // 专属 agent：命中时用其人设 prompt 作 system，并在未显式指定 provider/model 时沿用 agent 绑定值
+      const agent = req.agentId ? getAgentRepository().get(req.agentId) : null
+      const agentPersona =
+        agent && typeof agent.prompt === 'string' && agent.prompt.trim().length > 0
+          ? agent.prompt.trim()
+          : ''
+      const preferredProviderId =
+        req.providerProfileId ?? (agent?.providerProfileId ? agent.providerProfileId : null)
+      const ordered = preferredProviderId
+        ? profiles.filter((p) => p.id === preferredProviderId)
         : [...profiles].sort((a, b) => Number(b.isDefault) - Number(a.isDefault))
       let chosen: { profile: (typeof profiles)[number]; apiKey: string } | null = null
       for (const profile of ordered) {
-        if (req.providerProfileId == null && !isTextProvider(profile)) continue
+        if (preferredProviderId == null && !isTextProvider(profile)) continue
         if (!profile.keystoreRef) continue
         try {
           const apiKey = await keystore.getSecret(profile.keystoreRef as keystore.KeystoreRef)
@@ -2776,11 +2784,16 @@ export function registerAllIpcHandlers(): void {
           '未找到可用的文本模型 Provider（需要已配置 API Key 的文本/通用模型）',
         )
       }
-      const model = req.modelId?.trim() || chosen.profile.defaultModel
+      const model =
+        req.modelId?.trim() ||
+        (agent?.modelId && agent.modelId.trim().length > 0 ? agent.modelId.trim() : '') ||
+        chosen.profile.defaultModel
+      // system 提示词：选了专属 agent 用其人设，否则用通用影视创作助手；反向提示词作为硬约束追加。
+      const baseSystem = agentPersona || '你是影视创作助手。严格遵循用户指令，直接输出结果，不要解释过程。'
       const system =
         req.negativePrompt && req.negativePrompt.trim().length > 0
-          ? `你是影视创作助手。严格遵循用户指令，直接输出结果，不要解释过程。约束（不可违反）：${req.negativePrompt.trim()}`
-          : '你是影视创作助手。严格遵循用户指令，直接输出结果，不要解释过程。'
+          ? `${baseSystem}\n\n约束（不可违反）：${req.negativePrompt.trim()}`
+          : baseSystem
       const result = await generateCanvasText({
         providerType: chosen.profile.provider,
         apiKey: chosen.apiKey,
@@ -2795,6 +2808,17 @@ export function registerAllIpcHandlers(): void {
         provider: chosen.profile.provider,
         model,
         text: result.text,
+        rawResponse: {
+          providerProfileId: chosen.profile.id,
+          provider: chosen.profile.provider,
+          providerName: chosen.profile.name,
+          model,
+          agentId: agent?.id ?? null,
+          agentName: agent?.name ?? null,
+          systemPrompt: system,
+          prompt: req.prompt,
+          outputText: result.text,
+        },
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasBottomDock.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasBottomDock.tsx
@@ -11,6 +11,7 @@ import type { CanvasTool } from './CanvasToolbar'
  *   - 工具：选择 / 平移
  *   - 添加：文本 / 图片 / 组 + 节点工厂（更多类型）
  *   - AI：快速发起常用 AI 操作
+ *   - 编辑：删除选中节点
  *   - 视图：适配屏幕 / 回到中心 / 网格开关
  *
  * 底部工具栏保持常驻，关键工作台以最大化浮层承载，避免用户误收起后找不到入口。
@@ -24,8 +25,10 @@ export function CanvasBottomDock({
   onOpenFilmCenter,
   onOpenShotDirector,
   onOpenAgent,
+  onDeleteSelected,
   onToggleGrid,
   gridVisible,
+  selectedCount,
 }: {
   activeTool: CanvasTool
   onToolChange: (tool: CanvasTool) => void
@@ -35,12 +38,16 @@ export function CanvasBottomDock({
   onOpenFilmCenter: () => void
   onOpenShotDirector: () => void
   onOpenAgent: () => void
+  onDeleteSelected: () => void
   onToggleGrid: () => void
   gridVisible: boolean
+  selectedCount: number
 }) {
   const items = useAddNodeMenuItems()
   const [addMenuOpen, setAddMenuOpen] = useState(false)
   const contentItems = items.filter((item) => item.category === 'content')
+  const deleteTooltip =
+    selectedCount > 0 ? `删除选中节点（${selectedCount}）` : '选择节点后可删除'
   const openAddMenu = () => {
     onOpenAddMenu()
     setAddMenuOpen(true)
@@ -147,6 +154,22 @@ export function CanvasBottomDock({
               icon={<Icons.Bot size={15} />}
               aria-label="画布 Agent 助手"
               onClick={() => closeAddMenuAndRun(onOpenAgent)}
+            />
+          </Tooltip>
+        </div>
+
+        <div className="canvas-bottom-dock-divider" />
+
+        <div className="canvas-bottom-dock-group">
+          <Tooltip title={deleteTooltip} placement="top">
+            <Button
+              size="small"
+              type="text"
+              danger
+              icon={<Icons.Trash size={15} />}
+              aria-label="删除选中节点"
+              disabled={selectedCount === 0}
+              onClick={() => closeAddMenuAndRun(onDeleteSelected)}
             />
           </Tooltip>
         </div>

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasContextMenu.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasContextMenu.tsx
@@ -1,6 +1,13 @@
 import { Icons } from '../../Icons'
 import type { CanvasNode } from './canvas.types'
-import { getPipelineActions } from './canvasPipeline'
+import { getNodePipelineActions } from './canvasPipeline'
+
+/** 把 op 的图标 key 映射为 Icons 组件（找不到回退 Workflow） */
+function resolvePipelineIcon(iconKey: string | undefined): React.ReactNode {
+  const map = Icons as unknown as Record<string, (p: { size?: number }) => React.ReactNode>
+  const IconFn = (iconKey && map[iconKey]) || Icons.Workflow
+  return <IconFn size={14} />
+}
 
 /**
  * 右键菜单上下文（文档 §7.6 / §11.4）。
@@ -115,8 +122,8 @@ export function buildContextMenuItems(
       { type: 'item', key: 'delete_node', label: '删除组', icon: <Icons.Trash size={14} />, danger: true },
     ]
   }
-  // 普通内容节点
-  const pipelineActions = getPipelineActions(node.data?.pipelineRole)
+  // 普通内容节点：专用流水线操作（无 pipelineRole 的文本节点也给「剧本类」入口）
+  const pipelineActions = getNodePipelineActions(node)
   const pipelineItems: CanvasContextMenuItem[] =
     pipelineActions.length > 0
       ? [
@@ -125,7 +132,7 @@ export function buildContextMenuItems(
               type: 'item',
               key: `pipeline:${action.id}`,
               label: `${action.label}`,
-              icon: <Icons.Workflow size={14} />,
+              icon: resolvePipelineIcon(action.icon),
             }),
           ),
           { type: 'divider' },

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasFilmAssetCenter.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasFilmAssetCenter.tsx
@@ -38,6 +38,9 @@ import {
   totalPlannedDurationSec,
   type PlannedShot,
 } from './canvasShotPlanner'
+import { planSegmentSplit, resolveSegmentDuration, type ShotSplitPart } from './canvasShotSplit'
+import { parseShotTable, type ParsedShotRow } from './canvasShotTableParse'
+import { DEFAULT_MAX_CLIP_SEC } from './canvasAgentPromptPresets'
 import { buildEdlMarkdown, buildTimeline, totalRuntimeSec, formatTimecode } from './canvasFilmTimeline'
 
 /**
@@ -130,6 +133,8 @@ export type FilmCenterHandlers = {
   }) => void
   /** 把画布当前选中的图片节点设为该分镜的关键帧（§S7→S8 回链）：返回设置的关键帧数 */
   onSetSegmentKeyframesFromSelection?: (input: { group: ShotGroup; segment: ShotSegment }) => number
+  /** 生成分镜图（宫格关键帧）：把整组分镜画成一张多格分镜图，发起 text_to_image */
+  onGenerateStoryboardGrid?: (group: ShotGroup) => void
   hasPromptCanvasTarget?: () => boolean
   onApplyPromptEntryToCanvas?: (entry: CanvasPromptLibraryEntry) => Promise<boolean>
   onInsertAssetToCanvas: (assetId: string) => void
@@ -1388,7 +1393,9 @@ function AssetEditor({
   const [attributes, setAttributes] = useState<Record<string, string>>(() => {
     const stored = asset?.metadata?.attributes as Record<string, string> | undefined
     const init: Record<string, string> = {}
-    for (const field of attributeFields) init[field.key] = stored?.[field.key] ?? ''
+    for (const field of attributeFields) {
+      init[field.key] = readStoredAttribute(stored, field.key, field.aliases) ?? ''
+    }
     return init
   })
 
@@ -1576,6 +1583,7 @@ function AssetEditor({
           <span>{kind === 'script' ? '剧本内容' : kind === 'prompt_library' ? '提示词内容' : '整体描述'}</span>
           <Input.TextArea
             rows={kind === 'script' ? 14 : kind === 'prompt_library' ? 8 : 6}
+            autoSize={{ minRows: kind === 'script' ? 14 : kind === 'prompt_library' ? 8 : 8, maxRows: 22 }}
             value={text}
             placeholder={getEditorPlaceholder(kind)}
             onChange={(e) => setText(e.target.value)}
@@ -1591,7 +1599,8 @@ function AssetEditor({
           <label className="canvas-film-editor-field">
             <span>默认生成提示词（AI 生图/生视频时复用）</span>
             <Input.TextArea
-              rows={3}
+              rows={5}
+              autoSize={{ minRows: 5, maxRows: 16 }}
               value={prompt}
               placeholder="如：电影感、高质量、精细细节..."
               onChange={(e) => setPrompt(e.target.value)}
@@ -1774,25 +1783,32 @@ function ReferenceToolbar({
 }
 
 /** 各资产种类的附加属性字段 */
-function getAttributeFields(kind: FilmAssetKind): Array<{ key: string; label: string; placeholder: string }> {
+function getAttributeFields(
+  kind: FilmAssetKind,
+): Array<{ key: string; label: string; placeholder: string; aliases?: string[] }> {
   switch (kind) {
     case 'character':
       return [
-        { key: 'age', label: '年龄阶段', placeholder: '如：青年' },
-        { key: 'gender', label: '性别', placeholder: '如：女' },
-        { key: 'occupation', label: '身份/职业', placeholder: '如：剑客' },
-        { key: 'appearance', label: '外貌特征', placeholder: '如：银色长发、绿色眼睛' },
-        { key: 'costume', label: '服饰', placeholder: '如：黑色战甲、长靴' },
-        { key: 'personality', label: '性格关键词', placeholder: '如：坚毅、冷静' },
+        { key: 'age', label: '年龄阶段', placeholder: '如：青年', aliases: ['年龄', '年龄段', '年纪'] },
+        { key: 'gender', label: '性别', placeholder: '如：女', aliases: ['性别'] },
+        { key: 'occupation', label: '身份/职业', placeholder: '如：剑客', aliases: ['身份', '职业', '角色定位'] },
+        { key: 'appearance', label: '外貌特征', placeholder: '如：银色长发、绿色眼睛', aliases: ['外貌', '外形', '长相'] },
+        { key: 'hair', label: '发型', placeholder: '如：短发、银色长发', aliases: ['发型', '发式', '头发'] },
+        { key: 'costume', label: '服饰', placeholder: '如：黑色战甲、长靴', aliases: ['服饰', '服装', '穿着'] },
+        { key: 'signatureProp', label: '标志道具', placeholder: '如：铜钥匙', aliases: ['标志道具', '随身道具', '道具'] },
+        { key: 'personality', label: '性格关键词', placeholder: '如：坚毅、冷静', aliases: ['性格', '气质', '个性'] },
+        { key: 'voice', label: '声线', placeholder: '如：低沉、沙哑', aliases: ['声线', '声音', '嗓音'] },
       ]
     case 'scene':
       return [
-        { key: 'settingType', label: '内/外景', placeholder: '内景 / 外景' },
-        { key: 'location', label: '地点类型', placeholder: '如：街道、宫殿' },
-        { key: 'timeOfDay', label: '时间段', placeholder: '如：黄昏、深夜' },
-        { key: 'weather', label: '天气', placeholder: '如：雨天、晴' },
-        { key: 'lighting', label: '光线', placeholder: '如：逆光、柔和' },
-        { key: 'colorTone', label: '色彩基调', placeholder: '如：冷色调、暖色调' },
+        { key: 'settingType', label: '内/外景', placeholder: '内景 / 外景', aliases: ['类型', '内外景', '场景类型'] },
+        { key: 'location', label: '地点类型', placeholder: '如：街道、宫殿', aliases: ['地点', '位置', '场所'] },
+        { key: 'timeOfDay', label: '时间段', placeholder: '如：黄昏、深夜', aliases: ['时间', '时段', '时间段'] },
+        { key: 'weather', label: '天气', placeholder: '如：雨天、晴', aliases: ['天气'] },
+        { key: 'lighting', label: '光线', placeholder: '如：逆光、柔和', aliases: ['光线', '光影', '照明'] },
+        { key: 'colorTone', label: '色彩基调', placeholder: '如：冷色调、暖色调', aliases: ['色调', '色彩', '色温'] },
+        { key: 'artDirection', label: '美术风格', placeholder: '如：赛博废墟', aliases: ['美术', '美术风格', '风格'] },
+        { key: 'mood', label: '氛围', placeholder: '如：压抑、悬疑', aliases: ['氛围', '情绪', '气氛'] },
       ]
     case 'prop':
       return [
@@ -1802,6 +1818,20 @@ function getAttributeFields(kind: FilmAssetKind): Array<{ key: string; label: st
     default:
       return []
   }
+}
+
+function readStoredAttribute(
+  stored: Record<string, string> | undefined,
+  key: string,
+  aliases: string[] | undefined,
+): string | undefined {
+  const direct = stored?.[key]?.trim()
+  if (direct) return direct
+  for (const alias of aliases ?? []) {
+    const value = stored?.[alias]?.trim()
+    if (value) return value
+  }
+  return undefined
 }
 
 function getEditorPlaceholder(kind: FilmAssetKind): string {
@@ -2053,6 +2083,93 @@ function ShotSegmentEditor({
   const [sceneText, setSceneText] = useState('')
   const [pacing, setPacing] = useState('3')
   const [autoBusy, setAutoBusy] = useState(false)
+  // 分镜表展示方式：卡片 / 表格（按秒）
+  const [viewMode, setViewMode] = useState<'card' | 'table'>('table')
+  // 拆分一镜为多段（设计 §S8：适配短视频模型时长上限）
+  const [splitTarget, setSplitTarget] = useState<ShotSegment | null>(null)
+  const [splitMaxClip, setSplitMaxClip] = useState<string>(String(DEFAULT_MAX_CLIP_SEC))
+  const [splitBusy, setSplitBusy] = useState(false)
+  const splitPreview = useMemo<ShotSplitPart[]>(() => {
+    if (!splitTarget) return []
+    const max = Number.parseFloat(splitMaxClip)
+    return planSegmentSplit(splitTarget, {
+      ...(Number.isFinite(max) && max > 0 ? { maxClipSec: max } : {}),
+    })
+  }, [splitTarget, splitMaxClip])
+  const runSplit = useCallback(async () => {
+    if (!splitTarget || splitPreview.length <= 1) return
+    setSplitBusy(true)
+    try {
+      for (const part of splitPreview) {
+        await handlers.createShotSegment(group.id, {
+          title: part.title,
+          ...(part.description ? { description: part.description } : {}),
+          ...(part.dialogue ? { dialogue: part.dialogue } : {}),
+          ...(part.narration ? { narration: part.narration } : {}),
+          durationSec: part.durationSec,
+          ...(part.inSec != null ? { inSec: part.inSec } : {}),
+          ...(part.outSec != null ? { outSec: part.outSec } : {}),
+          ...(part.characterAssetIds ? { characterAssetIds: part.characterAssetIds } : {}),
+          ...(part.sceneAssetId ? { sceneAssetId: part.sceneAssetId } : {}),
+          ...(part.propAssetIds ? { propAssetIds: part.propAssetIds } : {}),
+          ...(part.shotPrompt ? { shotPrompt: part.shotPrompt } : {}),
+          ...(part.cameraDesignId ? { cameraDesignId: part.cameraDesignId } : {}),
+          ...(part.actionDesignId ? { actionDesignId: part.actionDesignId } : {}),
+          ...(part.frameDesignId ? { frameDesignId: part.frameDesignId } : {}),
+        })
+      }
+      await handlers.deleteShotSegment(group.id, splitTarget.id)
+      message.success(`已拆分为 ${splitPreview.length} 段`)
+      setSplitTarget(null)
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '拆分失败')
+    } finally {
+      setSplitBusy(false)
+    }
+  }, [splitTarget, splitPreview, handlers, group.id])
+  // 从分镜 agent 的 Markdown 分镜表解析并批量落库
+  const [importOpen, setImportOpen] = useState(false)
+  const [importText, setImportText] = useState('')
+  const [importBusy, setImportBusy] = useState(false)
+  const parsedRows = useMemo<ParsedShotRow[]>(
+    () => (importText.trim() ? parseShotTable(importText) : []),
+    [importText],
+  )
+  const matchCharacterIds = useCallback(
+    (names: string[] | undefined): string[] => {
+      if (!names || names.length === 0) return []
+      return names
+        .map((name) => characterAssets.find((asset) => (asset.title ?? '').trim() === name.trim()))
+        .filter((asset): asset is CanvasAsset => Boolean(asset))
+        .map((asset) => asset.id)
+    },
+    [characterAssets],
+  )
+  const runImportTable = useCallback(async () => {
+    if (parsedRows.length === 0) return
+    setImportBusy(true)
+    try {
+      for (const row of parsedRows) {
+        const characterIds = matchCharacterIds(row.characterNames)
+        await handlers.createShotSegment(group.id, {
+          title: row.title,
+          ...(row.description ? { description: row.description } : {}),
+          ...(row.dialogue ? { dialogue: row.dialogue } : {}),
+          ...(row.narration ? { narration: row.narration } : {}),
+          ...(row.durationSec != null ? { durationSec: row.durationSec } : {}),
+          ...(row.shotPrompt ? { shotPrompt: row.shotPrompt } : {}),
+          ...(characterIds.length > 0 ? { characterAssetIds: characterIds } : {}),
+        })
+      }
+      message.success(`已从分镜表导入 ${parsedRows.length} 个分镜片段`)
+      setImportOpen(false)
+      setImportText('')
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '导入失败')
+    } finally {
+      setImportBusy(false)
+    }
+  }, [parsedRows, matchCharacterIds, handlers, group.id])
   const plannedShots = useMemo<PlannedShot[]>(() => {
     if (!sceneText.trim()) return []
     const parsedPacing = Number.parseFloat(pacing)
@@ -2105,6 +2222,36 @@ function ShotSegmentEditor({
           {group.description && <span className="canvas-film-segments-desc">{group.description}</span>}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
+          <Button
+            size="small"
+            type={viewMode === 'table' ? 'primary' : 'default'}
+            icon={<Icons.FileText size={13} />}
+            onClick={() => setViewMode('table')}
+          >
+            分镜表
+          </Button>
+          <Button
+            size="small"
+            type={viewMode === 'card' ? 'primary' : 'default'}
+            icon={<Icons.Grid size={13} />}
+            onClick={() => setViewMode('card')}
+          >
+            卡片
+          </Button>
+          {handlers.onGenerateStoryboardGrid && group.segments.length > 0 && (
+            <Tooltip title="把全部分镜关键帧画成一张宫格分镜图">
+              <Button
+                size="small"
+                icon={<Icons.Combine size={13} />}
+                onClick={() => {
+                  void handlers.onGenerateStoryboardGrid?.(group)
+                  message.success('已发起分镜图生成')
+                }}
+              >
+                生成分镜图
+              </Button>
+            </Tooltip>
+          )}
           {handlers.onExpandShotsToCanvas && group.segments.length > 0 && (
             <Button
               size="small"
@@ -2120,6 +2267,11 @@ function ShotSegmentEditor({
           <Button size="small" icon={<Icons.Workflow size={13} />} onClick={() => setAutoOpen(true)}>
             按剧本自动分镜
           </Button>
+                    <Tooltip title="粘贴分镜 agent 生成的 JSON 或 Markdown 分镜表，解析为分镜片段">
+            <Button size="small" icon={<Icons.FilePlus size={13} />} onClick={() => setImportOpen(true)}>
+              导入分镜表
+            </Button>
+          </Tooltip>
           <Button size="small" type="primary" icon={<Icons.Plus size={13} />} onClick={() => setCreating(true)}>
             新建片段
           </Button>
@@ -2189,8 +2341,106 @@ function ShotSegmentEditor({
           </div>
         )}
       </Modal>
+      <Modal
+        open={splitTarget != null}
+        title={`拆分「${splitTarget?.title ?? ''}」为多段`}
+        width={560}
+        okText={splitPreview.length > 1 ? `拆成 ${splitPreview.length} 段` : '无需拆分'}
+        cancelText="取消"
+        okButtonProps={{ disabled: splitPreview.length <= 1, loading: splitBusy }}
+        onCancel={() => setSplitTarget(null)}
+        onOk={() => void runSplit()}
+      >
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 10 }}>
+          <span style={{ whiteSpace: 'nowrap' }}>单段时长上限（秒）</span>
+          <Input
+            type="number"
+            min={1}
+            step={0.5}
+            value={splitMaxClip}
+            style={{ width: 120 }}
+            onChange={(e) => setSplitMaxClip(e.target.value)}
+          />
+          <span style={{ color: 'var(--lobe-color-text-secondary, #888)', fontSize: 12 }}>
+            原镜 {splitTarget ? resolveSegmentDuration(splitTarget) : 0}s · 多数视频模型每段 ≤
+            {DEFAULT_MAX_CLIP_SEC}s
+          </span>
+        </div>
+        {splitPreview.length > 1 ? (
+          <div className="canvas-film-segment-list" style={{ maxHeight: 220, overflow: 'auto' }}>
+            {splitPreview.map((part, idx) => (
+              <div key={idx} style={{ fontSize: 12, padding: '3px 0' }}>
+                <strong>{part.title}</strong>　{part.inSec}s–{part.outSec}s（{part.durationSec}s）
+                {part.dialogue ? `　台词：${part.dialogue}` : ''}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ fontSize: 12, color: 'var(--lobe-color-text-secondary, #888)' }}>
+            当前时长未超过上限，无需拆分。
+          </div>
+        )}
+      </Modal>
+      <Modal
+        open={importOpen}
+          title="导入分镜表（解析 JSON / Markdown）"
+        width={720}
+        okText={parsedRows.length > 0 ? `导入 ${parsedRows.length} 个分镜` : '解析'}
+        cancelText="取消"
+        okButtonProps={{ disabled: parsedRows.length === 0, loading: importBusy }}
+        onCancel={() => setImportOpen(false)}
+        onOk={() => void runImportTable()}
+      >
+        <div style={{ fontSize: 12, color: 'var(--lobe-color-text-secondary, #888)', marginBottom: 8 }}>
+            粘贴分镜 agent / 导演 agent 生成的分镜表（优先 JSON shots，兼容 Markdown 表格）。按表头识别列，容忍列顺序与额外列；
+          角色名会自动匹配同名角色资产。
+        </div>
+        <Input.TextArea
+          placeholder={'| 镜号 | 时长(秒) | 景别 | 运镜 | 画面/动作 | 对白 | 角色 |\n| --- | --- | --- | --- | --- | --- | --- |\n| 1 | 3 | 近景 | 推 | 少年握紧剑柄 | 住手！ | 少年 |'}
+          value={importText}
+          onChange={(e) => setImportText(e.target.value)}
+          autoSize={{ minRows: 8, maxRows: 16 }}
+        />
+        {parsedRows.length > 0 && (
+          <div className="canvas-shot-table-wrap" style={{ marginTop: 8, maxHeight: 220 }}>
+            <table className="canvas-shot-table">
+              <thead>
+                <tr>
+                  <th>镜号</th>
+                  <th>时长</th>
+                  <th>镜头</th>
+                  <th>画面</th>
+                  <th>对白</th>
+                  <th>角色</th>
+                </tr>
+              </thead>
+              <tbody>
+                {parsedRows.map((row, idx) => (
+                  <tr key={idx}>
+                    <td>{row.index ?? idx + 1}</td>
+                    <td>{row.durationSec != null ? `${row.durationSec}s` : '—'}</td>
+                    <td className="canvas-shot-table-shot">{row.shotPrompt || '—'}</td>
+                    <td className="canvas-shot-table-desc">{row.description || '—'}</td>
+                    <td className="canvas-shot-table-line">{row.dialogue || '—'}</td>
+                    <td>{row.characterNames?.join('、') || '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Modal>
       {group.segments.length === 0 ? (
         <Empty description="暂无分镜片段" className="canvas-film-empty" />
+      ) : viewMode === 'table' ? (
+        <ShotSegmentTable
+          group={group}
+          characterAssets={characterAssets}
+          sceneAssets={sceneAssets}
+          handlers={handlers}
+          onEdit={setEditingId}
+          onSplit={setSplitTarget}
+        />
       ) : (
         <div className="canvas-film-segment-list">
           {group.segments.map((segment) => {
@@ -2273,6 +2523,9 @@ function ShotSegmentEditor({
                         />
                       </Tooltip>
                     )}
+                    <Tooltip title="拆分为多段（适配短视频模型）">
+                      <Button size="small" type="text" icon={<Icons.Scissors size={13} />} onClick={() => setSplitTarget(segment)} />
+                    </Tooltip>
                     <Button size="small" type="text" icon={<Icons.Edit size={13} />} onClick={() => setEditingId(segment.id)} />
                     <Button size="small" type="text" danger icon={<Icons.Trash size={13} />} onClick={() => void handlers.deleteShotSegment(group.id, segment.id)} />
                   </div>
@@ -2281,6 +2534,168 @@ function ShotSegmentEditor({
           })}
         </div>
       )}
+    </div>
+  )
+}
+
+/**
+ * 分镜表（按秒）：以表格方式展示一个分镜分组的全部片段，带累计时间码列。
+ * 每行支持生成关键帧 / 设关键帧 / 生成视频 / 拆分 / 编辑 / 删除。
+ */
+function ShotSegmentTable({
+  group,
+  characterAssets,
+  sceneAssets,
+  handlers,
+  onEdit,
+  onSplit,
+}: {
+  group: ShotGroup
+  characterAssets: CanvasAsset[]
+  sceneAssets: CanvasAsset[]
+  handlers: FilmCenterHandlers
+  onEdit: (id: string) => void
+  onSplit: (segment: ShotSegment) => void
+}) {
+  // 累计时间码：优先用片段自带 inSec，否则按时长顺序累加
+  let cursor = 0
+  const rows = group.segments.map((segment) => {
+    const duration = resolveSegmentDuration(segment)
+    const inSec = typeof segment.inSec === 'number' ? segment.inSec : cursor
+    const outSec =
+      typeof segment.outSec === 'number' ? segment.outSec : inSec + duration
+    cursor = outSec
+    const characters = (segment.characterAssetIds ?? [])
+      .map((id) => characterAssets.find((asset) => asset.id === id))
+      .filter((asset): asset is CanvasAsset => Boolean(asset))
+    const scene = segment.sceneAssetId
+      ? sceneAssets.find((asset) => asset.id === segment.sceneAssetId)
+      : undefined
+    return { segment, duration, inSec, outSec, characters, scene }
+  })
+  const totalSec = rows.reduce((sum, row) => sum + row.duration, 0)
+
+  return (
+    <div className="canvas-shot-table-wrap">
+      <table className="canvas-shot-table">
+        <thead>
+          <tr>
+            <th>镜号</th>
+            <th>时间码</th>
+            <th>时长</th>
+            <th>画面 / 动作</th>
+            <th>镜头</th>
+            <th>对白</th>
+            <th>角色 / 场景</th>
+            <th>操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ segment, duration, inSec, outSec, characters, scene }) => {
+            const overLimit = duration > DEFAULT_MAX_CLIP_SEC
+            return (
+              <tr key={segment.id}>
+                <td className="canvas-shot-table-idx">
+                  #{segment.index}
+                  {segment.keyframeNodeIds && segment.keyframeNodeIds.length > 0 && (
+                    <span className="canvas-shot-table-kf" title="已设关键帧">
+                      🎞{segment.keyframeNodeIds.length}
+                    </span>
+                  )}
+                </td>
+                <td className="canvas-shot-table-time">
+                  {formatTimecode(inSec)}–{formatTimecode(outSec)}
+                </td>
+                <td className={overLimit ? 'canvas-shot-table-over' : undefined}>
+                  {duration}s
+                  {overLimit && (
+                    <Tooltip title={`超过单段上限 ${DEFAULT_MAX_CLIP_SEC}s，建议拆分`}>
+                      <span className="canvas-shot-table-warn">!</span>
+                    </Tooltip>
+                  )}
+                </td>
+                <td className="canvas-shot-table-desc">
+                  <div className="canvas-shot-table-title">{segment.title}</div>
+                  {segment.description && <div>{segment.description}</div>}
+                </td>
+                <td className="canvas-shot-table-shot">{segment.shotPrompt || '—'}</td>
+                <td className="canvas-shot-table-line">{segment.dialogue || '—'}</td>
+                <td>
+                  <div className="canvas-shot-table-refs">
+                    {scene && <Tag color="blue">{scene.title ?? '场景'}</Tag>}
+                    {characters.map((character) => (
+                      <Tag key={character.id} color="orange">
+                        {character.title}
+                      </Tag>
+                    ))}
+                    {!scene && characters.length === 0 && '—'}
+                  </div>
+                </td>
+                <td className="canvas-shot-table-ops">
+                  {handlers.onGenerateSegmentKeyframes && (
+                    <Tooltip title="生成关键帧（首/尾帧）">
+                      <Button
+                        size="small"
+                        type="text"
+                        icon={<Icons.Image size={13} />}
+                        onClick={() =>
+                          handlers.onGenerateSegmentKeyframes?.({
+                            group,
+                            segment,
+                            characters,
+                            ...(scene ? { scene } : {}),
+                          })
+                        }
+                      />
+                    </Tooltip>
+                  )}
+                  {handlers.onGenerateSegmentVideo && (
+                    <Tooltip title="生成视频">
+                      <Button
+                        size="small"
+                        type="text"
+                        icon={<Icons.Play size={13} />}
+                        onClick={() =>
+                          handlers.onGenerateSegmentVideo?.({
+                            group,
+                            segment,
+                            characters,
+                            ...(scene ? { scene } : {}),
+                          })
+                        }
+                      />
+                    </Tooltip>
+                  )}
+                  <Tooltip title="拆分为多段（适配短视频模型）">
+                    <Button
+                      size="small"
+                      type="text"
+                      icon={<Icons.Scissors size={13} />}
+                      onClick={() => onSplit(segment)}
+                    />
+                  </Tooltip>
+                  <Button
+                    size="small"
+                    type="text"
+                    icon={<Icons.Edit size={13} />}
+                    onClick={() => onEdit(segment.id)}
+                  />
+                  <Button
+                    size="small"
+                    type="text"
+                    danger
+                    icon={<Icons.Trash size={13} />}
+                    onClick={() => void handlers.deleteShotSegment(group.id, segment.id)}
+                  />
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+      <div className="canvas-shot-table-foot">
+        共 {rows.length} 镜 · 总时长 {formatTimecode(totalSec)}（{totalSec}s）
+      </div>
     </div>
   )
 }

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.tsx
@@ -11,7 +11,13 @@ import { Button, Checkbox as LobeCheckbox, Input, Tag, Tooltip } from '@lobehub/
 import { Icons } from '../../Icons'
 import { Select as LobeSelect } from '@lobehub/ui'
 import { capabilityForOperation } from '@spark/protocol'
-import type { CanvasMediaModelSummary, CanvasMediaTaskInputFile } from '@spark/protocol'
+import type { CanvasMediaModelSummary, CanvasMediaTaskInputFile, ManagedAgent } from '@spark/protocol'
+import {
+  CANVAS_AGENT_PRESETS,
+  buildAgentPresetPrompt,
+  getAgentPreset,
+  type CanvasAgentRoleId,
+} from './canvasAgentPromptPresets'
 import { canvasApi } from './canvas.api'
 import { CANVAS_CAPABILITIES, isCapabilityRecommended } from './canvas.capabilities'
 import { CanvasPromptEditor } from './CanvasPromptEditor'
@@ -51,6 +57,8 @@ export function CanvasInlineAiComposer({
     modelParams?: Record<string, unknown>
     inputTransport?: CanvasInputTransport
     inputRoles?: Record<string, CanvasTaskInputRole>
+    /** 文本类操作可指定专属 agent（应用内 agent 管理配置的 ManagedAgent） */
+    agentId?: string
   }) => void
 }) {
   const [operation, setOperation] = useState<CanvasOperationType>('text_to_image')
@@ -69,6 +77,9 @@ export function CanvasInlineAiComposer({
   const [referenceFrameNodeIds, setReferenceFrameNodeIds] = useState<string[]>([])
   const [panelPosition, setPanelPosition] = useState<{ x: number; y: number } | null>(null)
   const [fullscreen, setFullscreen] = useState(false)
+  /** 文本类操作可选的专属 agent（应用内 agent 管理） */
+  const [agents, setAgents] = useState<ManagedAgent[]>([])
+  const [selectedAgentId, setSelectedAgentId] = useState<string>('')
   const panelRef = useRef<HTMLElement | null>(null)
   const lastOpenRef = useRef(false)
   /** 参数草稿兜底 key（operation::model，保留旧行为） */
@@ -102,6 +113,23 @@ export function CanvasInlineAiComposer({
       })
       .finally(() => {
         if (!cancelled) setModelsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  // 加载应用内 agent 列表（供文本类操作指定专属 agent）
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    void window.spark
+      .invoke('agent:list', { includeDisabled: false })
+      .then((res) => {
+        if (!cancelled) setAgents((res as { agents?: ManagedAgent[] }).agents ?? [])
+      })
+      .catch(() => {
+        if (!cancelled) setAgents([])
       })
     return () => {
       cancelled = true
@@ -179,6 +207,11 @@ export function CanvasInlineAiComposer({
   }, [capabilities, nodePromptContext, open, nodeCacheKey])
 
   const mediaCapabilityIds = useMemo(() => capabilityForOperation(operation), [operation])
+  /** 文本类操作（剧本/分镜/导演/动作 等专属 agent 适用）：走真实文本模型，可指定 agent */
+  const isTextOperation =
+    operation === 'text_generate' ||
+    operation === 'text_rewrite' ||
+    operation === 'prompt_optimize'
   const supportedMediaModels = useMemo(() => {
     if (mediaCapabilityIds.length === 0) return []
     return mediaModels.filter((model) =>
@@ -478,6 +511,28 @@ export function CanvasInlineAiComposer({
     event.preventDefault()
   }, [])
 
+  /**
+   * 套用内置角色预设：把写好的提示词（含上游内容）填入提示词框，切到该角色默认操作，
+   * 并在未指定 agent 时尝试自动匹配同名的应用内 agent。
+   */
+  const applyAgentPreset = useCallback(
+    (role: CanvasAgentRoleId) => {
+      const preset = getAgentPreset(role)
+      if (!preset) return
+      setOperation(preset.defaultOperation)
+      setPrompt(buildAgentPresetPrompt(role, { upstreamText: nodePromptContext }))
+      if (!selectedAgentId) {
+        const match = agents.find(
+          (agent) =>
+            agent.name.includes(preset.label.replace(/\s*agent$/i, '').trim()) ||
+            (agent.description ?? '').includes(preset.label),
+        )
+        if (match) setSelectedAgentId(match.id)
+      }
+    },
+    [agents, nodePromptContext, selectedAgentId],
+  )
+
   if (!open) return null
 
   return (
@@ -684,6 +739,46 @@ export function CanvasInlineAiComposer({
               {videoFrameMaxImages <= 1 ? ' 如需多图参考，先用“多图合成”生成一张新图片节点。' : ''}
             </div>
           </div>
+        )}
+        {isTextOperation && (
+          <>
+            <div className="canvas-form-row">
+              <label>专属 Agent</label>
+              <LobeSelect
+                value={selectedAgentId || undefined}
+                placeholder="使用通用文本模型（不指定 agent）"
+                onChange={(value) => setSelectedAgentId(String(value ?? ''))}
+                options={agents.map((agent) => ({
+                  value: agent.id,
+                  label: agent.builtIn ? `${agent.name}（内置）` : agent.name,
+                }))}
+                allowClear
+              />
+              <div className="canvas-model-hint">
+                {agents.length > 0
+                  ? '选中后用该 agent 的人设与绑定模型执行；不选则用通用影视创作助手。'
+                  : '未配置 agent，可继续用通用文本模型，或到「Agents」中新建专属 agent。'}
+              </div>
+            </div>
+            <div className="canvas-form-row">
+              <label>内置角色</label>
+              <div className="canvas-creative-actions">
+                {CANVAS_AGENT_PRESETS.map((preset) => (
+                  <Button
+                    key={preset.role}
+                    size="small"
+                    title={preset.description}
+                    onClick={() => applyAgentPreset(preset.role)}
+                  >
+                    {preset.label}
+                  </Button>
+                ))}
+              </div>
+              <div className="canvas-model-hint">
+                一键填入该角色的内置提示词（含上游内容），可继续编辑后发起。
+              </div>
+            </div>
+          </>
         )}
         <CanvasPromptEditor
           prompt={prompt}
@@ -930,10 +1025,12 @@ export function CanvasInlineAiComposer({
               modelParams?: Record<string, unknown>
               inputTransport?: CanvasInputTransport
               inputRoles?: Record<string, CanvasTaskInputRole>
+              agentId?: string
             } = {
               operation,
               prompt: effectivePrompt,
             }
+            if (isTextOperation && selectedAgentId) payload.agentId = selectedAgentId
             if (effectiveNegativePrompt) payload.negativePrompt = effectiveNegativePrompt
             if (selectedModel?.providerProfileId)
               payload.providerProfileId = selectedModel.providerProfileId

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -6,9 +6,16 @@ import { normalizeEduAssetUrl } from '@spark/shared'
 import { Icons } from '../../Icons'
 import { operationLabel } from './canvas.api'
 import { isOperationNode, nodeOperation } from './canvas.capabilities'
-import { getPipelineActions } from './canvasPipeline'
+import { getNodePipelineActions } from './canvasPipeline'
 import type { CanvasNode as SparkCanvasNode } from './canvas.types'
 import type { CanvasOperationType } from './canvas.types'
+
+/** 把 op 的图标 key 映射为 Icons 组件（找不到回退 Workflow） */
+function resolvePipelineIcon(iconKey: string | undefined, size = 14): React.ReactNode {
+  const map = Icons as unknown as Record<string, (p: { size?: number }) => React.ReactNode>
+  const IconFn = (iconKey && map[iconKey]) || Icons.Workflow
+  return <IconFn size={size} />
+}
 
 /** 操作节点图标：按 operation 类型映射 */
 function operationNodeIcon(operation: CanvasOperationType | null): React.ReactNode {
@@ -129,7 +136,7 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
   const normalizedAudioSrc = node.data.url ? normalizeEduAssetUrl(node.data.url) : ''
   const normalizedVideoSrc = node.data.url ? normalizeEduAssetUrl(node.data.url) : ''
 
-  const pipelineActions = isTask || isGroup ? [] : getPipelineActions(node.data.pipelineRole)
+  const pipelineActions = isTask || isGroup ? [] : getNodePipelineActions(node)
   const menu = {
     className: 'canvas-node-context-menu',
     items: [
@@ -139,7 +146,7 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
               key: `pipeline-${action.id}`,
               label: (
                 <span className="canvas-menu-item">
-                  <Icons.Workflow size={14} /> {action.label}
+                  {resolvePipelineIcon(action.icon)} {action.label}
                 </span>
               ),
               onClick: () => actions.pipelineAction(node.id, action.id),
@@ -246,7 +253,7 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
                     actions.pipelineAction(node.id, action.id)
                   }}
                 >
-                  <Icons.Workflow size={12} />
+                  {resolvePipelineIcon(action.icon, 12)}
                   <span>{action.label}</span>
                 </button>
               </Tooltip>

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -4,8 +4,10 @@ import { Button } from '@lobehub/ui'
 import { Icons } from '../../Icons'
 import {
   capabilityForOperation,
+  type ManagedAgent,
   type CanvasMediaModelSummary,
   type CanvasMediaTaskInputFile,
+  type ProviderProfile,
 } from '@spark/protocol'
 import { operationLabel } from './canvas.api'
 import { getCanvasCapability, nodeOperation } from './canvas.capabilities'
@@ -49,6 +51,7 @@ export type OperationRunParams = {
   inputNodeIds?: string[]
   inputTransport?: CanvasInputTransport
   inputRoles?: Record<string, CanvasTaskInputRole>
+  agentId?: string
   providerProfileId?: string
   manifestId?: string
   modelId?: string
@@ -84,6 +87,7 @@ export function CanvasOperationPanel({
   const operation = nodeOperation(node) ?? 'text_generate'
   const capability = getCanvasCapability(operation)
   const operationText = operationLabel(operation)
+  const isTextOperation = isTextModelOperation(operation)
   const [fullscreen, setFullscreen] = useState(false)
   const canEditMediaInputs =
     capability?.inputTypes.some((type) => type === 'image' || type === 'video') ?? false
@@ -166,6 +170,14 @@ export function CanvasOperationPanel({
   const [mediaModels, setMediaModels] = useState<CanvasMediaModelSummary[]>([])
   const [modelsLoading, setModelsLoading] = useState(false)
   const [selectedModelKey, setSelectedModelKey] = useState('')
+  const [agents, setAgents] = useState<ManagedAgent[]>([])
+  const [providers, setProviders] = useState<ProviderProfile[]>([])
+  const [runtimeLoading, setRuntimeLoading] = useState(false)
+  const [selectedAgentId, setSelectedAgentId] = useState(task?.agentId ?? '')
+  const [selectedTextProviderId, setSelectedTextProviderId] = useState(
+    task?.providerProfileId ?? '',
+  )
+  const [selectedTextModelId, setSelectedTextModelId] = useState(task?.modelId ?? '')
   const [modelParamDraft, setModelParamDraft] = useState<Record<string, string>>({})
   const [customParams, setCustomParams] = useState<CustomParamDraft[]>([])
   const [selectedInputNodeIds, setSelectedInputNodeIds] = useState<string[]>(() =>
@@ -194,6 +206,9 @@ export function CanvasOperationPanel({
     setNegativePrompt(inheritedNegativePrompt)
     setTitleDraft(node.title ?? '')
     setMessageDraft(node.data.message ?? '')
+    setSelectedAgentId(task?.agentId ?? '')
+    setSelectedTextProviderId(task?.providerProfileId ?? '')
+    setSelectedTextModelId(task?.modelId ?? '')
   }, [
     inheritedNegativePrompt,
     node.data.message,
@@ -202,6 +217,9 @@ export function CanvasOperationPanel({
     node.title,
     snapshot.project.settings?.prompt,
     task?.prompt,
+    task?.agentId,
+    task?.modelId,
+    task?.providerProfileId,
   ])
 
   useEffect(() => {
@@ -222,6 +240,32 @@ export function CanvasOperationPanel({
       cancelled = true
     }
   }, [])
+
+  useEffect(() => {
+    if (!isTextOperation) return
+    let cancelled = false
+    setRuntimeLoading(true)
+    void Promise.all([
+      window.spark.invoke('agent:list', { includeDisabled: false }),
+      window.spark.invoke('provider:list', {}),
+    ])
+      .then(([agentRes, providerRes]) => {
+        if (cancelled) return
+        setAgents((agentRes as { agents?: ManagedAgent[] }).agents ?? [])
+        setProviders((providerRes as { profiles?: ProviderProfile[] }).profiles ?? [])
+      })
+      .catch(() => {
+        if (cancelled) return
+        setAgents([])
+        setProviders([])
+      })
+      .finally(() => {
+        if (!cancelled) setRuntimeLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isTextOperation])
 
   // 输入节点内容带入 prompt（首次打开时如果 prompt 为空）
   useEffect(() => {
@@ -267,6 +311,40 @@ export function CanvasOperationPanel({
   const selectedModel = useMemo(
     () => supportedMediaModels.find((model) => mediaModelKey(model) === selectedModelKey),
     [selectedModelKey, supportedMediaModels],
+  )
+  const textProviders = useMemo(
+    () =>
+      providers.filter(
+        (provider) =>
+          provider.modelType == null ||
+          provider.modelType === 'text' ||
+          provider.modelType === 'multimodal',
+      ),
+    [providers],
+  )
+  const selectedAgent = useMemo(
+    () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
+    [agents, selectedAgentId],
+  )
+  const selectedTextProvider = useMemo(
+    () => textProviders.find((provider) => provider.id === selectedTextProviderId) ?? null,
+    [selectedTextProviderId, textProviders],
+  )
+  const textProviderOptions = useMemo(
+    () =>
+      textProviders.map((provider) => ({
+        value: provider.id,
+        label: `${provider.name} / ${provider.provider}`,
+      })),
+    [textProviders],
+  )
+  const textModelOptions = useMemo(
+    () =>
+      getProviderTextModels(selectedTextProvider).map((model) => ({
+        value: model,
+        label: model,
+      })),
+    [selectedTextProvider],
   )
   const selectedCapability = useMemo(() => {
     if (!selectedModel) return null
@@ -455,14 +533,21 @@ export function CanvasOperationPanel({
         prompt: prompt.trim(),
         ...(negativePrompt.trim() ? { negativePrompt: negativePrompt.trim() } : {}),
         inputNodeIds: runInputNodeIds,
+        ...(isTextOperation && selectedAgentId ? { agentId: selectedAgentId } : {}),
         ...(selectedModel?.providerKind === 'xai'
           ? { inputTransport: 'base64' as const }
           : { inputTransport: 'cloud_url' as const }),
-        ...(selectedModel?.providerProfileId
-          ? { providerProfileId: selectedModel.providerProfileId }
-          : {}),
+        ...(isTextOperation && selectedTextProviderId
+          ? { providerProfileId: selectedTextProviderId }
+          : selectedModel?.providerProfileId
+            ? { providerProfileId: selectedModel.providerProfileId }
+            : {}),
         ...(selectedModel?.manifestId ? { manifestId: selectedModel.manifestId } : {}),
-        ...(selectedModel?.effectiveModelId ? { modelId: selectedModel.effectiveModelId } : {}),
+        ...(isTextOperation && selectedTextModelId
+          ? { modelId: selectedTextModelId }
+          : selectedModel?.effectiveModelId
+            ? { modelId: selectedModel.effectiveModelId }
+            : {}),
         ...(Object.keys(nextModelParams).length > 0 ? { modelParams: nextModelParams } : {}),
         ...(inputRoles && Object.keys(inputRoles).length > 0 ? { inputRoles } : {}),
       })
@@ -489,6 +574,10 @@ export function CanvasOperationPanel({
     lastFrameNodeId,
     selectedInputNodeIds,
     referenceFrameNodeIds,
+    isTextOperation,
+    selectedAgentId,
+    selectedTextModelId,
+    selectedTextProviderId,
     supportsVideoFrameRoles,
   ])
 
@@ -764,6 +853,73 @@ export function CanvasOperationPanel({
                 ))}
               </div>
             )}
+          </div>
+        )}
+
+        {isTextOperation && (
+          <div className="canvas-operation-panel-section">
+            <div className="canvas-operation-panel-section-label">Agent / 文本模型</div>
+            <div className="canvas-operation-panel-runtime-grid">
+              <Select
+                size="small"
+                allowClear
+                showSearch
+                loading={runtimeLoading}
+                value={selectedAgentId || undefined}
+                placeholder="通用影视创作助手"
+                options={agents.map((agent) => ({
+                  value: agent.id,
+                  label: agent.builtIn ? `${agent.name}（内置）` : agent.name,
+                }))}
+                optionFilterProp="label"
+                disabled={running}
+                onChange={(value) => {
+                  const nextId = value == null ? '' : String(value)
+                  setSelectedAgentId(nextId)
+                  const nextAgent = agents.find((agent) => agent.id === nextId)
+                  if (nextAgent?.providerProfileId) setSelectedTextProviderId(nextAgent.providerProfileId)
+                  if (nextAgent?.modelId) setSelectedTextModelId(nextAgent.modelId)
+                }}
+              />
+              <Select
+                size="small"
+                allowClear
+                showSearch
+                loading={runtimeLoading}
+                value={selectedTextProviderId || undefined}
+                placeholder="自动选择文本 Provider"
+                options={textProviderOptions}
+                optionFilterProp="label"
+                disabled={running}
+                onChange={(value) => {
+                  const nextId = value == null ? '' : String(value)
+                  setSelectedTextProviderId(nextId)
+                  const provider = textProviders.find((item) => item.id === nextId)
+                  const models = getProviderTextModels(provider)
+                  setSelectedTextModelId((current) =>
+                    current && models.includes(current) ? current : provider?.defaultModel ?? models[0] ?? '',
+                  )
+                }}
+              />
+              <Select
+                size="small"
+                allowClear
+                showSearch
+                value={selectedTextModelId || undefined}
+                placeholder="自动 / Agent 绑定模型"
+                options={textModelOptions}
+                optionFilterProp="label"
+                disabled={running || (selectedTextProviderId.length > 0 && textModelOptions.length === 0)}
+                onChange={(value) => setSelectedTextModelId(value == null ? '' : String(value))}
+              />
+            </div>
+            <div className="canvas-operation-panel-hint">
+              {selectedAgent
+                ? `将使用 ${selectedAgent.name} 的人设${selectedTextModelId ? ` · ${selectedTextModelId}` : ''}`
+                : selectedTextProvider
+                  ? `将调用 ${selectedTextProvider.name}${selectedTextModelId ? ` · ${selectedTextModelId}` : ''}`
+                  : '不选择时使用应用内默认文本 Provider 与通用影视创作助手；任务详情会记录实际 Provider / 模型。'}
+            </div>
           </div>
         )}
 
@@ -1055,6 +1211,31 @@ function isSupportedMediaInputNode(node: CanvasNode, inputTypes: readonly string
   if (node.type === 'image') return inputTypes.includes('image')
   if (node.type === 'video') return inputTypes.includes('video')
   return false
+}
+
+function isTextModelOperation(operation: CanvasOperationType): boolean {
+  return (
+    operation === 'text_generate' ||
+    operation === 'text_rewrite' ||
+    operation === 'prompt_optimize'
+  )
+}
+
+function getProviderTextModels(provider: ProviderProfile | null | undefined): string[] {
+  if (!provider) return []
+  return Array.from(
+    new Set(
+      [
+        provider.defaultModel,
+        provider.haikuModel,
+        provider.sonnetModel,
+        provider.opusModel,
+        ...(provider.modelIds ?? []),
+      ]
+        .map((model) => model?.trim())
+        .filter((model): model is string => Boolean(model)),
+    ),
+  )
 }
 
 function inferCustomParamType(value: unknown): CustomParamType {

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
@@ -155,6 +155,12 @@ function TaskDetailModal({
   const taskNode = nodes.find((node) => node.taskId === task.id)
   const canCancel = isTaskActive(task)
   const canDemoComplete = !isMediaOperation(task.operation) && task.status !== 'completed'
+  const raw = isRecord(task.rawResponse) ? task.rawResponse : null
+  const systemPrompt = stringField(raw?.systemPrompt)
+  const rawPrompt = stringField(raw?.prompt)
+  const outputText = stringField(raw?.outputText) || stringField(raw?.text)
+  const parsedEntities = raw?.parsedEntities
+  const displayPrompt = rawPrompt || task.prompt || ''
 
   return (
     <Modal
@@ -162,7 +168,7 @@ function TaskDetailModal({
       open
       onCancel={onClose}
       footer={null}
-      width={680}
+      width={920}
       className="canvas-task-detail-modal"
     >
       <div className="canvas-task-detail">
@@ -208,8 +214,10 @@ function TaskDetailModal({
           items={[
             { label: 'Task ID', children: task.id },
             { label: 'Request', children: task.requestId ?? '-' },
+            { label: 'Provider', children: task.provider ?? '-' },
             { label: 'Provider Profile', children: task.providerProfileId ?? '-' },
             { label: 'Manifest', children: task.manifestId ?? '-' },
+            { label: 'Model', children: task.modelId ?? '-' },
             { label: 'Agent', children: task.agentId ?? task.agentMode ?? '-' },
             { label: '创建时间', children: formatTime(task.createdAt) },
             { label: '更新时间', children: formatTime(task.updatedAt) },
@@ -217,9 +225,21 @@ function TaskDetailModal({
           ]}
         />
 
-        {task.prompt && (
-          <DetailBlock title="Prompt">
-            <pre>{task.prompt}</pre>
+        {systemPrompt && (
+          <DetailBlock title="System / Agent 人设">
+            <pre>{systemPrompt}</pre>
+          </DetailBlock>
+        )}
+
+        {displayPrompt && (
+          <DetailBlock title="实际提交 Prompt">
+            <pre>{displayPrompt}</pre>
+          </DetailBlock>
+        )}
+
+        {outputText && (
+          <DetailBlock title="模型输出">
+            <pre>{outputText}</pre>
           </DetailBlock>
         )}
 
@@ -235,6 +255,12 @@ function TaskDetailModal({
         <DetailBlock title="参数">
           <pre>{formatJson(task.modelParams)}</pre>
         </DetailBlock>
+
+        {parsedEntities != null && (
+          <DetailBlock title="结构化解析结果">
+            <pre>{formatJson(parsedEntities)}</pre>
+          </DetailBlock>
+        )}
 
         {task.requestCall && (
           <DetailBlock title="请求摘要">
@@ -262,6 +288,23 @@ function TaskDetailModal({
         <DetailBlock title="运行日志">
           <div className="canvas-task-log-list">
             <TaskLogItem time={task.createdAt} label="任务创建" />
+            {(task.agentId || task.providerProfileId || task.modelId) && (
+              <TaskLogItem
+                time={task.updatedAt}
+                label={`运行配置：${[
+                  task.agentId ? `Agent ${task.agentId}` : '',
+                  task.providerProfileId ? `Profile ${task.providerProfileId}` : '',
+                  task.provider ? `Provider ${task.provider}` : '',
+                  task.modelId ? `Model ${task.modelId}` : '',
+                ].filter(Boolean).join(' / ')}`}
+              />
+            )}
+            {displayPrompt && (
+              <TaskLogItem time={task.updatedAt} label={`Prompt ${displayPrompt.length} 字符`} />
+            )}
+            {outputText && (
+              <TaskLogItem time={task.updatedAt} label={`模型输出 ${outputText.length} 字符`} />
+            )}
             {task.requestId && <TaskLogItem time={task.updatedAt} label={`Provider request: ${task.requestId}`} />}
             <TaskLogItem time={task.updatedAt} label={`状态更新为 ${task.status}`} />
             {task.completedAt && <TaskLogItem time={task.completedAt} label="任务结束" />}
@@ -379,4 +422,12 @@ function formatJson(value: unknown): string {
   } catch {
     return String(value)
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
 }

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -2704,6 +2704,7 @@ body.canvas-side-panel-resizing {
 .canvas-prompt-library-head,
 .canvas-node-edit-prompt-library-head {
   display: flex;
+  flex: 0 0 auto;
   align-items: flex-start;
   justify-content: space-between;
   gap: 8px;
@@ -2738,10 +2739,17 @@ body.canvas-side-panel-resizing {
 
 .canvas-prompt-library-categories {
   display: flex;
+  flex: 0 0 auto;
   flex-wrap: nowrap;
   gap: 6px;
   overflow-x: auto;
+  overflow-y: hidden;
   padding-bottom: 2px;
+}
+
+.canvas-prompt-library-panel > .ant-input,
+.canvas-prompt-library-panel > .ant-input-affix-wrapper {
+  flex: 0 0 auto;
 }
 
 .canvas-prompt-library-category {
@@ -3260,6 +3268,10 @@ body.canvas-side-panel-resizing {
   flex-direction: column;
 }
 
+.canvas-task-detail-modal {
+  max-width: calc(100vw - 32px);
+}
+
 .canvas-task-detail-modal .ant-modal-body {
   flex: 1;
   min-height: 0;
@@ -3303,7 +3315,7 @@ body.canvas-side-panel-resizing {
 
 .canvas-task-detail-block pre,
 .canvas-task-error-log pre {
-  max-height: 380px;
+  max-height: 52vh;
   margin: 0;
   overflow: auto;
   padding: 9px 10px;
@@ -3422,12 +3434,12 @@ body.canvas-side-panel-resizing {
 
 .canvas-task-log-item strong {
   min-width: 0;
-  overflow: hidden;
+  overflow-wrap: anywhere;
+  overflow: visible;
   color: var(--text);
   font-size: 12px;
   font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 @media (max-width: 980px) {
@@ -5190,6 +5202,106 @@ body.canvas-side-panel-resizing {
   gap: 8px;
 }
 
+// ── 分镜表（按秒）─────────────────────────────────────────────
+.canvas-shot-table-wrap {
+  overflow: auto;
+}
+
+.canvas-shot-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+
+  th,
+  td {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--canvas-border, rgba(0, 0, 0, 0.08));
+    text-align: left;
+    vertical-align: top;
+  }
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--canvas-panel-bg, rgba(255, 255, 255, 0.04));
+    font-weight: 600;
+    white-space: nowrap;
+    color: var(--lobe-color-text-secondary, #888);
+  }
+
+  tbody tr:hover {
+    background: var(--canvas-row-hover, rgba(0, 0, 0, 0.03));
+  }
+
+  .canvas-shot-table-idx {
+    white-space: nowrap;
+    font-weight: 600;
+  }
+
+  .canvas-shot-table-kf {
+    margin-left: 4px;
+    font-weight: 400;
+    opacity: 0.75;
+  }
+
+  .canvas-shot-table-time {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    color: var(--lobe-color-text-secondary, #888);
+  }
+
+  .canvas-shot-table-over {
+    color: var(--lobe-color-warning, #e0a500);
+    font-weight: 600;
+  }
+
+  .canvas-shot-table-warn {
+    display: inline-block;
+    margin-left: 4px;
+    width: 14px;
+    height: 14px;
+    line-height: 14px;
+    text-align: center;
+    border-radius: 50%;
+    background: var(--lobe-color-warning, #e0a500);
+    color: #fff;
+    font-size: 10px;
+  }
+
+  .canvas-shot-table-title {
+    font-weight: 600;
+  }
+
+  .canvas-shot-table-desc {
+    min-width: 160px;
+    max-width: 280px;
+  }
+
+  .canvas-shot-table-shot,
+  .canvas-shot-table-line {
+    max-width: 180px;
+    color: var(--lobe-color-text-secondary, #888);
+    word-break: break-word;
+  }
+
+  .canvas-shot-table-refs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .canvas-shot-table-ops {
+    white-space: nowrap;
+  }
+}
+
+.canvas-shot-table-foot {
+  padding: 8px 4px 0;
+  font-size: 12px;
+  color: var(--lobe-color-text-secondary, #888);
+}
+
 .canvas-film-segment-card {
   position: relative;
   display: flex;
@@ -6071,6 +6183,12 @@ body.canvas-side-panel-resizing {
 .canvas-operation-panel-params {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 6px;
+}
+
+.canvas-operation-panel-runtime-grid {
+  display: grid;
+  grid-template-columns: minmax(160px, 0.9fr) minmax(180px, 1fr) minmax(180px, 1fr);
   gap: 6px;
 }
 

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -36,6 +36,7 @@ import {
   buildCharacterSheetPrompt,
   getCharacterSheetTemplate,
   type CharacterPromptFields,
+  type CharacterSheetAspect,
 } from './canvasCharacterSheetPrompts'
 import {
   collectDownstream,
@@ -43,6 +44,10 @@ import {
   upsertStylePreset,
   writeStyleBible,
 } from './canvasPipeline'
+import { buildStoryboardGridPrompt } from './canvasStoryboardGrid'
+import { buildOpPrompt } from './canvasPipelineOps'
+import { buildEntityExtractionPrompt, parseExtractedEntities } from './canvasEntityExtract'
+import { DEFAULT_MAX_CLIP_SEC } from './canvasAgentPromptPresets'
 import { CanvasPromptLibraryPanel, type CanvasPromptLibraryEntry } from './CanvasPromptLibraryPanel'
 import { CanvasProductionPanel } from './CanvasProductionPanel'
 import type { TabKind as FilmCenterTab } from './CanvasFilmAssetCenter'
@@ -57,6 +62,7 @@ import type {
   CanvasAsset,
   CanvasNode,
   CanvasOperationType,
+  CanvasPipelineRole,
   CanvasProject,
   CanvasProjectSettings,
   CanvasTask,
@@ -77,6 +83,10 @@ type TrackedCanvasWorkflowResult = {
   outputAssetIds?: string[]
   message?: string
   rawResponse?: unknown
+  agentId?: string | null
+  providerProfileId?: string | null
+  provider?: string | null
+  modelId?: string | null
 }
 type PreparedImageUpload = {
   file: File
@@ -1252,6 +1262,38 @@ export function CanvasWorkspaceView({
     [deleteNodes],
   )
 
+  const handleDeleteSelectedNodes = useCallback(() => {
+    const nodeIds = selectedNodes.map((node) => node.id)
+    if (nodeIds.length === 0) return
+    Modal.confirm({
+      title: nodeIds.length === 1 ? '删除选中节点？' : `删除选中的 ${nodeIds.length} 个节点？`,
+      content:
+        nodeIds.length === 1
+          ? '删除后该节点会从当前画布移除，相关连线也会同步清理。'
+          : '删除后这些节点会从当前画布移除，相关连线也会同步清理。',
+      okText: '删除',
+      okButtonProps: { danger: true },
+      cancelText: '取消',
+      onOk: async () => {
+        try {
+          await deleteNodes(nodeIds)
+          setSelectedNodeIds([])
+          setActiveOperationPanelNodeId((currentId) =>
+            currentId && nodeIds.includes(currentId) ? null : currentId,
+          )
+          setEditingNodeId((currentId) =>
+            currentId && nodeIds.includes(currentId) ? null : currentId,
+          )
+          closeCanvasFloatPanels()
+          message.success(nodeIds.length === 1 ? '已删除节点' : `已删除 ${nodeIds.length} 个节点`)
+        } catch (error) {
+          message.error(error instanceof Error ? error.message : '删除节点失败')
+          throw error
+        }
+      },
+    })
+  }, [closeCanvasFloatPanels, deleteNodes, selectedNodes])
+
   const handleDuplicateNode = useCallback(
     (nodeId: string) => {
       void duplicateNodes([nodeId])
@@ -1809,6 +1851,10 @@ export function CanvasWorkspaceView({
     modelParams,
     inputTransport,
     inputRoles,
+    agentId,
+    taskTitle,
+    taskPipelineRole,
+    outputPipelineRole,
   }: {
     operation: CanvasOperationType
     prompt: string
@@ -1820,6 +1866,10 @@ export function CanvasWorkspaceView({
     modelParams?: Record<string, unknown>
     inputTransport?: CanvasInputTransport
     inputRoles?: Record<string, CanvasTaskInputRole>
+    agentId?: string
+    taskTitle?: string
+    taskPipelineRole?: CanvasPipelineRole
+    outputPipelineRole?: CanvasPipelineRole
   }) => {
     // 从选中节点派生输入文件（图生图 / 图生视频 / 语音转写 等需要参考输入）
     const taskInputNodes =
@@ -1853,6 +1903,10 @@ export function CanvasWorkspaceView({
       ...(manifestId != null ? { manifestId } : {}),
       ...(modelId != null ? { modelId } : {}),
       ...(modelParams != null ? { modelParams } : {}),
+      ...(agentId != null ? { agentId } : {}),
+      ...(taskTitle != null ? { taskTitle } : {}),
+      ...(taskPipelineRole != null ? { taskPipelineRole } : {}),
+      ...(outputPipelineRole != null ? { outputPipelineRole } : {}),
       outputPlacement: {
         x: placement.x,
         y: placement.y,
@@ -1867,6 +1921,10 @@ export function CanvasWorkspaceView({
       inputNodeIds?: string[]
       inputAssetIds?: string[]
       message?: string
+      agentId?: string
+      providerProfileId?: string
+      provider?: string
+      modelId?: string
       modelParams?: Record<string, unknown>
     },
     run: () => Promise<TrackedCanvasWorkflowResult>,
@@ -1884,6 +1942,10 @@ export function CanvasWorkspaceView({
       ...(request.inputNodeIds ? { inputNodeIds: request.inputNodeIds } : {}),
       ...(request.inputAssetIds ? { inputAssetIds: request.inputAssetIds } : {}),
       ...(request.message ? { message: request.message } : {}),
+      ...(request.agentId ? { agentId: request.agentId } : {}),
+      ...(request.providerProfileId ? { providerProfileId: request.providerProfileId } : {}),
+      ...(request.provider ? { provider: request.provider } : {}),
+      ...(request.modelId ? { modelId: request.modelId } : {}),
       ...(request.modelParams ? { modelParams: request.modelParams } : {}),
       outputPlacement: { x: placement.x, y: placement.y },
     })
@@ -1897,6 +1959,10 @@ export function CanvasWorkspaceView({
         ...(result.outputAssetIds ? { outputAssetIds: result.outputAssetIds } : {}),
         ...(result.message ? { message: result.message } : {}),
         ...(result.rawResponse !== undefined ? { rawResponse: result.rawResponse } : {}),
+        ...(result.agentId !== undefined ? { agentId: result.agentId } : {}),
+        ...(result.providerProfileId !== undefined ? { providerProfileId: result.providerProfileId } : {}),
+        ...(result.provider !== undefined ? { provider: result.provider } : {}),
+        ...(result.modelId !== undefined ? { modelId: result.modelId } : {}),
       })
       await refresh()
       return result
@@ -2116,13 +2182,16 @@ export function CanvasWorkspaceView({
       text: chapterText,
       tags: [`来源:${asset.title ?? '章节'}`],
     })
-    // 触发 agent 把小说体改写为场次剧本格式（结果回到剧本资产）
+    // 触发 agent 把小说体改写为场次剧本格式（产出节点标记为 screenplay，可直接右键继续编排）
     void handleCreateTask({
       operation: 'text_rewrite',
       prompt: buildChapterToScreenplayInstruction(chapterText),
       inputNodeIds: [],
+      taskTitle: '生成剧本',
+      taskPipelineRole: 'screenplay',
+      outputPipelineRole: 'screenplay',
     })
-    message.success(`已创建剧本「${scriptAsset.title}」，并发起剧本化改写；可在剧本 tab 继续拆解`)
+    message.success(`已创建剧本「${scriptAsset.title}」，并发起剧本化改写；产出的剧本节点可右键继续编排`)
   }
 
   const handleSetProductionState = async (
@@ -2172,6 +2241,24 @@ export function CanvasWorkspaceView({
     return { group, segment, characters, ...(scene ? { scene } : {}) }
   }
 
+  const resolveRuntimeFromNode = (
+    node: CanvasNode,
+  ): {
+    agentId?: string
+    providerProfileId?: string
+    modelId?: string
+  } => {
+    const asset = node.assetId ? snapshot.assets.find((item) => item.id === node.assetId) : null
+    const assetTaskId =
+      typeof asset?.metadata?.taskId === 'string' ? asset.metadata.taskId : undefined
+    const task = snapshot.tasks.find((item) => item.id === (node.taskId ?? assetTaskId))
+    return {
+      ...(task?.agentId ? { agentId: task.agentId } : {}),
+      ...(task?.providerProfileId ? { providerProfileId: task.providerProfileId } : {}),
+      ...(task?.modelId ? { modelId: task.modelId } : {}),
+    }
+  }
+
   const handleNodePipelineAction = async (nodeId: string, actionId: string): Promise<void> => {
     const node = snapshot.nodes.find((item) => item.id === nodeId)
     if (!node) return
@@ -2189,45 +2276,251 @@ export function CanvasWorkspaceView({
     const asset = node.assetId
       ? snapshot.assets.find((item) => item.id === node.assetId)
       : undefined
-    if (!asset) {
-      message.warning('该节点未关联资源，无法执行流水线操作')
-      return
+    // 文本来源：优先关联资产正文，回退节点自身文本（让章→剧本改写产出的纯文本节点右键即可用）
+    const sourceText = (asset?.contentText ?? node.data.text ?? '').trim()
+    const requireAsset = (): CanvasAsset | null => {
+      if (!asset) {
+        message.warning('该节点未关联资源，无法执行此操作')
+        return null
+      }
+      return asset
     }
+
     switch (actionId) {
-      case 'chapter.to_screenplay':
-        await handleChapterToScreenplay(asset)
+      case 'chapter.to_screenplay': {
+        const a = requireAsset()
+        if (a) await handleChapterToScreenplay(a)
         break
-      case 'screenplay.extract_resources':
-      case 'screenplay.to_shots':
-        await handleBreakdownScriptAsset(asset)
+      }
+      case 'screenplay.to_shot_script':
+        handleGenerateShotScript(node, sourceText)
         break
-      case 'character.generate_images':
-        handleGenerateCharacterSheets(asset, ['turnaround', 'expression', 'costume'])
+      case 'screenplay.extract_characters':
+        await handleExtractEntities(node, sourceText, 'character')
         break
-      case 'scene.generate_concept':
-      case 'prop.generate_concept':
-      case 'effect.generate_concept':
-        handleGenerateAssetReference(asset)
+      case 'screenplay.extract_scenes':
+        await handleExtractEntities(node, sourceText, 'scene')
         break
+      case 'screenplay.storyboard_grid':
+        handleStoryboardGridFromNode()
+        break
+      case 'character.three_view': {
+        const a = requireAsset()
+        if (a) handleGenerateCharacterSheets(a, ['turnaround'], node.id)
+        break
+      }
+      case 'scene.scene_image':
+      case 'prop.prop_image':
+      case 'effect.effect_image': {
+        const a = requireAsset()
+        if (a) handleGenerateAssetReference(a, node.id)
+        break
+      }
       default:
         message.info('该操作暂未支持在画布节点上直接触发')
     }
   }
 
-  const handleGenerateAssetReference: NonNullable<
-    FilmCenterHandlers['onGenerateAssetReference']
-  > = (asset) => {
+  /** 生成分镜脚本：剧本/文本节点 → 任务节点 → 分镜脚本产物节点（专用包装 + 血缘） */
+  const handleGenerateShotScript = (node: CanvasNode, sourceText: string) => {
+    if (!sourceText) {
+      message.warning('该节点没有可用文本，无法生成分镜脚本')
+      return
+    }
+    const styleBible = readStyleBible(snapshot.project.metadata)
+    const placement = placeNodeRightOfNodes([node], { x: 360, y: 0 })
+    const runtime = resolveRuntimeFromNode(node)
+    void createTask({
+      operation: 'text_generate',
+      prompt: buildOpPrompt('screenplay.to_shot_script', {
+        upstreamText: sourceText,
+        ...(styleBible ? { styleBible } : {}),
+        maxClipSec: DEFAULT_MAX_CLIP_SEC,
+      }),
+      inputNodeIds: [node.id],
+      ...(node.assetId ? { inputAssetIds: [node.assetId] } : {}),
+      taskTitle: '生成分镜脚本',
+      taskPipelineRole: 'shot',
+      // 产物是「分镜脚本文本」而非分镜片段节点，不打 shot 角色，避免右键出现不适用的关键帧/视频操作；
+      // 其下一步是分镜面板「导入分镜表」解析落库（见 §S6）。
+      ...runtime,
+      outputPlacement: { x: placement.x, y: placement.y },
+    })
+    message.info('已发起分镜脚本生成；产物可在分镜面板「导入分镜表」解析落库')
+  }
+
+  /** 生成分镜关键帧图：从项目最近的分镜分组出一张宫格分镜图 */
+  const handleStoryboardGridFromNode = () => {
+    const film = readFilmData(snapshot.project.metadata)
+    const groups = film?.shotGroups ?? []
+    const group = groups[groups.length - 1]
+    if (!group || group.segments.length === 0) {
+      message.warning('暂无分镜片段，请先「生成分镜脚本」并导入分镜表，再生成分镜图')
+      return
+    }
+    handleGenerateStoryboardGrid(group)
+  }
+
+  /**
+   * 提取角色 / 场景（一对多）：源节点 → 抽取任务节点 → 多个实体节点。
+   * 每个实体登记到资产库（createFilmAsset）并在画布生成关联节点，任务完成自动连 generated 边。
+   */
+  const handleExtractEntities = async (
+    node: CanvasNode,
+    sourceText: string,
+    kind: 'character' | 'scene',
+    options: {
+      prompt?: string
+      agentId?: string
+      providerProfileId?: string
+      modelId?: string
+    } = {},
+  ) => {
+    if (!sourceText) {
+      message.warning('该节点没有可用文本，无法抽取')
+      return
+    }
+    const label = kind === 'character' ? '提取角色' : '提取场景'
+    const styleBible = readStyleBible(snapshot.project.metadata)
+    const extractionPrompt =
+      options.prompt?.trim() || buildEntityExtractionPrompt(kind, sourceText, styleBible)
+    const runtime = {
+      ...resolveRuntimeFromNode(node),
+      ...(options.agentId ? { agentId: options.agentId } : {}),
+      ...(options.providerProfileId ? { providerProfileId: options.providerProfileId } : {}),
+      ...(options.modelId ? { modelId: options.modelId } : {}),
+    }
+    try {
+      await runTrackedCanvasWorkflow(
+        {
+          title: label,
+          prompt: extractionPrompt,
+          inputNodeIds: [node.id],
+          ...(node.assetId ? { inputAssetIds: [node.assetId] } : {}),
+          message: `正在${label}...`,
+          ...runtime,
+          modelParams: { workflow: `extract_${kind}`, responseFormat: 'json' },
+        },
+        async () => {
+          const response = await window.spark.invoke('canvas:task:generate-text', {
+            operation: 'text_generate',
+            prompt: extractionPrompt,
+            ...(runtime.agentId ? { agentId: runtime.agentId } : {}),
+            ...(runtime.providerProfileId ? { providerProfileId: runtime.providerProfileId } : {}),
+            ...(runtime.modelId ? { modelId: runtime.modelId } : {}),
+          })
+          if (response.status !== 'succeeded' || !response.text) {
+            throw new Error(response.error?.message ?? '抽取失败')
+          }
+          const entities = parseExtractedEntities(kind, response.text)
+          if (entities.length === 0) {
+            throw new Error('未识别到实体，请检查文本内容或改用更规范的剧本')
+          }
+          // 已存在同名（同 kind）资产去重
+          const existingByName = new Map<string, CanvasAsset>()
+          for (const item of snapshot.assets) {
+            if (readAssetKind(item) === kind && item.title) {
+              existingByName.set(item.title.trim().toLowerCase(), item)
+            }
+          }
+          const outputNodeIds: string[] = []
+          const outputAssetIds: string[] = []
+          const baseX = node.x + 460
+          let created = 0
+          let failed = 0
+          for (let i = 0; i < entities.length; i++) {
+            const entity = entities[i]!
+            // 单实体失败不影响其它实体（尽力而为，避免整批回滚）
+            try {
+              const nameKey = entity.name.trim().toLowerCase()
+              let entityAsset = existingByName.get(nameKey)
+              if (!entityAsset) {
+                entityAsset = await createFilmAsset({
+                  kind,
+                  name: entity.name,
+                  text: entity.description,
+                  prompt: entity.prompt ?? entity.description,
+                  attributes: entity.fields,
+                  tags: [`来源:${node.title ?? '剧本'}`],
+                })
+                existingByName.set(nameKey, entityAsset)
+              }
+              outputAssetIds.push(entityAsset.id)
+              const placed = await insertAsset({
+                assetId: entityAsset.id,
+                boardId: snapshot.board.id,
+                x: baseX,
+                y: node.y + i * 190,
+              })
+              if (placed) {
+                await updateNodeData(placed.id, { pipelineRole: kind, productionState: 'draft' })
+                outputNodeIds.push(placed.id)
+              }
+              created += 1
+            } catch {
+              failed += 1
+            }
+          }
+          if (created === 0) {
+            throw new Error(`识别到 ${entities.length} 个实体，但全部落库失败`)
+          }
+          return {
+            count: created,
+            outputNodeIds,
+            outputAssetIds,
+            message: failed > 0 ? `已${label} ${created} 个（${failed} 个失败）` : `已${label} ${created} 个`,
+            agentId: runtime.agentId ?? null,
+            providerProfileId: (response.providerProfileId || runtime.providerProfileId) ?? null,
+            provider: response.provider || null,
+            modelId: (response.model || runtime.modelId) ?? null,
+            rawResponse: {
+              workflow: `extract_${kind}`,
+              responseFormat: 'json',
+              count: created,
+              failed,
+              providerProfileId: response.providerProfileId,
+              provider: response.provider,
+              model: response.model,
+              agentId: runtime.agentId ?? null,
+              prompt: extractionPrompt,
+              outputText: response.text,
+              parsedEntities: entities.map((entity) => ({
+                name: entity.name,
+                description: entity.description,
+                prompt: entity.prompt ?? '',
+                attributes: entity.fields,
+                raw: entity.raw ?? null,
+              })),
+            },
+          }
+        },
+      )
+      message.success(`${label}完成`)
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : `${label}失败`)
+    }
+  }
+
+  const handleGenerateAssetReference = (asset: CanvasAsset, sourceNodeId?: string) => {
+    const kind = readAssetKind(asset)
+    const title =
+      kind === 'scene' ? '生成场景图' : kind === 'prop' ? '生成道具图' : kind === 'effect' ? '生成特效图' : '生成设计图'
     void handleCreateTask({
       operation: 'text_to_image',
       prompt: buildFilmAssetReferencePrompt(asset, readStyleBible(snapshot.project.metadata)),
-      inputNodeIds: [],
+      inputNodeIds: sourceNodeId ? [sourceNodeId] : [],
+      taskTitle: title,
+      taskPipelineRole: 'design_card',
+      outputPipelineRole: 'design_card',
     })
-    message.info('已发起参考图生成任务，结果会出现在画布上')
+    message.info(`已发起${title}任务，结果会出现在画布上`)
   }
 
-  const handleGenerateCharacterSheets: NonNullable<
-    FilmCenterHandlers['onGenerateCharacterSheets']
-  > = (asset, aspects) => {
+  const handleGenerateCharacterSheets = (
+    asset: CanvasAsset,
+    aspects: CharacterSheetAspect[],
+    sourceNodeId?: string,
+  ) => {
     if (aspects.length === 0) return
     const styleBible = readStyleBible(snapshot.project.metadata)
     const character = assetToCharacterFields(asset)
@@ -2243,6 +2536,7 @@ export function CanvasWorkspaceView({
         ...(styleBible ? { styleBible } : {}),
         ...(stylePrompt ? { extraPrompt: stylePrompt } : {}),
       })
+      const sheetTitle = aspect === 'turnaround' ? `生成三视图 · ${asset.title ?? '角色'}` : '生成角色图'
       const needsBase = getCharacterSheetTemplate(aspect)?.needsBaseImage ?? false
       if (needsBase && baseImageNode) {
         i2iCount += 1
@@ -2250,9 +2544,19 @@ export function CanvasWorkspaceView({
           operation: 'image_to_image',
           prompt,
           inputNodeIds: [baseImageNode.id],
+          taskTitle: sheetTitle,
+          taskPipelineRole: 'design_card',
+          outputPipelineRole: 'design_card',
         })
       } else {
-        void handleCreateTask({ operation: 'text_to_image', prompt, inputNodeIds: [] })
+        void handleCreateTask({
+          operation: 'text_to_image',
+          prompt,
+          inputNodeIds: sourceNodeId ? [sourceNodeId] : [],
+          taskTitle: sheetTitle,
+          taskPipelineRole: 'design_card',
+          outputPipelineRole: 'design_card',
+        })
       }
     }
     message.info(
@@ -2442,6 +2746,25 @@ export function CanvasWorkspaceView({
       })
     }
     message.info('已发起首帧/尾帧关键帧生成任务，结果会出现在画布上')
+  }
+
+  const handleGenerateStoryboardGrid: NonNullable<
+    FilmCenterHandlers['onGenerateStoryboardGrid']
+  > = (group) => {
+    const styleBible = readStyleBible(snapshot.project.metadata)
+    // 把角色/场景 assetId 解析为标题写进每格，提升跨格一致性
+    const titleById = new Map(snapshot.assets.map((asset) => [asset.id, asset.title ?? '']))
+    const prompt = buildStoryboardGridPrompt({
+      group,
+      ...(styleBible ? { styleBible } : {}),
+      nameById: (id) => titleById.get(id) || undefined,
+    })
+    if (!prompt) {
+      message.warning('该分镜分组暂无可用片段')
+      return
+    }
+    void handleCreateTask({ operation: 'text_to_image', prompt, inputNodeIds: [] })
+    message.info('已发起分镜图（宫格）生成任务，结果会出现在画布上')
   }
 
   const handleRetryTask = async (task: CanvasTask) => {
@@ -2642,6 +2965,8 @@ export function CanvasWorkspaceView({
             }}
             onToggleGrid={handleToggleGrid}
             gridVisible={snapshot.board.settings.grid !== false}
+            selectedCount={selectedNodes.length}
+            onDeleteSelected={handleDeleteSelectedNodes}
           />
           <CanvasInlineAiComposer
             open={inlineAiOpen}
@@ -2699,6 +3024,35 @@ export function CanvasWorkspaceView({
                           (opNode.data.operation ?? opNode.type) as CanvasOperationType,
                         )
                       : '')
+                  const workflow =
+                    opTask && typeof opTask.modelParams?.workflow === 'string'
+                      ? opTask.modelParams.workflow
+                      : ''
+                  if (workflow === 'extract_character' || workflow === 'extract_scene') {
+                    const sourceNode = taskInputNodes[0]
+                    if (!sourceNode) {
+                      message.warning('该抽取节点缺少原始输入，无法重新执行')
+                      return
+                    }
+                    const sourceAsset = sourceNode.assetId
+                      ? snapshot.assets.find((item) => item.id === sourceNode.assetId)
+                      : undefined
+                    const sourceText = (sourceAsset?.contentText ?? sourceNode.data.text ?? '').trim()
+                    await handleExtractEntities(
+                      sourceNode,
+                      sourceText,
+                      workflow === 'extract_character' ? 'character' : 'scene',
+                      {
+                        prompt: effectivePrompt,
+                        ...(params.agentId ? { agentId: params.agentId } : {}),
+                        ...(params.providerProfileId ? { providerProfileId: params.providerProfileId } : {}),
+                        ...(params.modelId ? { modelId: params.modelId } : {}),
+                      },
+                    )
+                    setActiveOperationPanelNodeId(null)
+                    setSelectedNodeIds([])
+                    return
+                  }
                   await runOperationNode(opNode.id, {
                     prompt: effectivePrompt,
                     ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
@@ -2707,6 +3061,7 @@ export function CanvasWorkspaceView({
                       .map((item) => item.assetId)
                       .filter((id): id is string => Boolean(id)),
                     ...(inputFiles.length > 0 ? { inputFiles } : {}),
+                    ...(params.agentId ? { agentId: params.agentId } : {}),
                     ...(params.providerProfileId
                       ? { providerProfileId: params.providerProfileId }
                       : {}),
@@ -2813,6 +3168,7 @@ export function CanvasWorkspaceView({
               onGenerateSegmentVideo: handleGenerateSegmentVideo,
               onGenerateSegmentKeyframes: handleGenerateSegmentKeyframes,
               onSetSegmentKeyframesFromSelection: handleSetSegmentKeyframesFromSelection,
+              onGenerateStoryboardGrid: handleGenerateStoryboardGrid,
               hasPromptCanvasTarget: () => selectedNodes.length > 0,
               onApplyPromptEntryToCanvas: handleApplyPromptEntryBesideSelection,
               onInsertAssetToCanvas: (assetId) => void handleInsertAsset(assetId),

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -65,6 +65,9 @@ type CanvasWorkflowTaskStartRequest = {
   message?: string
   progress?: number
   agentId?: string
+  providerProfileId?: string
+  provider?: string
+  modelId?: string
   modelParams?: Record<string, unknown>
 }
 
@@ -77,6 +80,10 @@ type CanvasWorkflowTaskFinishRequest = {
   errorMsg?: string | null
   errorDetail?: string | null
   rawResponse?: unknown
+  agentId?: string | null
+  providerProfileId?: string | null
+  provider?: string | null
+  modelId?: string | null
 }
 
 /**
@@ -1065,6 +1072,48 @@ function fitMediaNodeSize(
   return { width: 300, height: 164 }
 }
 
+function textDisplayColumns(text: string): number {
+  let columns = 0
+  for (const char of text) {
+    columns += /[\u1100-\uFFEF]/.test(char) ? 2 : 1
+  }
+  return columns
+}
+
+function fitTextNodeSize(text: string): { width: number; height: number } {
+  const normalized = text.replace(/\r\n?/g, '\n').trim()
+  if (!normalized) return { width: 300, height: 164 }
+
+  const lines = normalized.split('\n')
+  const longestLineColumns = Math.max(...lines.map(textDisplayColumns), 0)
+  const width = Math.min(
+    520,
+    Math.max(300, Math.round(Math.min(longestLineColumns, 68) * 7.2 + 48)),
+  )
+  const bodyColumns = Math.max(28, Math.floor((width - 28) / 7.2))
+  const estimatedRows = lines.reduce((sum, line) => {
+    return sum + Math.max(1, Math.ceil(textDisplayColumns(line) / bodyColumns))
+  }, 0)
+  const height = Math.min(720, Math.max(164, 36 + 24 + estimatedRows * 21))
+  return { width, height }
+}
+
+function readAssetTextForNode(asset: CanvasAsset): string {
+  const contentText = nonEmptyString(asset.contentText)
+  if (contentText) return contentText
+
+  const prompt = nonEmptyString(asset.metadata?.prompt)
+  if (prompt) return prompt
+
+  const referenceText = readReferences(asset.metadata)
+    .map((ref) => ref.description.trim())
+    .filter(Boolean)
+    .join('\n')
+  if (referenceText) return referenceText
+
+  return asset.title?.trim() ?? ''
+}
+
 function readDisplayImageDimensions(
   src: string,
 ): Promise<{ width: number; height: number } | null> {
@@ -2028,11 +2077,16 @@ export const canvasApi = {
             : asset.type === 'prompt'
               ? 'prompt'
               : 'text'
-    const size = fitMediaNodeSize(asset.type, asset.width, asset.height)
+    const assetText =
+      nodeType === 'text' || nodeType === 'prompt' ? readAssetTextForNode(asset) : ''
+    const size =
+      nodeType === 'text' || nodeType === 'prompt'
+        ? fitTextNodeSize(assetText)
+        : fitMediaNodeSize(asset.type, asset.width, asset.height)
     const data: CanvasNode['data'] =
       nodeType === 'text' || nodeType === 'prompt'
         ? {
-            text: asset.contentText ?? '',
+            text: assetText,
             format: nodeType === 'prompt' ? 'prompt' : 'plain',
             origin: 'asset',
           }
@@ -3110,16 +3164,26 @@ export const canvasApi = {
   async updateNodeData(
     projectId: string,
     nodeId: string,
-    data: CanvasNode['data'],
+    data: Partial<CanvasNode['data']>,
   ): Promise<CanvasSnapshot> {
     const db = readDb()
     const node = db.nodes.find((item) => item.id === nodeId && item.projectId === projectId)
     if (!node) return this.openSnapshot(projectId)
-    node.data = data
+    const nextData = { ...node.data, ...data }
+    for (const key of Object.keys(nextData)) {
+      if ((nextData as Record<string, unknown>)[key] === undefined) {
+        delete (nextData as Record<string, unknown>)[key]
+      }
+    }
+    node.data = nextData
     node.updatedAt = now()
 
     const asset = node.assetId ? db.assets.find((item) => item.id === node.assetId) : null
-    if (asset && (node.type === 'text' || node.type === 'prompt')) {
+    if (
+      asset &&
+      (node.type === 'text' || node.type === 'prompt') &&
+      Object.prototype.hasOwnProperty.call(data, 'text')
+    ) {
       asset.contentText = data.text ?? ''
       asset.updatedAt = now()
     }
@@ -3404,9 +3468,11 @@ export const canvasApi = {
       inputAssetIds: request.inputAssetIds ?? [],
       outputNodeIds: [],
       outputAssetIds: [],
-      provider: 'canvas_workflow',
+      provider: request.provider ?? 'canvas_workflow',
       agentId: request.agentId ?? null,
       agentMode: 'local',
+      providerProfileId: request.providerProfileId ?? null,
+      modelId: request.modelId ?? null,
       modelParams: request.modelParams ?? {},
       createdAt: at,
       updatedAt: at,
@@ -3455,6 +3521,10 @@ export const canvasApi = {
     if (result.errorMsg !== undefined) task.errorMsg = result.errorMsg
     if (result.errorDetail !== undefined) task.errorDetail = result.errorDetail
     if (result.rawResponse !== undefined) task.rawResponse = result.rawResponse
+    if (result.agentId !== undefined) task.agentId = result.agentId
+    if (result.providerProfileId !== undefined) task.providerProfileId = result.providerProfileId
+    if (result.provider !== undefined) task.provider = result.provider
+    if (result.modelId !== undefined) task.modelId = result.modelId
 
     const defaultMessage =
       status === 'completed'
@@ -3661,9 +3731,12 @@ export const canvasApi = {
       ...(oldTask.providerProfileId ? { providerProfileId: oldTask.providerProfileId } : {}),
       ...(oldTask.manifestId ? { manifestId: oldTask.manifestId } : {}),
       ...(oldTask.modelId ? { modelId: oldTask.modelId } : {}),
+      ...(oldTask.agentId ? { agentId: oldTask.agentId } : {}),
     }
     // 重试：绑定到原操作节点，不新建节点
-    return this.createMediaTask(projectId, request, { bindToNodeId: nodeId })
+    return isTextModelOperation(request.operation)
+      ? this.createTextTask(projectId, request, { bindToNodeId: nodeId })
+      : this.createMediaTask(projectId, request, { bindToNodeId: nodeId })
   },
 
   /**
@@ -3679,6 +3752,7 @@ export const canvasApi = {
       inputNodeIds?: string[]
       inputAssetIds?: string[]
       inputFiles?: CanvasMediaTaskInputFile[]
+      agentId?: string
       providerProfileId?: string
       manifestId?: string
       modelId?: string
@@ -3739,12 +3813,15 @@ export const canvasApi = {
       ...(inputAssetIds.length > 0 ? { inputAssetIds } : {}),
       ...(params.inputFiles ? { inputFiles: params.inputFiles } : {}),
       outputPlacement: { x: baseX, y: node.y },
+      ...(params.agentId ? { agentId: params.agentId } : {}),
       ...(params.providerProfileId ? { providerProfileId: params.providerProfileId } : {}),
       ...(params.manifestId ? { manifestId: params.manifestId } : {}),
       ...(params.modelId ? { modelId: params.modelId } : {}),
       ...(params.modelParams ? { modelParams: params.modelParams } : {}),
     }
-    return this.createMediaTask(projectId, request, { bindToNodeId: nodeId })
+    return isTextModelOperation(request.operation)
+      ? this.createTextTask(projectId, request, { bindToNodeId: nodeId })
+      : this.createMediaTask(projectId, request, { bindToNodeId: nodeId })
   },
   async cancelTask(projectId: string, taskId: string): Promise<CanvasSnapshot> {
     const db = readDb()
@@ -3832,6 +3909,9 @@ export const canvasApi = {
       message: '调用平台 adapter 中…',
     }
     if (request.prompt != null) taskNodeData.prompt = request.prompt
+    // 专用流水线节点：任务节点角色 + 暂存产物节点角色（供完成回写读取）
+    if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
+    if (request.outputPipelineRole != null) taskNodeData.outputPipelineRole = request.outputPipelineRole
     let taskNode: CanvasNode
     const bindNode = options?.bindToNodeId
       ? db.nodes.find((n) => n.id === options.bindToNodeId && n.projectId === projectId)
@@ -3847,7 +3927,7 @@ export const canvasApi = {
         boardId: board.id,
         type: request.operation as CanvasNodeType,
         taskId,
-        title: operationLabel(request.operation),
+        title: request.taskTitle ?? operationLabel(request.operation),
         x,
         y,
         width: 300,
@@ -3894,7 +3974,6 @@ export const canvasApi = {
         createdAt: at,
       }),
     )
-    if (!bindNode) db.nodes.push(taskNode)
     db.tasks.push(task)
     db.edges.push(...inputEdges)
     updateProjectCounts(db, projectId)
@@ -3945,6 +4024,9 @@ export const canvasApi = {
   async createTextTask(
     projectId: string,
     request: Omit<CreateCanvasTaskRequest, 'boardId'>,
+    options?: {
+      bindToNodeId?: string
+    },
   ): Promise<CanvasSnapshot> {
     const db = readDb()
     const board = db.boards.find((item) => item.projectId === projectId)
@@ -3962,19 +4044,34 @@ export const canvasApi = {
       message: '调用文本模型中…',
     }
     if (request.prompt != null) taskNodeData.prompt = request.prompt
-    const taskNode = createNodeBase({
-      projectId,
-      boardId: board.id,
-      type: request.operation as CanvasNodeType,
-      taskId,
-      title: operationLabel(request.operation),
-      x,
-      y,
-      width: 300,
-      height: 152,
-      data: taskNodeData,
-      at,
-    })
+    // 专用流水线节点：任务节点角色 + 暂存产物节点角色（供完成回写读取）
+    if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
+    if (request.outputPipelineRole != null) taskNodeData.outputPipelineRole = request.outputPipelineRole
+    let taskNode: CanvasNode
+    const bindNode = options?.bindToNodeId
+      ? db.nodes.find((n) => n.id === options.bindToNodeId && n.projectId === projectId)
+      : null
+    if (bindNode) {
+      bindNode.data = { ...bindNode.data, ...taskNodeData }
+      bindNode.taskId = taskId
+      bindNode.updatedAt = at
+      taskNode = bindNode
+    } else {
+      taskNode = createNodeBase({
+        projectId,
+        boardId: board.id,
+        type: request.operation as CanvasNodeType,
+        taskId,
+        title: request.taskTitle ?? operationLabel(request.operation),
+        x,
+        y,
+        width: 300,
+        height: 152,
+        data: taskNodeData,
+        at,
+      })
+      db.nodes.push(taskNode)
+    }
     const task: CanvasTask = {
       id: taskId,
       projectId,
@@ -3983,7 +4080,7 @@ export const canvasApi = {
       operation: request.operation,
       status: 'running',
       progress: 30,
-      title: operationLabel(request.operation),
+      title: request.taskTitle ?? operationLabel(request.operation),
       prompt: request.prompt ?? null,
       negativePrompt: request.negativePrompt ?? null,
       inputNodeIds: request.inputNodeIds ?? [],
@@ -4012,7 +4109,6 @@ export const canvasApi = {
         createdAt: at,
       }),
     )
-    db.nodes.push(taskNode)
     db.tasks.push(task)
     db.edges.push(...inputEdges)
     updateProjectCounts(db, projectId)
@@ -4028,6 +4124,7 @@ export const canvasApi = {
           ? { providerProfileId: request.providerProfileId }
           : {}),
         ...(request.modelId != null ? { modelId: request.modelId } : {}),
+        ...(request.agentId != null ? { agentId: request.agentId } : {}),
       })
     } catch (err) {
       response = {
@@ -4061,6 +4158,10 @@ export const canvasApi = {
         response.error?.code,
         response.error?.message ?? '文本生成失败',
       )
+      task.providerProfileId = response.providerProfileId || task.providerProfileId || null
+      task.provider = response.provider || task.provider || null
+      task.modelId = response.model || task.modelId || null
+      if (response.rawResponse !== undefined) task.rawResponse = response.rawResponse
       task.updatedAt = now()
       taskNode.data = {
         ...taskNode.data,
@@ -4083,10 +4184,16 @@ export const canvasApi = {
       source: 'ai_generated',
       title: `${task.title ?? operationLabel(task.operation)} result`,
       contentText: response.text,
-      metadata: { taskId, provider: response.provider, model: response.model },
+      metadata: {
+        taskId,
+        providerProfileId: response.providerProfileId,
+        provider: response.provider,
+        model: response.model,
+      },
       createdAt: at,
       updatedAt: at,
     }
+    const outputRole = taskNode.data.outputPipelineRole
     const resultNode = createNodeBase({
       projectId,
       boardId: task.boardId,
@@ -4097,15 +4204,22 @@ export const canvasApi = {
       y: taskNode.y,
       width: 320,
       height: 220,
-      data: { text: response.text, format: 'markdown', origin: 'task_output' },
+      data: {
+        text: response.text,
+        format: 'markdown',
+        origin: 'task_output',
+        ...(outputRole ? { pipelineRole: outputRole } : {}),
+      },
       at,
     })
     task.status = 'completed'
     task.progress = 100
     task.completedAt = at
     task.updatedAt = at
+    task.providerProfileId = response.providerProfileId || task.providerProfileId || null
     task.provider = response.provider || task.provider || null
     task.modelId = response.model || task.modelId || null
+    if (response.rawResponse !== undefined) task.rawResponse = response.rawResponse
     task.outputAssetIds.push(asset.id)
     task.outputNodeIds.push(resultNode.id)
     taskNode.data = {
@@ -4278,6 +4392,8 @@ export const canvasApi = {
         nodeType === 'text'
           ? { text: asset.contentText ?? '', format: 'plain' }
           : { message: assetOut.filePath ?? asset.title ?? 'media asset' }
+      // 专用流水线节点：产物图片/视频继承任务暂存的产物角色（如三视图=design_card、关键帧=keyframe）
+      if (taskNode.data.outputPipelineRole) nodeData.pipelineRole = taskNode.data.outputPipelineRole
       if (nodeType !== 'text') {
         if (displayUrl) nodeData.url = displayUrl
         if (asset.mimeType) nodeData.mimeType = asset.mimeType

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
@@ -533,6 +533,7 @@ export function useCanvasWorkspace(projectId: string) {
         inputNodeIds?: string[]
         inputAssetIds?: string[]
         inputFiles?: CanvasMediaTaskInputFile[]
+        agentId?: string
         providerProfileId?: string
         manifestId?: string
         modelId?: string

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
@@ -168,6 +168,8 @@ export type CanvasNodeData = {
   /** 分镜节点化（设计 §S6 节点化）：回链到分镜分组/片段 */
   shotGroupId?: string
   shotSegmentId?: string
+  /** 专用流水线任务节点上暂存的「产物节点角色」，供任务完成回写产物节点时读取 */
+  outputPipelineRole?: CanvasPipelineRole
 }
 
 export type CanvasNode = {
@@ -323,6 +325,12 @@ export type CreateCanvasTaskRequest = {
   providerProfileId?: string
   manifestId?: string
   modelId?: string
+  /** 专用流水线节点：覆盖任务节点标题（如「生成分镜脚本」「提取角色」） */
+  taskTitle?: string
+  /** 专用流水线节点：任务节点的流水线角色（驱动着色/语义） */
+  taskPipelineRole?: CanvasPipelineRole
+  /** 专用流水线节点：产物节点的流水线角色（如分镜脚本产物 = shot） */
+  outputPipelineRole?: CanvasPipelineRole
 }
 
 export type CanvasCapability = {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasAgentPromptPresets.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasAgentPromptPresets.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CANVAS_AGENT_PRESETS,
+  DEFAULT_MAX_CLIP_SEC,
+  buildAgentPresetPrompt,
+  getAgentPreset,
+} from './canvasAgentPromptPresets'
+
+describe('canvasAgentPromptPresets', () => {
+  it('覆盖四个专属 agent 角色', () => {
+    expect(CANVAS_AGENT_PRESETS.map((preset) => preset.role)).toEqual([
+      'screenwriter',
+      'storyboard',
+      'director',
+      'action',
+    ])
+  })
+
+  it('四个预设默认操作均为 composer 可选的文本能力', () => {
+    const selectable = new Set(['text_generate', 'prompt_optimize'])
+    for (const preset of CANVAS_AGENT_PRESETS) {
+      expect(selectable.has(preset.defaultOperation)).toBe(true)
+    }
+  })
+
+  it('每个预设都有人设与模板', () => {
+    for (const preset of CANVAS_AGENT_PRESETS) {
+      expect(preset.persona.length).toBeGreaterThan(0)
+      expect(preset.template).toContain('{upstream}')
+    }
+  })
+
+  describe('buildAgentPresetPrompt', () => {
+    it('填入上游文本与视觉总设定', () => {
+      const prompt = buildAgentPresetPrompt('screenwriter', {
+        upstreamText: '少年走进茶馆。',
+        styleBible: '水墨写意，冷色调',
+      })
+      expect(prompt).toContain('少年走进茶馆。')
+      expect(prompt).toContain('全片视觉总设定')
+      expect(prompt).toContain('水墨写意，冷色调')
+      // 占位槽位应被替换干净
+      expect(prompt).not.toContain('{upstream}')
+      expect(prompt).not.toContain('{style}')
+    })
+
+    it('缺上游文本时给出中文占位提示', () => {
+      const prompt = buildAgentPresetPrompt('storyboard', {})
+      expect(prompt).toContain('在此粘贴上游内容')
+    })
+
+    it('分镜预设带入节奏基线与时长上限', () => {
+      const prompt = buildAgentPresetPrompt('storyboard', {
+        upstreamText: '场1',
+        pacingSecPerShot: 4,
+        maxClipSec: 8,
+      })
+      expect(prompt).toContain('约 4 秒/镜')
+      expect(prompt).toContain('不得超过 8 秒')
+      expect(prompt).toContain('"shots"')
+      expect(prompt).toContain('Markdown 表格')
+    })
+
+    it('分镜预设时长上限缺省用 DEFAULT_MAX_CLIP_SEC', () => {
+      const prompt = buildAgentPresetPrompt('storyboard', { upstreamText: '场1' })
+      expect(prompt).toContain(`不得超过 ${DEFAULT_MAX_CLIP_SEC} 秒`)
+    })
+
+    it('无视觉总设定时不残留多余空行', () => {
+      const prompt = buildAgentPresetPrompt('action', { upstreamText: '二人对峙' })
+      expect(prompt).not.toMatch(/\n{3,}/)
+    })
+
+    it('未知角色返回空串', () => {
+      // @ts-expect-error 故意传非法角色
+      expect(buildAgentPresetPrompt('unknown', {})).toBe('')
+    })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasAgentPromptPresets.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasAgentPromptPresets.ts
@@ -1,0 +1,204 @@
+/**
+ * 画布「专属 agent」内置提示词预设（设计 §12 Agent 能力 / 用户诉求：剧本/分镜/导演/动作 agent）。
+ *
+ * 落点：不新增独立 agent 节点，而是作为 **AI 操作节点（文本类）的内置提示词预设**。
+ * 用户在操作节点里：
+ *   1. 可选一个应用内配置的专属 agent（ManagedAgent，提供人设 system prompt）；
+ *   2. 选一个内置角色预设（本模块），把「写好的提示词」一键填入可编辑的提示词框；
+ *   3. 自由编辑后发起 text_generate / text_rewrite。
+ *
+ * 与 canvasCharacterSheetPrompts（图像积木）同构：纯逻辑、可单测、无 DOM/IPC。
+ * 这里产出的是**给文本模型/agent 的中文指令**（非英文积木），因为剧本/分镜/导演/动作
+ * 是结构化创作任务，需要明确的角色身份 + 输入 + 输出格式约束。
+ */
+
+import type { CanvasOperationType, CanvasPipelineRole } from './canvas.types'
+
+/** 专属创作 agent 角色 id */
+export type CanvasAgentRoleId =
+  | 'screenwriter' // 剧本 agent
+  | 'storyboard' // 分镜 agent
+  | 'director' // 导演 agent
+  | 'action' // 动作设计 agent
+
+/** 填充内置提示词模板的上下文（全部可选，便于解耦/测试） */
+export type AgentPresetContext = {
+  /** 上游已确认节点的文本（章节原文 / 场次剧本 / 分镜表等） */
+  upstreamText?: string
+  /** S0 视觉总设定（项目级风格），拼进指令尾部统一全片风格 */
+  styleBible?: string
+  /** 场次 / 段落标题，用于 prompt 抬头 */
+  title?: string
+  /** 节奏基线：平均镜时（秒/镜），分镜 agent 切分用 */
+  pacingSecPerShot?: number
+  /** 单段视频模型时长上限（秒）；分镜 agent 据此保证每镜不超模型上限 */
+  maxClipSec?: number
+}
+
+export type CanvasAgentPreset = {
+  role: CanvasAgentRoleId
+  /** 中文标签 */
+  label: string
+  /** 一句话职责 */
+  description: string
+  /** 关联流水线角色（用于节点着色 / 推荐匹配的 ManagedAgent） */
+  pipelineRole: CanvasPipelineRole
+  /** 默认 AI 操作：剧本改写走 text_rewrite，其余生成走 text_generate */
+  defaultOperation: CanvasOperationType
+  /**
+   * 人设 system 提示词：当用户**未**选具体 ManagedAgent 时，可由调用方把它
+   * 作为兜底 system（或前缀）使用，让"无 agent"也带角色身份。
+   */
+  persona: string
+  /**
+   * 可编辑的指令模板（一键填入操作节点的「提示词」框）。
+   * `{upstream}` / `{title}` / `{style}` / `{pacing}` / `{maxClip}` 为占位槽，
+   * 由 buildAgentPresetPrompt 用上下文替换；未提供的槽给出占位说明，提示用户补全。
+   */
+  template: string
+}
+
+/** 默认单段视频时长上限（秒）——多数图生视频模型支持 4~10s，取保守上限 */
+export const DEFAULT_MAX_CLIP_SEC = 5
+
+/** 内置专属 agent 预设 */
+export const CANVAS_AGENT_PRESETS: CanvasAgentPreset[] = [
+  {
+    role: 'screenwriter',
+    label: '剧本 agent',
+    description: '把章节原文改写为规范的场次剧本，或润色既有剧本的对白与节奏',
+    pipelineRole: 'screenplay',
+    defaultOperation: 'text_generate',
+    persona:
+      '你是资深影视编剧。擅长把小说/散文改写为可拍摄的场次剧本，精通场景切分、动作描述、对白塑造与节奏控制。严格遵循格式，直接输出剧本，不解释过程。',
+    template: [
+      '【任务】把下面的原文改写为规范的影视场次剧本。',
+      '',
+      '【输出格式】按场次组织，每场包含：',
+      '- 场号 + 内/外景 + 地点 + 时间（例：场1 内景 茶馆 日）',
+      '- 出场人物',
+      '- 动作描述（客观、可视、现在时）',
+      '- 对白（角色名：台词）',
+      '- 必要时给出旁白/字幕',
+      '不要加入镜头语言（景别/运镜留给分镜阶段）。保持原文情节与人物关系，可合并琐碎、强化戏剧张力。',
+      '',
+      '【原文】',
+      '{upstream}',
+      '',
+      '{style}',
+    ].join('\n'),
+  },
+  {
+    role: 'storyboard',
+    label: '分镜 agent',
+    description: '把场次剧本拆成精确到秒的分镜表，每镜不超过视频模型时长上限',
+    pipelineRole: 'shot',
+    defaultOperation: 'text_generate',
+    persona:
+      '你是专业分镜师。把剧本拆解为可逐镜生成的分镜表，精确到秒，兼顾对白朗读时长、动作节拍与整体节奏。每一镜都要能被图生视频模型单独生成。',
+    template: [
+      '【任务】把下面的场次剧本拆成「精确到秒」的分镜表。',
+      '',
+      '【切分依据】对白按朗读时长估时（中文约5字/秒）+ 动作节拍 + 节奏基线（约 {pacing} 秒/镜）。',
+      '【硬约束】单镜时长不得超过 {maxClip} 秒（视频模型上限）；超过则拆成多镜，并保证镜间画面可衔接。',
+      '',
+      '【输出格式】先输出一个 JSON 对象，再输出 Markdown 表格。',
+      'JSON 顶层结构必须为：{"shots":[...],"summary":{"shotCount":数字,"totalDurationSec":数字}}。',
+      '每个 shots[] 项包含 index、durationSec、shotSize、movement、description、dialogue、characters、shotPrompt；字段无内容可用空字符串或空数组。',
+      '',
+      '随后输出兼容导入器的 Markdown 表格，列：',
+      '| 镜号 | 时长(秒) | 景别 | 运镜 | 画面/动作 | 对白 | 角色 |',
+      '景别用：远景/全景/中景/近景/特写；运镜用：固定/推/拉/摇/移/跟/环绕。',
+      '表格后给出：总镜数、总时长（秒）。',
+      '',
+      '【场次剧本】',
+      '{upstream}',
+      '',
+      '{style}',
+    ].join('\n'),
+  },
+  {
+    role: 'director',
+    label: '导演 agent',
+    description: '为分镜补全镜头语言、调度与视觉方案，统一全片影像气质',
+    pipelineRole: 'camera',
+    defaultOperation: 'text_generate',
+    persona:
+      '你是电影导演。从场面调度、镜头语言、光影与色彩、表演情绪出发，给分镜注入电影感，并保证全片视觉统一。给出可执行的镜头方案，不空谈理论。',
+    template: [
+      '【任务】作为导演，审阅并增强下面的分镜，补全镜头语言与场面调度。',
+      '',
+      '【对每一镜给出】',
+      '- 景别 / 角度（平视/俯/仰/过肩/主观）/ 运镜 / 焦段',
+      '- 构图与视觉重点、光影与色调、氛围',
+      '- 主要角色的位置关系、走位与表演情绪',
+      '- 与上一镜、下一镜的衔接（动作衔接/视线匹配/转场）',
+      '保持镜号与时长不变，只补充/优化镜头语言，输出与输入同结构的增强版分镜表。',
+      '',
+      '【分镜】',
+      '{upstream}',
+      '',
+      '{style}',
+    ].join('\n'),
+  },
+  {
+    role: 'action',
+    label: '动作设计 agent',
+    description: '为打斗/特技/运动镜头做动作分解与节拍设计，配套运镜建议',
+    pipelineRole: 'action',
+    defaultOperation: 'text_generate',
+    persona:
+      '你是动作指导（武术指导）。擅长把一段冲突/打斗/追逐分解为清晰、安全、有节奏的动作节拍，并给出与之匹配的运镜与剪辑建议。动作要具体到招式与身体部位。',
+    template: [
+      '【任务】为下面的动作段落做专业动作设计与节拍分解。',
+      '',
+      '【输出】按节拍编号给出：',
+      '- 节拍 N：双方/主体的具体动作（招式、发力、身体部位、移动方向）',
+      '- 力度与速度（蓄力/爆发/停顿）、预期时长（秒）',
+      '- 配套运镜与剪辑点（跟拍/甩镜/慢镜/硬切）',
+      '- 安全与可拍性提示',
+      '最后给出整段的动作高潮点与总时长建议。',
+      '',
+      '【动作段落】',
+      '{upstream}',
+      '',
+      '{style}',
+    ].join('\n'),
+  },
+]
+
+export function getAgentPreset(role: CanvasAgentRoleId): CanvasAgentPreset | undefined {
+  return CANVAS_AGENT_PRESETS.find((preset) => preset.role === role)
+}
+
+/**
+ * 用上下文填充内置提示词模板，返回可继续编辑的最终提示词。
+ * 未提供的槽位给出中文占位提示（而非留空），引导用户补全。
+ */
+export function buildAgentPresetPrompt(role: CanvasAgentRoleId, ctx: AgentPresetContext = {}): string {
+  const preset = getAgentPreset(role)
+  if (!preset) return ''
+
+  const upstream =
+    ctx.upstreamText && ctx.upstreamText.trim().length > 0
+      ? ctx.upstreamText.trim()
+      : '（在此粘贴上游内容，或先选中上游节点再发起）'
+  const pacing = ctx.pacingSecPerShot && ctx.pacingSecPerShot > 0 ? String(ctx.pacingSecPerShot) : '3'
+  const maxClip = ctx.maxClipSec && ctx.maxClipSec > 0 ? String(ctx.maxClipSec) : String(DEFAULT_MAX_CLIP_SEC)
+  const style =
+    ctx.styleBible && ctx.styleBible.trim().length > 0
+      ? `【全片视觉总设定（须贯彻）】\n${ctx.styleBible.trim()}`
+      : ''
+
+  let result = preset.template
+    .replaceAll('{upstream}', upstream)
+    .replaceAll('{pacing}', pacing)
+    .replaceAll('{maxClip}', maxClip)
+    .replaceAll('{style}', style)
+
+  // title 槽位（可选，部分模板未使用）
+  result = result.replaceAll('{title}', ctx.title?.trim() ?? '')
+
+  // 清理 style 为空时残留的多余空行
+  return result.replace(/\n{3,}/g, '\n\n').trim()
+}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasAssetInsert.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasAssetInsert.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { canvasApi } from './canvas.api'
+import type { CanvasDb } from './canvas.api'
+import type { CanvasNode } from './canvas.types'
+import type { FilmAssetKind } from './canvasFilmAssets'
+
+const STORAGE_KEY = 'spark-canvas:v1'
+const at = '2026-06-18T00:00:00.000Z'
+const pipelineRoleByKind: Partial<Record<FilmAssetKind, CanvasNode['data']['pipelineRole']>> = {
+  chapter: 'chapter',
+  script: 'screenplay',
+  character: 'character',
+  scene: 'scene',
+  prop: 'prop',
+  effect: 'effect',
+}
+
+function seedProject(): void {
+  const db: CanvasDb = {
+    projects: [
+      {
+        id: 'project-1',
+        userId: 0,
+        title: '影视资产项目',
+        status: 'active',
+        rootPath: '/tmp/project-1',
+        settings: {},
+        nodeCount: 0,
+        assetCount: 0,
+        taskCount: 0,
+        createdAt: at,
+        updatedAt: at,
+      },
+    ],
+    boards: [
+      {
+        id: 'board-1',
+        projectId: 'project-1',
+        userId: 0,
+        name: 'Board',
+        viewport: { x: 0, y: 0, zoom: 1 },
+        settings: {},
+        createdAt: at,
+        updatedAt: at,
+      },
+    ],
+    nodes: [],
+    edges: [],
+    assets: [],
+    tasks: [],
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(db))
+}
+
+function longAssetText(label: string): string {
+  return Array.from(
+    { length: 8 },
+    (_, index) => `${label}第${index + 1}段：角色在雨夜街口停下，霓虹和雾气压低画面，动作、情绪、环境细节都需要保留在画布节点中。`,
+  ).join('\n')
+}
+
+describe('canvas asset insertion', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.stubGlobal('window', window)
+    Object.assign(window, {
+      spark: { invoke: vi.fn().mockResolvedValue({ rootPath: '/tmp/project-1' }) },
+    })
+    seedProject()
+  })
+
+  it('keeps screenplay text after inserting a film asset and tagging pipeline role', async () => {
+    const scriptText = longAssetText('剧本')
+    const asset = await canvasApi.createFilmAsset('project-1', {
+      kind: 'script',
+      name: '雨夜追逐',
+      text: scriptText,
+    })
+
+    const node = await canvasApi.insertAssetToBoard({
+      projectId: 'project-1',
+      boardId: 'board-1',
+      assetId: asset.id,
+      x: 100,
+      y: 120,
+    })
+
+    expect(node?.type).toBe('text')
+    expect(node?.data.text).toBe(scriptText)
+    expect(node?.width).toBeGreaterThan(300)
+    expect(node?.height).toBeGreaterThan(164)
+
+    await canvasApi.updateNodeData('project-1', node!.id, { pipelineRole: 'screenplay' })
+    const snapshot = await canvasApi.openSnapshot('project-1')
+    const updatedNode = snapshot.nodes.find((item) => item.id === node!.id)
+    const updatedAsset = snapshot.assets.find((item) => item.id === asset.id)
+
+    expect(updatedNode?.data.text).toBe(scriptText)
+    expect(updatedNode?.data.pipelineRole).toBe('screenplay')
+    expect(updatedAsset?.contentText).toBe(scriptText)
+  })
+
+  it.each([
+    ['manuscript', 'text'],
+    ['chapter', 'text'],
+    ['script', 'text'],
+    ['character', 'prompt'],
+    ['scene', 'prompt'],
+    ['prop', 'prompt'],
+    ['effect', 'prompt'],
+  ] as Array<[FilmAssetKind, CanvasNode['type']]>)(
+    'inserts %s assets with their text and adaptive text size',
+    async (kind, expectedNodeType) => {
+      const text = longAssetText(kind)
+      const asset = await canvasApi.createFilmAsset('project-1', {
+        kind,
+        name: `${kind} asset`,
+        text,
+      })
+
+      const node = await canvasApi.insertAssetToBoard({
+        projectId: 'project-1',
+        boardId: 'board-1',
+        assetId: asset.id,
+        x: 10,
+        y: 20,
+      })
+
+      expect(node?.type).toBe(expectedNodeType)
+      expect(node?.data.text).toBe(text)
+      expect(node?.width).toBeGreaterThan(300)
+      expect(node?.height).toBeGreaterThan(164)
+
+      const role = pipelineRoleByKind[kind]
+      if (node && role) {
+        await canvasApi.updateNodeData('project-1', node.id, { pipelineRole: role })
+        const snapshot = await canvasApi.openSnapshot('project-1')
+        const updatedNode = snapshot.nodes.find((item) => item.id === node.id)
+        expect(updatedNode?.data.text).toBe(text)
+        expect(updatedNode?.data.pipelineRole).toBe(role)
+      }
+    },
+  )
+
+  it('uses prompt metadata when a prompt-like film asset has no contentText', async () => {
+    const prompt = longAssetText('场景提示词')
+    const asset = await canvasApi.createFilmAsset('project-1', {
+      kind: 'scene',
+      name: '雨夜巷口',
+      prompt,
+    })
+
+    const node = await canvasApi.insertAssetToBoard({
+      projectId: 'project-1',
+      boardId: 'board-1',
+      assetId: asset.id,
+      x: 0,
+      y: 0,
+    })
+
+    expect(node?.type).toBe('prompt')
+    expect(node?.data.text).toBe(prompt)
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildEntityDescription,
+  buildEntityExtractionPrompt,
+  parseExtractedCharacters,
+  parseExtractedScenes,
+} from './canvasEntityExtract'
+
+describe('canvasEntityExtract', () => {
+  describe('buildEntityExtractionPrompt', () => {
+    it('角色抽取提示词含格式要求与剧本', () => {
+      const prompt = buildEntityExtractionPrompt('character', '林岚推门进入。', '水墨写意')
+      expect(prompt).toContain('抽取其中出现的全部角色')
+      expect(prompt).toContain('"entities"')
+      expect(prompt).toContain('只输出一个 JSON 对象')
+      expect(prompt).toContain('林岚推门进入。')
+      expect(prompt).toContain('水墨写意')
+    })
+    it('场景抽取提示词用场景字段', () => {
+      const prompt = buildEntityExtractionPrompt('scene', '车站候车室')
+      expect(prompt).toContain('抽取其中出现的全部场景')
+      expect(prompt).toContain('location')
+    })
+  })
+
+  describe('buildEntityDescription', () => {
+    it('拼接字段为可读描述', () => {
+      const desc = buildEntityDescription('林岚', { gender: '男', appearance: '清瘦' })
+      expect(desc).toBe('林岚（性别：男；外貌：清瘦）')
+    })
+    it('无字段只返回名称', () => {
+      expect(buildEntityDescription('林岚', {})).toBe('林岚')
+    })
+  })
+
+  describe('parseExtractedCharacters', () => {
+    const OUTPUT = `
+名称：林岚
+性别：男
+外貌：清瘦，左脸有疤
+服饰：靛蓝短打
+标志道具：铜钥匙
+性格：沉默、坚韧
+
+名称：陈默
+性别：男
+身份：神秘访客
+外貌：高大，戴墨镜
+`
+
+    it('一对多解析出多个角色', () => {
+      const rows = parseExtractedCharacters(OUTPUT)
+      expect(rows).toHaveLength(2)
+      expect(rows[0]!.name).toBe('林岚')
+      expect(rows[1]!.name).toBe('陈默')
+    })
+
+    it('字段归一化进 fields', () => {
+      const rows = parseExtractedCharacters(OUTPUT)
+      expect(rows[0]!.fields.appearance).toBe('清瘦，左脸有疤')
+      expect(rows[0]!.fields.signatureProp).toBe('铜钥匙')
+      expect(rows[1]!.fields.occupation).toBe('神秘访客')
+    })
+
+    it('字段别名（长相→外貌、穿着→服饰）归一', () => {
+      const rows = parseExtractedCharacters('名称：甲\n长相：圆脸\n穿着：白袍')
+      expect(rows[0]!.fields.appearance).toBe('圆脸')
+      expect(rows[0]!.fields.costume).toBe('白袍')
+    })
+
+    it('同名角色合并，不覆盖已有非空值', () => {
+      const rows = parseExtractedCharacters('名称：甲\n外貌：高\n\n名称：甲\n外貌：矮\n性格：急躁')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.fields.appearance).toBe('高')
+      expect(rows[0]!.fields.personality).toBe('急躁')
+    })
+
+    it('description 含名称与字段', () => {
+      const rows = parseExtractedCharacters('名称：甲\n外貌：高')
+      expect(rows[0]!.description).toContain('甲')
+      expect(rows[0]!.description).toContain('外貌：高')
+    })
+
+    it('无名称行返回空', () => {
+      expect(parseExtractedCharacters('这是一段没有实体的说明文字。')).toEqual([])
+    })
+
+    it('名称前缺失时忽略孤立字段行', () => {
+      const rows = parseExtractedCharacters('外貌：高\n名称：乙\n服饰：黑衣')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.name).toBe('乙')
+      expect(rows[0]!.fields.costume).toBe('黑衣')
+      expect(rows[0]!.fields.appearance).toBeUndefined()
+    })
+
+    it('兜底：编号列表「1. 名字」也能解析', () => {
+      const rows = parseExtractedCharacters('1. 林岚\n外貌：清瘦\n2. 陈默\n身份：访客')
+      expect(rows.map((r) => r.name)).toEqual(['林岚', '陈默'])
+      expect(rows[0]!.fields.appearance).toBe('清瘦')
+      expect(rows[1]!.fields.occupation).toBe('访客')
+    })
+
+    it('兜底：「1、名字：描述」名字与描述分离', () => {
+      const rows = parseExtractedCharacters('1、林岚：清瘦少年，铜钥匙')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.name).toBe('林岚')
+      expect(rows[0]!.description).toContain('清瘦少年')
+    })
+
+    it('兜底不误伤普通字段行（外貌：高 不被当作实体）', () => {
+      const rows = parseExtractedCharacters('名称：甲\n外貌：高\n性格：稳')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.fields.appearance).toBe('高')
+    })
+
+    it('优先解析 JSON 格式并保留 prompt', () => {
+      const rows = parseExtractedCharacters(
+        JSON.stringify({
+          entities: [
+            {
+              name: '林岚',
+              description: '清瘦青年',
+              prompt: 'slim young man',
+              attributes: { appearance: '清瘦', costume: '靛蓝短打' },
+            },
+          ],
+        }),
+      )
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.fields.appearance).toBe('清瘦')
+      expect(rows[0]!.prompt).toBe('slim young man')
+    })
+  })
+
+  describe('parseExtractedScenes', () => {
+    it('解析场景并归一化字段', () => {
+      const rows = parseExtractedScenes('名称：候车室\n内外景：内景\n位置：废弃车站\n光影：昏暗')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!.fields.settingType).toBe('内景')
+      expect(rows[0]!.fields.location).toBe('废弃车站')
+      expect(rows[0]!.fields.lighting).toBe('昏暗')
+    })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.ts
@@ -1,0 +1,320 @@
+/**
+ * 实体抽取（剧本 → 角色 / 场景，一对多）。
+ *
+ * 用于画布「文本节点右键 → 提取角色 / 提取场景」：让文本模型按**固定可解析格式**
+ * 输出实体清单，再用这里的解析器还原为结构化实体，逐个落库 + 在画布生成专用节点。
+ * 纯逻辑、无 DOM/IPC，便于单测。
+ */
+
+export type ExtractEntityKind = 'character' | 'scene'
+
+/** 解析出的单个实体（字段已归一化为中文标准 key） */
+export type ParsedEntity = {
+  /** 名称（唯一键） */
+  name: string
+  /** 归一化字段：标准字段名 → 值（可直接作为资产 attributes） */
+  fields: Record<string, string>
+  /** 默认生成提示词（用于后续生图/生视频），为空时回退 description */
+  prompt?: string
+  /** 整段可读描述（兜底文本，用作资产 text / 生成 prompt） */
+  description: string
+  /** 原始结构化数据，供任务日志/详情排查 */
+  raw?: unknown
+}
+
+/** 字段别名表：把模型可能用的不同字段名归一到标准 key */
+const FIELD_ALIASES: Record<ExtractEntityKind, Array<{ key: string; match: RegExp }>> = {
+  character: [
+    { key: 'gender', match: /^性别|gender$/i },
+    { key: 'age', match: /^年龄|年龄段|年纪|age$/i },
+    { key: 'occupation', match: /^身份|职业|角色定位|occupation|role$/i },
+    { key: 'appearance', match: /^外貌|外形|长相|相貌|体貌|appearance|look$/i },
+    { key: 'hair', match: /^发型|发式|头发|hair$/i },
+    { key: 'costume', match: /^服饰|服装|穿着|衣着|costume|clothing$/i },
+    { key: 'signatureProp', match: /^标志道具|随身道具|道具|标志物|signatureProp|prop$/i },
+    { key: 'personality', match: /^性格|气质|个性|personality$/i },
+    { key: 'voice', match: /^声线|声音|嗓音|voice$/i },
+  ],
+  scene: [
+    { key: 'settingType', match: /^类型|内外景|场景类型|settingType|type$/i },
+    { key: 'location', match: /^地点|位置|场所|location|place$/i },
+    { key: 'timeOfDay', match: /^时间|时段|时间段|timeOfDay|time$/i },
+    { key: 'weather', match: /^天气|weather$/i },
+    { key: 'lighting', match: /^光线|光影|照明|lighting|light$/i },
+    { key: 'colorTone', match: /^色调|色彩|色温|colorTone|palette$/i },
+    { key: 'artDirection', match: /^美术|美术风格|风格|artDirection|art$/i },
+    { key: 'mood', match: /^氛围|情绪|气氛|mood|atmosphere$/i },
+  ],
+}
+
+const FIELD_LABELS: Record<string, string> = {
+  age: '年龄',
+  gender: '性别',
+  occupation: '身份',
+  appearance: '外貌',
+  hair: '发型',
+  costume: '服饰',
+  signatureProp: '标志道具',
+  personality: '性格',
+  voice: '声线',
+  settingType: '类型',
+  location: '地点',
+  timeOfDay: '时间',
+  weather: '天气',
+  lighting: '光线',
+  colorTone: '色调',
+  artDirection: '美术',
+  mood: '氛围',
+}
+
+const ENTITY_LABEL: Record<ExtractEntityKind, string> = {
+  character: '角色',
+  scene: '场景',
+}
+
+/** 构造抽取提示词：要求模型按可解析格式逐个输出实体 */
+export function buildEntityExtractionPrompt(
+  kind: ExtractEntityKind,
+  scriptText: string,
+  styleBible?: string,
+): string {
+  const label = ENTITY_LABEL[kind]
+  const attributeKeys =
+    kind === 'character'
+      ? ['age', 'gender', 'occupation', 'appearance', 'hair', 'costume', 'signatureProp', 'personality', 'voice']
+      : ['settingType', 'location', 'timeOfDay', 'weather', 'lighting', 'colorTone', 'artDirection', 'mood']
+  const example =
+    kind === 'character'
+      ? {
+          kind: 'character',
+          entities: [
+            {
+              name: '林岚',
+              description: '清瘦青年，左脸有旧疤，沉默坚韧，是故事的主要行动者。',
+              prompt: 'slim young man, scar on left cheek, indigo short outfit, brass key, quiet and resilient, cinematic character design',
+              attributes: {
+                age: '青年',
+                gender: '男',
+                occupation: '主角 / 行动者',
+                appearance: '清瘦，左脸有疤',
+                costume: '靛蓝短打',
+                signatureProp: '铜钥匙',
+                personality: '沉默、坚韧',
+              },
+            },
+          ],
+        }
+      : {
+          kind: 'scene',
+          entities: [
+            {
+              name: '旧车站候车室',
+              description: '废弃车站的内景夜戏空间，顶灯忽明忽暗，压抑且悬疑。',
+              prompt: 'abandoned railway station waiting room at night, flickering ceiling lights, oppressive suspense mood, cinematic production design',
+              attributes: {
+                settingType: '内景',
+                location: '废弃车站',
+                timeOfDay: '夜',
+                lighting: '忽明忽暗的顶灯',
+                mood: '压抑、悬疑',
+              },
+            },
+          ],
+        }
+
+  return [
+    `【任务】通读下面的剧本，抽取其中出现的全部${label}，输出稳定 JSON。`,
+    '【硬性格式要求】只输出一个 JSON 对象，不要 Markdown，不要代码块，不要额外解释。',
+    `JSON 顶层结构必须为：{"kind":"${kind}","entities":[...]}`,
+    `每个 entities[] 项必须包含 name、description、prompt、attributes。attributes 只使用这些 key：${attributeKeys.join(', ')}。`,
+    'description 写完整可读设定；prompt 写可直接用于后续 AI 生图/生视频的视觉提示词；无信息的字段不要编造，可省略。',
+    `同一${label}只出现一次，按剧情重要性排序。`,
+    '',
+    '【示例】',
+    JSON.stringify(example, null, 2),
+    '',
+    styleBible && styleBible.trim() ? `【可参考的全片视觉总设定】\n${styleBible.trim()}\n` : '',
+    '【剧本】',
+    scriptText.trim(),
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+/** 取「字段：值」；返回 null 表示该行不是字段行 */
+function parseFieldLine(line: string): { rawKey: string; value: string } | null {
+  const match = line.match(/^[\s\-*•]*([^：:]{1,12})[：:]\s*(.*)$/)
+  if (!match) return null
+  return { rawKey: match[1]!.trim(), value: (match[2] ?? '').trim() }
+}
+
+/**
+ * 兜底：识别「编号 / 项目符号 + 名称」作为实体起点（模型不守「名称：」格式时常见）。
+ * 例：`1. 林岚`、`1、林岚：清瘦少年`、`- 陈默 - 神秘访客`。
+ * 返回 { name, rest }，rest 为名称后的补充描述（可空）；不匹配返回 null。
+ */
+function parseNumberedNameLine(line: string): { name: string; rest: string } | null {
+  const match = line.match(/^\s*(?:\d+|[一二三四五六七八九十]+)[.、)：:]\s*([^：:，,\-—]{1,16})(?:[：:，,\-—]\s*(.*))?$/)
+  if (!match) return null
+  const name = match[1]!.trim()
+  if (!name) return null
+  return { name, rest: (match[2] ?? '').trim() }
+}
+
+/** 归一化字段名到标准 key；无匹配返回原 key */
+function normalizeFieldKey(kind: ExtractEntityKind, rawKey: string): string {
+  for (const alias of FIELD_ALIASES[kind]) {
+    if (alias.match.test(rawKey)) return alias.key
+  }
+  return rawKey
+}
+
+/** 把归一化字段拼成可读描述 */
+export function buildEntityDescription(name: string, fields: Record<string, string>): string {
+  const parts = Object.entries(fields)
+    .filter(([, value]) => value.trim().length > 0)
+    .map(([key, value]) => `${FIELD_LABELS[key] ?? key}：${value.trim()}`)
+  return parts.length > 0 ? `${name}（${parts.join('；')}）` : name
+}
+
+function tryParseJsonObject(text: string): unknown | null {
+  const trimmed = text.trim()
+  const candidates = [trimmed]
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  if (fenced?.[1]) candidates.push(fenced[1].trim())
+  const firstBrace = trimmed.indexOf('{')
+  const lastBrace = trimmed.lastIndexOf('}')
+  if (firstBrace >= 0 && lastBrace > firstBrace) candidates.push(trimmed.slice(firstBrace, lastBrace + 1))
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate)
+    } catch {
+      // try next candidate
+    }
+  }
+  return null
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function parseJsonEntities(kind: ExtractEntityKind, text: string): ParsedEntity[] {
+  const parsed = tryParseJsonObject(text)
+  if (!parsed || typeof parsed !== 'object') return []
+  const root = parsed as Record<string, unknown>
+  const rawEntities = Array.isArray(root.entities) ? root.entities : []
+  const result: ParsedEntity[] = []
+  const seen = new Set<string>()
+  for (const raw of rawEntities) {
+    if (!raw || typeof raw !== 'object') continue
+    const item = raw as Record<string, unknown>
+    const name = stringField(item.name)
+    if (!name) continue
+    const key = name.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const fields: Record<string, string> = {}
+    const attrs = item.attributes
+    if (attrs && typeof attrs === 'object' && !Array.isArray(attrs)) {
+      for (const [rawKey, rawValue] of Object.entries(attrs as Record<string, unknown>)) {
+        const value = stringField(rawValue)
+        if (!value) continue
+        fields[normalizeFieldKey(kind, rawKey)] = value
+      }
+    }
+    const description = stringField(item.description) || buildEntityDescription(name, fields)
+    const prompt = stringField(item.prompt)
+    result.push({
+      name,
+      fields,
+      description,
+      ...(prompt ? { prompt } : {}),
+      raw: item,
+    })
+  }
+  return result
+}
+
+/**
+ * 解析模型输出的实体清单。容错：
+ * - 优先解析 JSON：{"entities":[{name, description, prompt, attributes}]}；
+ * - 以「名称：X」或「名称:X」作为实体起点；
+ * - 其后的「字段：值」行归一化进 fields；
+ * - 无冒号的行追加到当前实体描述；
+ * - 同名实体合并（后出现的字段补全先出现的，不覆盖已有非空值）。
+ */
+export function parseExtractedEntities(kind: ExtractEntityKind, text: string): ParsedEntity[] {
+  const jsonEntities = parseJsonEntities(kind, text)
+  if (jsonEntities.length > 0) return jsonEntities
+
+  const lines = text.replace(/\r\n/g, '\n').split('\n')
+  const byName = new Map<string, ParsedEntity>()
+  const order: string[] = []
+  let current: ParsedEntity | null = null
+  const extraLines = new Map<string, string[]>()
+
+  const isNameLine = (parsed: { rawKey: string } | null): boolean =>
+    parsed != null && /^名称|^名字|^名$/.test(parsed.rawKey)
+
+  const startEntity = (name: string): ParsedEntity => {
+    const key = name.toLowerCase()
+    const existing = byName.get(key)
+    if (existing) return existing
+    const entity: ParsedEntity = { name, fields: {}, description: '' }
+    byName.set(key, entity)
+    order.push(key)
+    extraLines.set(key, [])
+    return entity
+  }
+
+  for (const raw of lines) {
+    const line = raw.trim()
+    if (!line) continue
+    const field = parseFieldLine(line)
+
+    if (isNameLine(field) && field!.value.trim()) {
+      current = startEntity(field!.value.trim())
+      continue
+    }
+
+    // 兜底：「1. 林岚」「- 陈默 - 神秘访客」等编号/项目符号名称行作为实体起点
+    const numbered = parseNumberedNameLine(line)
+    if (numbered) {
+      current = startEntity(numbered.name)
+      if (numbered.rest) extraLines.get(current.name.toLowerCase())?.push(numbered.rest)
+      continue
+    }
+
+    if (!current) continue
+
+    if (field && field.value) {
+      const stdKey = normalizeFieldKey(kind, field.rawKey)
+      // 不覆盖已有非空值（合并语义）
+      if (!current.fields[stdKey] || current.fields[stdKey]!.trim().length === 0) {
+        current.fields[stdKey] = field.value
+      }
+    } else {
+      // 非字段行：作为补充描述
+      const key = current.name.toLowerCase()
+      extraLines.get(key)?.push(line)
+    }
+  }
+
+  return order.map((key) => {
+    const entity = byName.get(key)!
+    const extras = extraLines.get(key) ?? []
+    const base = buildEntityDescription(entity.name, entity.fields)
+    entity.description = extras.length > 0 ? `${base}\n${extras.join('\n')}` : base
+    return entity
+  })
+}
+
+export function parseExtractedCharacters(text: string): ParsedEntity[] {
+  return parseExtractedEntities('character', text)
+}
+
+export function parseExtractedScenes(text: string): ParsedEntity[] {
+  return parseExtractedEntities('scene', text)
+}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipeline.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipeline.test.ts
@@ -23,16 +23,18 @@ describe('canvasPipeline', () => {
       expect(actions[0]!.produces).toBe('screenplay')
     })
 
-    it('剧本可抽资源 + 生成分镜', () => {
+    it('剧本可生成分镜脚本 / 提取角色 / 提取场景 / 分镜关键帧图', () => {
       expect(getPipelineActions('screenplay').map((a) => a.id)).toEqual([
-        'screenplay.extract_resources',
-        'screenplay.to_shots',
+        'screenplay.to_shot_script',
+        'screenplay.extract_characters',
+        'screenplay.extract_scenes',
+        'screenplay.storyboard_grid',
       ])
     })
 
-    it('角色支持多面向出图', () => {
+    it('角色出三视图，产出设定图卡', () => {
       const actions = getPipelineActions('character')
-      expect(actions[0]!.multiAspect).toBe(true)
+      expect(actions.map((a) => a.id)).toEqual(['character.three_view'])
       expect(actions[0]!.produces).toBe('design_card')
     })
 

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipeline.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipeline.ts
@@ -21,10 +21,15 @@ import type {
   ManuscriptIndex,
 } from './canvasFilmTypes'
 import { readFilmMetadata, writeFilmMetadata } from './canvasFilmTypes'
+import {
+  getOpsForRole,
+  getOpsForNode,
+  type CanvasPipelineOp,
+} from './canvasPipelineOps'
 
 // ─── 编排动作（右键「下一步」菜单数据源，设计 §7）────────────────────────────
 
-/** 一个可执行的流水线编排动作 */
+/** 一个可执行的流水线编排动作（由 canvasPipelineOps 目录派生，保持单一事实源） */
 export type PipelineAction = {
   /** 动作 id（稳定，便于 UI 绑定与测试） */
   id: string
@@ -34,67 +39,31 @@ export type PipelineAction = {
   produces: CanvasPipelineRole
   /** 若直接落为媒体任务，对应的 operation（agent 文本动作则为空） */
   operation?: CanvasOperationType
-  /** 是否需要面向多选（角色图） */
-  multiAspect?: boolean
+  /** 图标 key（映射到 Icons.*） */
+  icon?: string
 }
 
-const PIPELINE_ACTIONS: Partial<Record<CanvasPipelineRole, PipelineAction[]>> = {
-  chapter: [{ id: 'chapter.to_screenplay', label: '转剧本', produces: 'screenplay' }],
-  screenplay: [
-    { id: 'screenplay.extract_resources', label: '抽取资源', produces: 'character' },
-    { id: 'screenplay.to_shots', label: '生成分镜', produces: 'shot' },
-  ],
-  character: [
-    {
-      id: 'character.generate_images',
-      label: '生成角色图',
-      produces: 'design_card',
-      operation: 'text_to_image',
-      multiAspect: true,
-    },
-  ],
-  scene: [
-    {
-      id: 'scene.generate_concept',
-      label: '生成概念图',
-      produces: 'design_card',
-      operation: 'text_to_image',
-    },
-  ],
-  prop: [
-    {
-      id: 'prop.generate_concept',
-      label: '生成道具图',
-      produces: 'design_card',
-      operation: 'text_to_image',
-    },
-  ],
-  effect: [
-    {
-      id: 'effect.generate_concept',
-      label: '生成特效图',
-      produces: 'design_card',
-      operation: 'text_to_image',
-    },
-  ],
-  shot: [
-    {
-      id: 'shot.to_keyframes',
-      label: '生成关键帧',
-      produces: 'keyframe',
-      operation: 'text_to_image',
-    },
-    { id: 'shot.to_video', label: '生成视频', produces: 'clip', operation: 'image_to_video' },
-  ],
-  keyframe: [
-    { id: 'keyframe.to_video', label: '出视频(首尾帧)', produces: 'clip', operation: 'image_to_video' },
-  ],
+function toAction(op: CanvasPipelineOp): PipelineAction {
+  return {
+    id: op.id,
+    label: op.label,
+    produces: op.produces,
+    icon: op.icon,
+    ...(op.baseOperation ? { operation: op.baseOperation } : {}),
+  }
 }
 
 /** 解析某流水线角色「下一步」可执行的编排动作 */
 export function getPipelineActions(role: CanvasPipelineRole | undefined): PipelineAction[] {
-  if (!role) return []
-  return PIPELINE_ACTIONS[role] ?? []
+  return getOpsForRole(role).map(toAction)
+}
+
+/** 解析某节点「下一步」可执行的编排动作（无 role 的文本节点也能拿到剧本类入口） */
+export function getNodePipelineActions(node: {
+  type: import('./canvas.types').CanvasNodeType
+  data?: { pipelineRole?: CanvasPipelineRole }
+}): PipelineAction[] {
+  return getOpsForNode(node).map(toAction)
 }
 
 // ─── 生产状态机 / 确认闸门 / 过期传播（设计 §9.2）──────────────────────────

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CANVAS_PIPELINE_OPS,
+  buildOpPrompt,
+  getOp,
+  getOpsForNode,
+  getOpsForRole,
+} from './canvasPipelineOps'
+
+describe('canvasPipelineOps', () => {
+  it('op id 全局唯一', () => {
+    const ids = CANVAS_PIPELINE_OPS.map((op) => op.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('剧本角色有四个专用 op', () => {
+    expect(getOpsForRole('screenplay').map((op) => op.id)).toEqual([
+      'screenplay.to_shot_script',
+      'screenplay.extract_characters',
+      'screenplay.extract_scenes',
+      'screenplay.storyboard_grid',
+    ])
+  })
+
+  it('角色/场景有出图 op', () => {
+    expect(getOpsForRole('character').map((op) => op.id)).toEqual(['character.three_view'])
+    expect(getOpsForRole('scene').map((op) => op.id)).toEqual(['scene.scene_image'])
+  })
+
+  describe('getOpsForNode', () => {
+    it('无 role 的文本节点给剧本类入口', () => {
+      const ops = getOpsForNode({ type: 'text' })
+      expect(ops.map((op) => op.id)).toContain('screenplay.to_shot_script')
+      expect(ops.map((op) => op.id)).toContain('screenplay.extract_characters')
+    })
+    it('有 role 时按角色匹配', () => {
+      const ops = getOpsForNode({ type: 'image', data: { pipelineRole: 'character' } })
+      expect(ops.map((op) => op.id)).toEqual(['character.three_view'])
+    })
+    it('无 role 的图片节点不给入口', () => {
+      expect(getOpsForNode({ type: 'image' })).toEqual([])
+    })
+  })
+
+  describe('buildOpPrompt', () => {
+    it('生成分镜脚本委托分镜预设，含时长上限', () => {
+      const prompt = buildOpPrompt('screenplay.to_shot_script', {
+        upstreamText: '场1 候车室',
+        maxClipSec: 8,
+      })
+      expect(prompt).toContain('场1 候车室')
+      expect(prompt).toContain('不得超过 8 秒')
+    })
+    it('提取角色委托抽取提示词', () => {
+      const prompt = buildOpPrompt('screenplay.extract_characters', { upstreamText: '林岚登场' })
+      expect(prompt).toContain('抽取其中出现的全部角色')
+      expect(prompt).toContain('林岚登场')
+    })
+    it('提取场景委托抽取提示词', () => {
+      const prompt = buildOpPrompt('screenplay.extract_scenes', { upstreamText: '车站' })
+      expect(prompt).toContain('抽取其中出现的全部场景')
+    })
+    it('图像类 op 返回空（由 workspace 用资产构建）', () => {
+      expect(buildOpPrompt('character.three_view', {})).toBe('')
+    })
+  })
+
+  it('getOp 命中与未命中', () => {
+    expect(getOp('shot.to_video')?.produces).toBe('clip')
+    expect(getOp('nope')).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.ts
@@ -1,0 +1,205 @@
+/**
+ * 画布专用流水线操作目录（「文本节点右键 → 专用流水线节点」改造的单一事实源）。
+ *
+ * 每个 op = 一个右键可执行的专用操作：源节点 → 任务节点 → 产物节点。
+ * 这里只描述「有哪些 op / 适用于哪些源 / 产出什么 / 文本类 op 的提示词怎么拼」，
+ * 真正的任务编排在 CanvasWorkspaceView（复用 handleCreateTask / runTrackedCanvasWorkflow）。
+ * 纯逻辑、无 DOM/IPC，便于单测。
+ */
+
+import type { CanvasOperationType, CanvasNodeType, CanvasPipelineRole } from './canvas.types'
+import { buildAgentPresetPrompt } from './canvasAgentPromptPresets'
+import { buildEntityExtractionPrompt, type ExtractEntityKind } from './canvasEntityExtract'
+
+/** op 类别：文本生成 / 实体抽取(一对多) / 图像生成 / 视频生成 */
+export type PipelineOpKind = 'text' | 'extract' | 'image' | 'video'
+
+export type CanvasPipelineOp = {
+  /** 稳定 id（UI 绑定 + dispatch + 测试） */
+  id: string
+  /** 中文菜单标签 */
+  label: string
+  /** 图标 key（映射到 Icons.*，避免在纯模块里引 JSX） */
+  icon: string
+  kind: PipelineOpKind
+  /** 产出节点的流水线角色 */
+  produces: CanvasPipelineRole
+  /** 适用的源流水线角色 */
+  appliesTo: CanvasPipelineRole[]
+  /** 是否也适用于「无 pipelineRole 的纯文本/Prompt 节点」（让剧本文本节点右键即可用） */
+  appliesToText?: boolean
+  /** 落为任务时的 operation */
+  baseOperation?: CanvasOperationType
+  /** 抽取类 op 的实体种类 */
+  extractKind?: ExtractEntityKind
+}
+
+export const CANVAS_PIPELINE_OPS: CanvasPipelineOp[] = [
+  // 章节
+  {
+    id: 'chapter.to_screenplay',
+    label: '转剧本',
+    icon: 'FileText',
+    kind: 'text',
+    produces: 'screenplay',
+    appliesTo: ['chapter'],
+    baseOperation: 'text_rewrite',
+  },
+  // 剧本（也适用于任意文本节点）
+  {
+    id: 'screenplay.to_shot_script',
+    label: '生成分镜脚本',
+    icon: 'Film',
+    kind: 'text',
+    produces: 'shot',
+    appliesTo: ['screenplay'],
+    appliesToText: true,
+    baseOperation: 'text_generate',
+  },
+  {
+    id: 'screenplay.extract_characters',
+    label: '提取角色',
+    icon: 'User',
+    kind: 'extract',
+    produces: 'character',
+    appliesTo: ['screenplay'],
+    appliesToText: true,
+    extractKind: 'character',
+  },
+  {
+    id: 'screenplay.extract_scenes',
+    label: '提取场景',
+    icon: 'Map',
+    kind: 'extract',
+    produces: 'scene',
+    appliesTo: ['screenplay'],
+    appliesToText: true,
+    extractKind: 'scene',
+  },
+  {
+    id: 'screenplay.storyboard_grid',
+    label: '生成分镜关键帧图',
+    icon: 'Image',
+    kind: 'image',
+    produces: 'keyframe',
+    appliesTo: ['screenplay'],
+    appliesToText: true,
+    baseOperation: 'text_to_image',
+  },
+  // 角色 / 场景 / 道具 / 特效设计图
+  {
+    id: 'character.three_view',
+    label: '生成三视图',
+    icon: 'User',
+    kind: 'image',
+    produces: 'design_card',
+    appliesTo: ['character'],
+    baseOperation: 'text_to_image',
+  },
+  {
+    id: 'scene.scene_image',
+    label: '生成场景图',
+    icon: 'Box',
+    kind: 'image',
+    produces: 'design_card',
+    appliesTo: ['scene'],
+    baseOperation: 'text_to_image',
+  },
+  {
+    id: 'prop.prop_image',
+    label: '生成道具图',
+    icon: 'Box',
+    kind: 'image',
+    produces: 'design_card',
+    appliesTo: ['prop'],
+    baseOperation: 'text_to_image',
+  },
+  {
+    id: 'effect.effect_image',
+    label: '生成特效图',
+    icon: 'Sparkles',
+    kind: 'image',
+    produces: 'design_card',
+    appliesTo: ['effect'],
+    baseOperation: 'text_to_image',
+  },
+  // 分镜 / 关键帧
+  {
+    id: 'shot.to_keyframes',
+    label: '生成关键帧',
+    icon: 'Image',
+    kind: 'image',
+    produces: 'keyframe',
+    appliesTo: ['shot'],
+    baseOperation: 'text_to_image',
+  },
+  {
+    id: 'shot.to_video',
+    label: '生成视频',
+    icon: 'Play',
+    kind: 'video',
+    produces: 'clip',
+    appliesTo: ['shot'],
+    baseOperation: 'image_to_video',
+  },
+  {
+    id: 'keyframe.to_video',
+    label: '出视频(首尾帧)',
+    icon: 'Play',
+    kind: 'video',
+    produces: 'clip',
+    appliesTo: ['keyframe'],
+    baseOperation: 'image_to_video',
+  },
+]
+
+export function getOp(id: string): CanvasPipelineOp | undefined {
+  return CANVAS_PIPELINE_OPS.find((op) => op.id === id)
+}
+
+/** 某流水线角色「下一步」可执行的 op */
+export function getOpsForRole(role: CanvasPipelineRole | undefined): CanvasPipelineOp[] {
+  if (!role) return []
+  return CANVAS_PIPELINE_OPS.filter((op) => op.appliesTo.includes(role))
+}
+
+/**
+ * 某节点可执行的 op。
+ * - 有 pipelineRole：按角色匹配；
+ * - 无 pipelineRole 的文本/Prompt 节点：给「剧本类」入口（生成分镜脚本 / 提取角色 / 提取场景 / 分镜关键帧图），
+ *   让章→剧本改写产出的纯文本节点右键即可用。
+ */
+export function getOpsForNode(node: {
+  type: CanvasNodeType
+  data?: { pipelineRole?: CanvasPipelineRole }
+}): CanvasPipelineOp[] {
+  const role = node.data?.pipelineRole
+  if (role) return getOpsForRole(role)
+  if (node.type === 'text' || node.type === 'prompt') {
+    return CANVAS_PIPELINE_OPS.filter((op) => op.appliesToText)
+  }
+  return []
+}
+
+/** 文本/抽取类 op 的提示词（图像/视频类返回空，由 workspace 用各自资产构建） */
+export function buildOpPrompt(
+  id: string,
+  ctx: { upstreamText?: string; styleBible?: string; maxClipSec?: number } = {},
+): string {
+  const op = getOp(id)
+  if (!op) return ''
+  switch (op.id) {
+    case 'screenplay.to_shot_script':
+      return buildAgentPresetPrompt('storyboard', {
+        ...(ctx.upstreamText ? { upstreamText: ctx.upstreamText } : {}),
+        ...(ctx.styleBible ? { styleBible: ctx.styleBible } : {}),
+        ...(ctx.maxClipSec ? { maxClipSec: ctx.maxClipSec } : {}),
+      })
+    case 'screenplay.extract_characters':
+      return buildEntityExtractionPrompt('character', ctx.upstreamText ?? '', ctx.styleBible)
+    case 'screenplay.extract_scenes':
+      return buildEntityExtractionPrompt('scene', ctx.upstreamText ?? '', ctx.styleBible)
+    default:
+      return ''
+  }
+}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasShotSplit.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasShotSplit.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import type { ShotSegment } from './canvasFilmAssets'
+import { planSegmentSplit, resolveSegmentDuration, splitSegmentAt } from './canvasShotSplit'
+
+function makeSegment(overrides: Partial<ShotSegment> = {}): ShotSegment {
+  return {
+    id: 'seg1',
+    index: 1,
+    title: '镜1',
+    description: '少年拔剑',
+    dialogue: '住手！',
+    durationSec: 12,
+    inSec: 0,
+    outSec: 12,
+    characterAssetIds: ['c1'],
+    sceneAssetId: 's1',
+    cameraDesignId: 'cam1',
+    ...overrides,
+  }
+}
+
+describe('canvasShotSplit', () => {
+  describe('resolveSegmentDuration', () => {
+    it('优先 durationSec', () => {
+      expect(resolveSegmentDuration({ durationSec: 6, inSec: 0, outSec: 4 })).toBe(6)
+    })
+    it('退化为 out-in', () => {
+      expect(resolveSegmentDuration({ inSec: 2, outSec: 7 })).toBe(5)
+    })
+    it('都没有则 0', () => {
+      expect(resolveSegmentDuration({})).toBe(0)
+    })
+  })
+
+  describe('planSegmentSplit by maxClipSec', () => {
+    it('12 秒按 5 秒上限拆成 3 段', () => {
+      const parts = planSegmentSplit(makeSegment(), { maxClipSec: 5 })
+      expect(parts).toHaveLength(3)
+      expect(parts.every((p) => p.durationSec <= 5)).toBe(true)
+    })
+
+    it('拆分后 in/out 连续且收尾对齐父镜', () => {
+      const parts = planSegmentSplit(makeSegment({ durationSec: 12, inSec: 0 }), { maxClipSec: 5 })
+      expect(parts[0]!.inSec).toBe(0)
+      for (let i = 1; i < parts.length; i += 1) {
+        expect(parts[i]!.inSec).toBe(parts[i - 1]!.outSec)
+      }
+      expect(parts.at(-1)!.outSec).toBe(12)
+    })
+
+    it('从父镜 inSec 偏移累计', () => {
+      const parts = planSegmentSplit(makeSegment({ durationSec: 10, inSec: 30, outSec: 40 }), {
+        maxClipSec: 5,
+      })
+      expect(parts[0]!.inSec).toBe(30)
+      expect(parts.at(-1)!.outSec).toBe(40)
+    })
+
+    it('对白只保留在第一段', () => {
+      const parts = planSegmentSplit(makeSegment(), { maxClipSec: 5 })
+      expect(parts[0]!.dialogue).toBe('住手！')
+      expect(parts[1]!.dialogue).toBeUndefined()
+      expect(parts[2]!.dialogue).toBeUndefined()
+    })
+
+    it('各段继承资源引用与风格预设', () => {
+      const parts = planSegmentSplit(makeSegment(), { maxClipSec: 5 })
+      for (const part of parts) {
+        expect(part.characterAssetIds).toEqual(['c1'])
+        expect(part.sceneAssetId).toBe('s1')
+        expect(part.cameraDesignId).toBe('cam1')
+      }
+    })
+
+    it('短于上限不拆，返回单段', () => {
+      const parts = planSegmentSplit(makeSegment({ durationSec: 4, outSec: 4 }), { maxClipSec: 5 })
+      expect(parts).toHaveLength(1)
+      expect(parts[0]!.title).toBe('镜1')
+    })
+
+    it('未知时长用上限兜底每段时长', () => {
+      const noDuration: ShotSegment = { id: 'seg1', index: 1, title: '镜1' }
+      const parts = planSegmentSplit(noDuration, { parts: 2, maxClipSec: 5 })
+      expect(parts).toHaveLength(2)
+      expect(parts.every((p) => p.durationSec > 0)).toBe(true)
+    })
+  })
+
+  describe('planSegmentSplit by parts', () => {
+    it('显式段数优先于时长上限', () => {
+      const parts = planSegmentSplit(makeSegment({ durationSec: 12 }), { parts: 4, maxClipSec: 5 })
+      expect(parts).toHaveLength(4)
+    })
+  })
+
+  describe('splitSegmentAt', () => {
+    it('在指定秒切成两段', () => {
+      const parts = splitSegmentAt(makeSegment({ durationSec: 10, inSec: 0, outSec: 10 }), 4)
+      expect(parts).toHaveLength(2)
+      expect(parts[0]!.outSec).toBe(4)
+      expect(parts[1]!.inSec).toBe(4)
+      expect(parts[1]!.outSec).toBe(10)
+    })
+
+    it('越界切点退化为均分', () => {
+      const parts = splitSegmentAt(makeSegment({ durationSec: 10, inSec: 0, outSec: 10 }), 99)
+      expect(parts[0]!.outSec).toBe(5)
+    })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasShotSplit.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasShotSplit.ts
@@ -1,0 +1,183 @@
+/**
+ * 分镜拆分（设计 §S6 / §S8：单段视频模型时长上限，需把一镜拆成多段逐段制作）。
+ *
+ * 纯逻辑：把一个分镜片段按「时长上限」或「指定段数 / 指定切点」拆成多段，
+ * 每段继承父镜的角色/场景/道具/风格预设引用与镜头提示词，重算 in/out/时长。
+ * 无 DOM/IPC，便于单测。
+ */
+
+import type { ShotSegment } from './canvasFilmAssets'
+import { DEFAULT_MAX_CLIP_SEC } from './canvasAgentPromptPresets'
+
+/** 拆分产物：可直接喂给 createShotSegment 的字段子集（不含 id / index，由调用方分配） */
+export type ShotSplitPart = {
+  title: string
+  description?: string
+  dialogue?: string
+  narration?: string
+  durationSec: number
+  inSec: number
+  outSec: number
+  characterAssetIds?: string[]
+  sceneAssetId?: string
+  propAssetIds?: string[]
+  shotPrompt?: string
+  cameraDesignId?: string
+  actionDesignId?: string
+  frameDesignId?: string
+}
+
+/** 取片段时长：优先 durationSec，其次 out-in，最后兜底 0 */
+export function resolveSegmentDuration(segment: Pick<ShotSegment, 'durationSec' | 'inSec' | 'outSec'>): number {
+  if (typeof segment.durationSec === 'number' && segment.durationSec > 0) return segment.durationSec
+  if (
+    typeof segment.inSec === 'number' &&
+    typeof segment.outSec === 'number' &&
+    segment.outSec > segment.inSec
+  ) {
+    return segment.outSec - segment.inSec
+  }
+  return 0
+}
+
+/** 四舍五入到 0.5 秒，避免浮点毛刺 */
+function roundHalf(value: number): number {
+  return Math.round(value * 2) / 2
+}
+
+/**
+ * 把一个分镜片段拆成多段。
+ *
+ * 段数决定优先级：
+ *   1. `parts` 显式指定段数；
+ *   2. 否则按 `maxClipSec` 时长上限计算 `ceil(duration / maxClipSec)`。
+ *
+ * 拆分后每段均分父镜时长，in/out 从父镜 inSec（缺省 0）累计推进。
+ * 对白默认保留在第一段（视觉继续，但台词不重复）；其余字段全部继承。
+ */
+export function planSegmentSplit(
+  segment: ShotSegment,
+  options: { maxClipSec?: number; parts?: number } = {},
+): ShotSplitPart[] {
+  const duration = resolveSegmentDuration(segment)
+  const maxClip = options.maxClipSec && options.maxClipSec > 0 ? options.maxClipSec : DEFAULT_MAX_CLIP_SEC
+
+  let parts: number
+  if (options.parts && options.parts > 0) {
+    parts = Math.floor(options.parts)
+  } else if (duration > 0) {
+    parts = Math.max(1, Math.ceil(duration / maxClip))
+  } else {
+    parts = 1
+  }
+
+  // 不需要拆（单段且未强制多段）：返回单段归一化结果
+  if (parts <= 1) {
+    return [toSinglePart(segment, duration)]
+  }
+
+  const baseIn = typeof segment.inSec === 'number' ? segment.inSec : 0
+  // 总时长未知时，用 maxClip * parts 兜底，保证每段有合理时长
+  const effectiveDuration = duration > 0 ? duration : maxClip * parts
+  const chunk = roundHalf(effectiveDuration / parts)
+
+  const result: ShotSplitPart[] = []
+  let cursor = baseIn
+  for (let i = 0; i < parts; i += 1) {
+    // 最后一段吸收四舍五入余量，保证 out 与父镜对齐
+    const isLast = i === parts - 1
+    const segOut = isLast ? roundHalf(baseIn + effectiveDuration) : roundHalf(cursor + chunk)
+    const segDuration = roundHalf(segOut - cursor)
+    result.push({
+      title: `${segment.title} (${i + 1}/${parts})`,
+      ...(segment.description ? { description: segment.description } : {}),
+      // 对白只放第一段，避免逐段重复念白
+      ...(i === 0 && segment.dialogue ? { dialogue: segment.dialogue } : {}),
+      ...(i === 0 && segment.narration ? { narration: segment.narration } : {}),
+      durationSec: segDuration > 0 ? segDuration : chunk,
+      inSec: roundHalf(cursor),
+      outSec: segOut,
+      ...inheritRefs(segment),
+    })
+    cursor = segOut
+  }
+  return result
+}
+
+/**
+ * 在指定时间点（相对父镜起点的秒数）把一个分镜片段切成两段。
+ * `atSec` 会被夹到 (0, duration) 开区间内；越界时退化为均分两段。
+ */
+export function splitSegmentAt(segment: ShotSegment, atSec: number): ShotSplitPart[] {
+  const duration = resolveSegmentDuration(segment)
+  const baseIn = typeof segment.inSec === 'number' ? segment.inSec : 0
+  const effectiveDuration = duration > 0 ? duration : DEFAULT_MAX_CLIP_SEC * 2
+  let cut = roundHalf(atSec)
+  if (!(cut > 0) || cut >= effectiveDuration) cut = roundHalf(effectiveDuration / 2)
+
+  const midOut = roundHalf(baseIn + cut)
+  const endOut = roundHalf(baseIn + effectiveDuration)
+  return [
+    {
+      title: `${segment.title} (1/2)`,
+      ...(segment.description ? { description: segment.description } : {}),
+      ...(segment.dialogue ? { dialogue: segment.dialogue } : {}),
+      ...(segment.narration ? { narration: segment.narration } : {}),
+      durationSec: roundHalf(midOut - baseIn),
+      inSec: roundHalf(baseIn),
+      outSec: midOut,
+      ...inheritRefs(segment),
+    },
+    {
+      title: `${segment.title} (2/2)`,
+      ...(segment.description ? { description: segment.description } : {}),
+      durationSec: roundHalf(endOut - midOut),
+      inSec: midOut,
+      outSec: endOut,
+      ...inheritRefs(segment),
+    },
+  ]
+}
+
+function toSinglePart(segment: ShotSegment, duration: number): ShotSplitPart {
+  const baseIn = typeof segment.inSec === 'number' ? segment.inSec : 0
+  const effectiveDuration = duration > 0 ? duration : DEFAULT_MAX_CLIP_SEC
+  return {
+    title: segment.title,
+    ...(segment.description ? { description: segment.description } : {}),
+    ...(segment.dialogue ? { dialogue: segment.dialogue } : {}),
+    ...(segment.narration ? { narration: segment.narration } : {}),
+    durationSec: roundHalf(effectiveDuration),
+    inSec: roundHalf(baseIn),
+    outSec: roundHalf(baseIn + effectiveDuration),
+    ...inheritRefs(segment),
+  }
+}
+
+/** 继承父镜的资源引用与风格预设 id（拆分后各段共享同一套设定，保证连贯） */
+function inheritRefs(
+  segment: ShotSegment,
+): Pick<
+  ShotSplitPart,
+  | 'characterAssetIds'
+  | 'sceneAssetId'
+  | 'propAssetIds'
+  | 'shotPrompt'
+  | 'cameraDesignId'
+  | 'actionDesignId'
+  | 'frameDesignId'
+> {
+  return {
+    ...(segment.characterAssetIds && segment.characterAssetIds.length > 0
+      ? { characterAssetIds: [...segment.characterAssetIds] }
+      : {}),
+    ...(segment.sceneAssetId ? { sceneAssetId: segment.sceneAssetId } : {}),
+    ...(segment.propAssetIds && segment.propAssetIds.length > 0
+      ? { propAssetIds: [...segment.propAssetIds] }
+      : {}),
+    ...(segment.shotPrompt ? { shotPrompt: segment.shotPrompt } : {}),
+    ...(segment.cameraDesignId ? { cameraDesignId: segment.cameraDesignId } : {}),
+    ...(segment.actionDesignId ? { actionDesignId: segment.actionDesignId } : {}),
+    ...(segment.frameDesignId ? { frameDesignId: segment.frameDesignId } : {}),
+  }
+}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasShotTableParse.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasShotTableParse.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { parseShotTable } from './canvasShotTableParse'
+
+const TABLE = `
+分镜 agent 输出：
+
+| 镜号 | 时长(秒) | 景别 | 运镜 | 画面/动作 | 对白 | 角色 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 3 | 近景 | 推 | 少年握紧剑柄 | 住手！ | 少年 |
+| 2 | 4.5 | 全景 | 跟 | 黑衣人后退半步 | — | 黑衣人、少年 |
+| 3 | 2 | 特写 | 固定 | 剑尖滴血 |  |  |
+
+总镜数：3 · 总时长：9.5s
+`
+
+describe('canvasShotTableParse', () => {
+  it('无表格返回空数组', () => {
+    expect(parseShotTable('这里没有表格，只是一段说明。')).toEqual([])
+  })
+
+  it('解析标准分镜表为结构化行', () => {
+    const rows = parseShotTable(TABLE)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toMatchObject({
+      index: 1,
+      durationSec: 3,
+      shotSize: '近景',
+      movement: '推',
+      description: '少年握紧剑柄',
+      dialogue: '住手！',
+      characterNames: ['少年'],
+    })
+    expect(rows[0]!.shotPrompt).toContain('近景')
+    expect(rows[0]!.shotPrompt).toContain('推')
+  })
+
+  it('优先解析 JSON shots', () => {
+    const rows = parseShotTable(
+      JSON.stringify({
+        shots: [
+          {
+            index: 1,
+            durationSec: 3,
+            shotSize: '近景',
+            movement: '推',
+            description: '少年握紧剑柄',
+            dialogue: '住手！',
+            characters: ['少年'],
+            shotPrompt: '近景，推镜',
+          },
+        ],
+      }),
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      index: 1,
+      durationSec: 3,
+      description: '少年握紧剑柄',
+      characterNames: ['少年'],
+      shotPrompt: '近景，推镜',
+    })
+  })
+
+  it('忽略合计行与表头分隔行', () => {
+    const rows = parseShotTable(TABLE)
+    expect(rows.some((r) => /总镜数/.test(r.description ?? ''))).toBe(false)
+    expect(rows.every((r) => r.title.startsWith('镜'))).toBe(true)
+  })
+
+  it('多角色按分隔符拆分，— 视为空', () => {
+    const rows = parseShotTable(TABLE)
+    expect(rows[1]!.characterNames).toEqual(['黑衣人', '少年'])
+    expect(rows[1]!.dialogue).toBeUndefined()
+    expect(rows[2]!.characterNames).toBeUndefined()
+  })
+
+  it('容忍时长写成 "3s" / "3 秒"', () => {
+    const rows = parseShotTable(
+      `| 镜号 | 时长 | 画面 |\n| - | - | - |\n| 1 | 3s | a |\n| 2 | 5 秒 | b |`,
+    )
+    expect(rows[0]!.durationSec).toBe(3)
+    expect(rows[1]!.durationSec).toBe(5)
+  })
+
+  it('列乱序也能按表头识别', () => {
+    const rows = parseShotTable(
+      `| 画面/动作 | 对白 | 时长(秒) | 镜号 |\n| - | - | - | - |\n| 拔剑 | 喝！ | 2 | 7 |`,
+    )
+    expect(rows[0]).toMatchObject({ index: 7, durationSec: 2, description: '拔剑', dialogue: '喝！' })
+  })
+
+  it('导演 agent 增强表（多出角度/镜头列）也能解析', () => {
+    const rows = parseShotTable(
+      `| 镜号 | 时长(秒) | 景别 | 角度 | 运镜 | 画面 | 对白 | 角色 |\n` +
+        `| - | - | - | - | - | - | - | - |\n` +
+        `| 1 | 3 | 中景 | 仰拍 | 环绕 | 英雄登场 | 我来了 | 英雄 |`,
+    )
+    expect(rows[0]).toMatchObject({
+      shotSize: '中景',
+      angle: '仰拍',
+      movement: '环绕',
+      description: '英雄登场',
+    })
+    expect(rows[0]!.shotPrompt).toContain('仰拍')
+  })
+
+  it('无表头识别时按默认列序兜底', () => {
+    const rows = parseShotTable(`| 1 | 3 | 近景 | 推 | 拔剑 | 住手 | 少年 |`)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ durationSec: 3, description: '拔剑', dialogue: '住手' })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasShotTableParse.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasShotTableParse.ts
@@ -1,0 +1,258 @@
+/**
+ * 分镜表解析（把「分镜 agent」产出的 Markdown 分镜表解析回结构化片段，批量落库）。
+ *
+ * 分镜 agent / 导演 agent 输出的是 Markdown 表格（列可乱序、可增列），形如：
+ *   | 镜号 | 时长(秒) | 景别 | 运镜 | 画面/动作 | 对白 | 角色 |
+ * 本模块按「表头关键字」识别列，容忍列顺序变化与额外列，解析为 ParsedShotRow[]，
+ * 供面板把每行 createShotSegment 落库。纯逻辑、无 DOM/IPC，便于单测。
+ */
+
+/** 解析出的一行分镜（字段全部可选，便于容错） */
+export type ParsedShotRow = {
+  /** 镜号（解析失败时由调用方按顺序兜底） */
+  index?: number
+  /** 标题（默认「镜N」） */
+  title: string
+  /** 时长（秒） */
+  durationSec?: number
+  /** 景别 */
+  shotSize?: string
+  /** 角度 */
+  angle?: string
+  /** 运镜 */
+  movement?: string
+  /** 画面 / 动作描述 */
+  description?: string
+  /** 对白 */
+  dialogue?: string
+  /** 旁白 */
+  narration?: string
+  /** 角色名（原始文本，调用方可再匹配为 assetId） */
+  characterNames?: string[]
+  /** 镜头语言合并文本（景别+角度+运镜，或「镜头」列原文） */
+  shotPrompt?: string
+}
+
+/** 表头关键字 → 逻辑列名 */
+type ColumnKey =
+  | 'index'
+  | 'duration'
+  | 'shotSize'
+  | 'angle'
+  | 'movement'
+  | 'shot'
+  | 'description'
+  | 'dialogue'
+  | 'narration'
+  | 'characters'
+
+const HEADER_MATCHERS: Array<{ key: ColumnKey; test: (h: string) => boolean }> = [
+  { key: 'index', test: (h) => /镜号|分镜号|序号|^#$|^no\.?$/i.test(h) },
+  { key: 'duration', test: (h) => /时长|时间|秒|duration|time/i.test(h) },
+  { key: 'shotSize', test: (h) => /景别|景\b|shot\s*size|scale/i.test(h) },
+  { key: 'angle', test: (h) => /角度|机位|angle/i.test(h) },
+  { key: 'movement', test: (h) => /运镜|镜头运动|运动|movement|camera\s*move/i.test(h) },
+  { key: 'shot', test: (h) => /镜头语言|镜头$|^镜头|camera$|lens|焦段/i.test(h) },
+  { key: 'description', test: (h) => /画面|动作|描述|内容|场景描述|description|action/i.test(h) },
+  { key: 'dialogue', test: (h) => /对白|台词|dialogue|line/i.test(h) },
+  { key: 'narration', test: (h) => /旁白|narration|voice\s*over|vo/i.test(h) },
+  { key: 'characters', test: (h) => /角色|人物|出场|character|cast/i.test(h) },
+]
+
+/** 把一行 Markdown 表格切成单元格（去掉首尾竖线与空白） */
+function splitRow(line: string): string[] {
+  let s = line.trim()
+  if (s.startsWith('|')) s = s.slice(1)
+  if (s.endsWith('|')) s = s.slice(0, -1)
+  return s.split('|').map((cell) => cell.trim())
+}
+
+/** 是否为分隔行（如 |---|:--:|） */
+function isSeparatorRow(cells: string[]): boolean {
+  return cells.length > 0 && cells.every((cell) => /^:?-{2,}:?$/.test(cell.replace(/\s/g, '')))
+}
+
+/** 从单元格解析时长秒数（容忍 "3s" / "3 秒" / "3.5"） */
+function parseDuration(cell: string): number | undefined {
+  const match = cell.match(/(\d+(?:\.\d+)?)/)
+  if (!match) return undefined
+  const value = Number.parseFloat(match[1]!)
+  return Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+/** 拆分角色名（逗号 / 顿号 / 斜杠 / 空格分隔） */
+function parseCharacterNames(cell: string): string[] {
+  return cell
+    .split(/[,，、\/\s]+/)
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0 && name !== '—' && name !== '-')
+}
+
+function cleanCell(cell: string | undefined): string {
+  const value = (cell ?? '').trim()
+  return value === '—' || value === '-' ? '' : value
+}
+
+function tryParseJsonObject(text: string): unknown | null {
+  const trimmed = text.trim()
+  const candidates = [trimmed]
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  if (fenced?.[1]) candidates.push(fenced[1].trim())
+  const firstBrace = trimmed.indexOf('{')
+  const lastBrace = trimmed.lastIndexOf('}')
+  if (firstBrace >= 0 && lastBrace > firstBrace) candidates.push(trimmed.slice(firstBrace, lastBrace + 1))
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate)
+    } catch {
+      // try next candidate
+    }
+  }
+  return null
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function numberField(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value
+  if (typeof value === 'string') return parseDuration(value)
+  return undefined
+}
+
+function parseJsonShotRows(text: string): ParsedShotRow[] {
+  const parsed = tryParseJsonObject(text)
+  if (!parsed || typeof parsed !== 'object') return []
+  const root = parsed as Record<string, unknown>
+  const rawShots = Array.isArray(root.shots) ? root.shots : Array.isArray(parsed) ? parsed : []
+  const rows: ParsedShotRow[] = []
+  for (const raw of rawShots) {
+    if (!raw || typeof raw !== 'object') continue
+    const item = raw as Record<string, unknown>
+    const index =
+      typeof item.index === 'number'
+        ? Math.floor(item.index)
+        : stringField(item.index).match(/\d+/)
+          ? Number.parseInt(stringField(item.index).match(/\d+/)![0]!, 10)
+          : undefined
+    const durationSec = numberField(item.durationSec ?? item.duration ?? item['时长'])
+    const description = stringField(item.description ?? item.action ?? item['画面/动作'])
+    const dialogue = stringField(item.dialogue ?? item['对白'])
+    const narration = stringField(item.narration ?? item['旁白'])
+    const shotSize = stringField(item.shotSize ?? item['景别'])
+    const angle = stringField(item.angle ?? item['角度'])
+    const movement = stringField(item.movement ?? item['运镜'])
+    const shotPrompt = stringField(item.shotPrompt ?? item.shot ?? item['镜头语言'])
+    const rawCharacters = item.characters ?? item.characterNames ?? item['角色']
+    const characterNames = Array.isArray(rawCharacters)
+      ? rawCharacters.map(stringField).filter(Boolean)
+      : stringField(rawCharacters)
+        ? parseCharacterNames(stringField(rawCharacters))
+        : []
+    if (!description && !dialogue && !narration && durationSec === undefined) continue
+    const fallbackIndex = rows.length + 1
+    rows.push({
+      ...(index !== undefined ? { index } : {}),
+      title: stringField(item.title) || `镜${index ?? fallbackIndex}`,
+      ...(durationSec !== undefined ? { durationSec } : {}),
+      ...(shotSize ? { shotSize } : {}),
+      ...(angle ? { angle } : {}),
+      ...(movement ? { movement } : {}),
+      ...(description ? { description } : {}),
+      ...(dialogue ? { dialogue } : {}),
+      ...(narration ? { narration } : {}),
+      ...(characterNames.length > 0 ? { characterNames } : {}),
+      ...(shotPrompt ? { shotPrompt } : {}),
+    })
+  }
+  return rows
+}
+
+/**
+ * 解析 Markdown 分镜表为结构化行。
+ * 优先解析标准 JSON shots；找不到 JSON/表格时返回 []。
+ * 无法识别表头则按「镜号|时长|景别|运镜|画面|对白|角色」默认列序兜底。
+ */
+export function parseShotTable(markdown: string): ParsedShotRow[] {
+  const jsonRows = parseJsonShotRows(markdown)
+  if (jsonRows.length > 0) return jsonRows
+
+  const lines = markdown.replace(/\r\n/g, '\n').split('\n')
+  const tableLines = lines.filter((line) => line.trim().startsWith('|'))
+  if (tableLines.length === 0) return []
+
+  // 第一行为表头
+  const headerCells = splitRow(tableLines[0]!)
+  const columnMap: Partial<Record<ColumnKey, number>> = {}
+  let recognized = 0
+  headerCells.forEach((header, idx) => {
+    for (const matcher of HEADER_MATCHERS) {
+      if (columnMap[matcher.key] === undefined && matcher.test(header)) {
+        columnMap[matcher.key] = idx
+        recognized += 1
+        break
+      }
+    }
+  })
+
+  // 表头识别不足（<2 列）：按默认列序兜底，并把第一行当作数据行
+  let dataLines = tableLines.slice(1)
+  if (recognized < 2) {
+    columnMap.index = 0
+    columnMap.duration = 1
+    columnMap.shotSize = 2
+    columnMap.movement = 3
+    columnMap.description = 4
+    columnMap.dialogue = 5
+    columnMap.characters = 6
+    dataLines = tableLines // 没有可信表头，全部按数据行处理
+  }
+
+  const at = (cells: string[], key: ColumnKey): string =>
+    columnMap[key] !== undefined ? cleanCell(cells[columnMap[key]!]) : ''
+
+  const rows: ParsedShotRow[] = []
+  for (const line of dataLines) {
+    const cells = splitRow(line)
+    if (isSeparatorRow(cells)) continue
+
+    const description = at(cells, 'description')
+    const dialogue = at(cells, 'dialogue')
+    const narration = at(cells, 'narration')
+    const durationCell = at(cells, 'duration')
+    const durationSec = durationCell ? parseDuration(durationCell) : undefined
+    const shotSize = at(cells, 'shotSize')
+    const angle = at(cells, 'angle')
+    const movement = at(cells, 'movement')
+    const shotCol = at(cells, 'shot')
+    const charactersCell = at(cells, 'characters')
+    const indexCell = at(cells, 'index')
+    const indexMatch = indexCell.match(/\d+/)
+    const index = indexMatch ? Number.parseInt(indexMatch[0]!, 10) : undefined
+
+    // 整行无实质内容（画面/对白/时长都空）→ 跳过（如残留的合计行）
+    if (!description && !dialogue && !narration && durationSec === undefined) continue
+
+    const shotPromptParts = [shotSize, angle, movement].filter(Boolean)
+    const shotPrompt = shotCol || (shotPromptParts.length > 0 ? shotPromptParts.join('，') : '')
+    const characterNames = charactersCell ? parseCharacterNames(charactersCell) : []
+    const fallbackIndex = rows.length + 1
+    const title = `镜${index ?? fallbackIndex}`
+
+    rows.push({
+      ...(index !== undefined ? { index } : {}),
+      title,
+      ...(durationSec !== undefined ? { durationSec } : {}),
+      ...(shotSize ? { shotSize } : {}),
+      ...(angle ? { angle } : {}),
+      ...(movement ? { movement } : {}),
+      ...(description ? { description } : {}),
+      ...(dialogue ? { dialogue } : {}),
+      ...(narration ? { narration } : {}),
+      ...(characterNames.length > 0 ? { characterNames } : {}),
+      ...(shotPrompt ? { shotPrompt } : {}),
+    })
+  }
+  return rows
+}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasStoryboardGrid.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasStoryboardGrid.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { ShotGroup, ShotSegment } from './canvasFilmAssets'
+import { buildStoryboardGridPrompt, recommendGridColumns } from './canvasStoryboardGrid'
+
+function seg(overrides: Partial<ShotSegment> & { index: number; title: string }): ShotSegment {
+  return { id: `s${overrides.index}`, ...overrides }
+}
+
+function group(segments: ShotSegment[]): Pick<ShotGroup, 'name' | 'segments'> {
+  return { name: '开场', segments }
+}
+
+describe('canvasStoryboardGrid', () => {
+  describe('recommendGridColumns', () => {
+    it('按镜数推荐列数', () => {
+      expect(recommendGridColumns(1)).toBe(1)
+      expect(recommendGridColumns(4)).toBe(2)
+      expect(recommendGridColumns(9)).toBe(3)
+      expect(recommendGridColumns(16)).toBe(4)
+      expect(recommendGridColumns(20)).toBe(5)
+    })
+  })
+
+  describe('buildStoryboardGridPrompt', () => {
+    it('空分组返回空串', () => {
+      expect(buildStoryboardGridPrompt({ group: group([]) })).toBe('')
+    })
+
+    it('包含镜数、行列网格与逐格关键帧描述', () => {
+      const prompt = buildStoryboardGridPrompt({
+        group: group([
+          seg({ index: 1, title: '镜1', description: '少年拔剑', shotPrompt: 'close-up', durationSec: 3, dialogue: '住手' }),
+          seg({ index: 2, title: '镜2', description: '对手后退', durationSec: 4 }),
+        ]),
+        styleBible: '水墨写意',
+      })
+      expect(prompt).toContain('film storyboard sheet containing 2 key-frame panels')
+      expect(prompt).toContain('2-column by 1-row grid')
+      expect(prompt).toContain('Panel 1 [key frame]')
+      expect(prompt).toContain('少年拔剑')
+      expect(prompt).toContain('shot: close-up')
+      expect(prompt).toContain('3s')
+      expect(prompt).toContain('dialogue: 住手')
+      expect(prompt).toContain('Panel 2 [key frame]')
+      expect(prompt).toContain('overall visual style: 水墨写意')
+    })
+
+    it('多镜推导出多行多列网格', () => {
+      const segments = Array.from({ length: 9 }, (_, i) =>
+        seg({ index: i + 1, title: `镜${i + 1}`, description: `画面${i + 1}` }),
+      )
+      const prompt = buildStoryboardGridPrompt({ group: group(segments) })
+      // 9 镜 → 3 列 × 3 行
+      expect(prompt).toContain('film storyboard sheet containing 9 key-frame panels')
+      expect(prompt).toContain('3-column by 3-row grid')
+      expect(prompt).toContain('Panel 9 [key frame]')
+    })
+
+    it('按 maxPanels 截断镜数', () => {
+      const segments = Array.from({ length: 30 }, (_, i) =>
+        seg({ index: i + 1, title: `镜${i + 1}`, description: `画面${i + 1}` }),
+      )
+      const prompt = buildStoryboardGridPrompt({ group: group(segments), maxPanels: 6 })
+      expect(prompt).toContain('containing 6 key-frame panels')
+      expect(prompt).toContain('Panel 6')
+      expect(prompt).not.toContain('Panel 7')
+    })
+
+    it('用 nameById 解析角色与场景写进每格', () => {
+      const prompt = buildStoryboardGridPrompt({
+        group: group([
+          seg({ index: 1, title: '镜1', description: '对峙', characterAssetIds: ['c1', 'c2'], sceneAssetId: 's1' }),
+        ]),
+        nameById: (id) => ({ c1: '少年', c2: '黑衣人', s1: '竹林' })[id],
+      })
+      expect(prompt).toContain('cast: 少年, 黑衣人')
+      expect(prompt).toContain('scene: 竹林')
+    })
+
+    it('可显式指定列数', () => {
+      const prompt = buildStoryboardGridPrompt({
+        group: group([seg({ index: 1, title: '镜1', description: 'a' })]),
+        columns: 3,
+      })
+      expect(prompt).toContain('3-column by 1-row grid')
+    })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasStoryboardGrid.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasStoryboardGrid.ts
@@ -1,0 +1,98 @@
+/**
+ * 分镜图（宫格关键帧）提示词组装（用户诉求：分镜表出来后，按分镜指导在一张图上
+ * 以宫格形式展示「许多」关键帧画面）。
+ *
+ * 纯逻辑：把一个分镜分组的片段拼成「一张多格分镜图」的 text_to_image 提示词，
+ * 每格 = 一镜的关键帧画面 + 镜头语言 + 角色/场景 + 时长/对白提示，整体继承视觉总设定。
+ * 强调宫格规整、逐格编号、跨格角色/风格一致。无 DOM/IPC，便于单测。
+ */
+
+import type { ShotGroup, ShotSegment } from './canvasFilmAssets'
+
+/** 单图最多纳入的宫格数（再多单图会糊；超出建议分多张分镜图） */
+export const DEFAULT_MAX_PANELS = 16
+
+/** 按镜数推荐宫格列数：尽量接近正方形，单行不超过 5 列 */
+export function recommendGridColumns(count: number): number {
+  if (count <= 1) return 1
+  if (count <= 4) return 2
+  if (count <= 9) return 3
+  if (count <= 16) return 4
+  return 5
+}
+
+/** 行数 = ceil(镜数 / 列数) */
+export function gridRows(count: number, columns: number): number {
+  if (count <= 0 || columns <= 0) return 0
+  return Math.ceil(count / columns)
+}
+
+/** 单格描述：镜号 + 关键帧画面 + 镜头 + 角色/场景 + 时长/对白 */
+function buildPanelLine(
+  segment: ShotSegment,
+  panelIndex: number,
+  nameById?: (id: string) => string | undefined,
+): string {
+  const parts: string[] = []
+  const visual = (segment.description || segment.title || '').trim()
+  parts.push(`Panel ${panelIndex} [key frame]`)
+  if (visual) parts.push(visual)
+  if (segment.shotPrompt && segment.shotPrompt.trim()) parts.push(`shot: ${segment.shotPrompt.trim()}`)
+
+  if (nameById) {
+    const cast = (segment.characterAssetIds ?? [])
+      .map((id) => nameById(id))
+      .filter((name): name is string => Boolean(name && name.trim()))
+    if (cast.length > 0) parts.push(`cast: ${cast.join(', ')}`)
+    const scene = segment.sceneAssetId ? nameById(segment.sceneAssetId) : undefined
+    if (scene && scene.trim()) parts.push(`scene: ${scene.trim()}`)
+  }
+
+  if (typeof segment.durationSec === 'number' && segment.durationSec > 0) {
+    parts.push(`${segment.durationSec}s`)
+  }
+  if (segment.dialogue && segment.dialogue.trim()) parts.push(`dialogue: ${segment.dialogue.trim()}`)
+  return parts.join(' — ')
+}
+
+/**
+ * 组装分镜图提示词。返回可继续编辑的最终 prompt。
+ * @param input.maxPanels 限制纳入的镜数（防止格子过多导致单图不清晰），默认 16。
+ * @param input.nameById  可选：把角色/场景 assetId 解析为名字，写进每格（提升一致性）。
+ */
+export function buildStoryboardGridPrompt(input: {
+  group: Pick<ShotGroup, 'name' | 'segments'>
+  styleBible?: string
+  columns?: number
+  maxPanels?: number
+  nameById?: (id: string) => string | undefined
+}): string {
+  const maxPanels = input.maxPanels && input.maxPanels > 0 ? input.maxPanels : DEFAULT_MAX_PANELS
+  const segments = input.group.segments.slice(0, maxPanels)
+  const count = segments.length
+  if (count === 0) return ''
+
+  const columns = input.columns && input.columns > 0 ? input.columns : recommendGridColumns(count)
+  const rows = gridRows(count, columns)
+
+  const header = [
+    `film storyboard sheet containing ${count} key-frame panels`,
+    `arranged in a regular ${columns}-column by ${rows}-row grid`,
+    'every panel the same size with thin gutters, ordered left-to-right then top-to-bottom',
+    'each panel clearly bordered and numbered in the top-left corner',
+    'each panel is a distinct key frame of its shot',
+    'hand-drawn film storyboard style, consistent character designs and setting across all panels',
+    'black and white line art with light grayscale shading, clear readable composition',
+    'no speech bubbles, no captions, no watermark',
+  ].join(', ')
+
+  const panels = segments
+    .map((segment, index) => buildPanelLine(segment, index + 1, input.nameById))
+    .join('\n')
+
+  const segs = [header, '', panels]
+  if (input.styleBible && input.styleBible.trim()) {
+    segs.push('', `overall visual style: ${input.styleBible.trim()}`)
+  }
+  return segs.join('\n').trim()
+}

--- a/docs/canvas-screenplay-to-video-pipeline-design.md
+++ b/docs/canvas-screenplay-to-video-pipeline-design.md
@@ -1,6 +1,6 @@
 # 画布「剧本文稿 → 影视产物」全流程生产设计
 
-> 状态: 实施中 | 最后核对: 2026-06-20
+> 状态: 实施中 | 最后核对: 2026-06-21
 >
 > 范围：把无限画布从「单点 AI 生成 + 影视资产中心」升级为一条
 > 「立项与视觉总设定 → 文稿/章节 → 剧本 → 实体资源 → 设定图卡 → 分镜（按秒）→ 关键帧 → 逐段视频 → 成片」
@@ -72,10 +72,44 @@
   - 说明：画布内文本任务已接真实文本模型（见上）；规则式拆解仍作为确定性、零成本的快速基线，
     与 LLM 改写/优化互补。后续可用真实文本模型把「拆解结果」结构化为资产（agent 抽取自动建资产）。
 
+- **§12 操作节点内专属 agent（2026-06-21）**：AI 操作节点（文本类）编辑器新增「专属 Agent」选择器，
+  可挑应用内 agent 管理配置的 ManagedAgent；命中时后端 `canvas:task:generate-text` 用该 agent 的人设
+  prompt 作 system，并在未显式指定时优先沿用 agent 绑定的 provider/model（协议 `CanvasTextTaskCreateRequest.agentId`）。
+  配套**内置角色提示词预设** `canvasAgentPromptPresets`（剧本 / 分镜 / 导演 / 动作设计），一键把写好的
+  指令（含上游内容）填入可编辑提示词框，用户可继续编辑后发起（纯逻辑 + 单测）。
+- **§S6 分镜表（按秒）+ 拆分（2026-06-21）**：分镜面板新增「分镜表」表格视图（镜号 / 累计时间码 /
+  时长 / 画面 / 镜头 / 对白 / 角色场景 / 操作），超单段上限的镜头标黄告警；新增**拆分**能力
+  `canvasShotSplit`：按「单段时长上限」把一镜拆成多段（适配短视频模型），各段继承资源/风格引用、
+  in/out 连续收尾对齐，对白只留首段，拆分即替换原镜（纯逻辑 + 单测）。
+- **分镜图（宫格关键帧）（2026-06-21）**：分镜面板「生成分镜图」按 `canvasStoryboardGrid` 把整组分镜拼成
+  一张多格分镜图的 `text_to_image` 提示词（按镜数推荐列数、逐格画面+镜头+时长+对白、继承视觉总设定），
+  发起生成落画布（纯逻辑 + 单测）。
+- **§7 文本节点右键专用流水线操作（2026-06-21 大改造）**：把「源节点 → 任务节点 → 产物节点」做成右键一键链路，
+  每个操作是包装好的专用节点，带进度（任务节点状态/进度）+ 流程（血缘连线）。
+  - 新增 `canvasPipelineOps`（专用 op 目录 + 文本/抽取类提示词委托，单一事实源）与 `canvasEntityExtract`
+    （角色/场景抽取提示词 + 一对多解析，纯逻辑 + 单测）。
+  - `canvasPipeline.getPipelineActions` 改为从 op 目录派生，新增 `getNodePipelineActions`：**无 pipelineRole 的
+    文本/Prompt 节点也给「剧本类」入口**（生成分镜脚本/提取角色/提取场景/分镜关键帧图），解决「章→剧本改写产出的
+    纯文本节点右键无操作」的卡点；右键菜单按 op 专属图标渲染。
+  - `CreateCanvasTaskRequest`/`CanvasNodeData` 增 `taskTitle`/`taskPipelineRole`/`outputPipelineRole` 透传，
+    任务节点与产物节点带专用标题+角色着色（包装专用节点）。
+  - `handleNodePipelineAction` 重写：文本来源优先关联资产正文、回退 `node.data.text`；
+    生成分镜脚本走 `text_generate`+血缘；**提取角色/场景（一对多）** 用 `runTrackedCanvasWorkflow`：
+    抽取任务节点 fan-out 多个实体节点，每个实体 `createFilmAsset` 登记资产库 + `insertAsset` 生成关联节点
+    （`pipelineRole`），完成自动连 `generated` 边；三视图每角色各一张、场景/道具/特效图走专用包装任务。
+  - **结构化与可审计增强（2026-06-21）**：角色/场景抽取提示词改为标准 JSON 契约
+    `{ kind, entities: [{ name, description, prompt, attributes }] }`，解析器优先读 JSON、兼容旧「名称：字段」格式；
+    `attributes` 写入资产编辑器可直接显示的标准 key（兼容旧中文 key），`prompt` 写入默认生成提示词，避免角色/场景卡片只有标题。
+    任务详情弹窗展示实际 system prompt、提交 prompt、模型输出、结构化解析结果、Provider/Profile/Model/Agent 运行配置；
+    文本操作节点编辑器新增专属 Agent + 文本 Provider + 模型选择，并透传到 `canvas:task:generate-text`。
+    分镜脚本提示词要求先输出 JSON `shots`、再输出兼容导入器的 Markdown 表格；分镜导入器优先解析 JSON，失败再回退 Markdown。
+  - 整体进度复用「制作面板 Production Cockpit」六阶段完成度，不另造运行态 UI。
+
 进行中 / 待落地（增强项）：
 
-- 用真实文本模型把剧本结构化抽取为资产（在规则式基线上叠加 LLM 抽取）、关键帧→分镜自动回链
-  （免手动「设为关键帧」）、一章一 board、真正的 ffmpeg 视频拼接（需后端）。
+- 关键帧→分镜自动回链（免手动「设为关键帧」）、一章一 board、真正的 ffmpeg 视频拼接（需后端）。
+- 分镜 agent 输出已支持 JSON/Markdown 导入；后续可在任务完成后自动解析回 `ShotSegment`，减少手工粘贴。
+- 分镜图（宫格）当前为「重绘」生成；后续可改为把已有关键帧图片节点做 `image_compose` 真实拼格。
 
 ## 1. 背景与目标
 

--- a/docs/canvas-screenplay-to-video-test-cases.md
+++ b/docs/canvas-screenplay-to-video-test-cases.md
@@ -316,9 +316,65 @@
 | T07 | P1 | 可访问性 | 键盘操作 | Tab 到按钮/阶段行/章节行后 Enter/Space | 行为与鼠标一致，焦点不丢失 |
 | T08 | P0 | 稳定性 | 快速打开关闭资产中心/导演台/操作面板 | 连续操作 20 次 | 不出现状态错乱、遮罩残留或无法点击 |
 
+### U. 操作节点专属 Agent、分镜表、分镜图（2026-06-21 新增）
+
+涉及模块：`canvasAgentPromptPresets`、`canvasShotSplit`、`canvasShotTableParse`、`canvasStoryboardGrid`，
+以及 `CanvasInlineAiComposer`（操作节点选 agent + 内置提示词）、`CanvasFilmAssetCenter` 分镜面板（分镜表 / 拆分 / 导入 / 分镜图）。
+
+| ID | 优先级 | 类型 | 前置条件 | 步骤 | 预期结果 |
+|---|---|---|---|---|---|
+| U01 | P0 | 单元 | 无 | `buildAgentPresetPrompt('storyboard', { upstreamText, pacingSecPerShot:4, maxClipSec:8 })` | 提示词含上游文本、「约 4 秒/镜」「不得超过 8 秒」，占位槽全部被替换 |
+| U02 | P0 | 单元 | 无 | 遍历 `CANVAS_AGENT_PRESETS` | 含剧本/分镜/导演/动作四角色，`defaultOperation` 均为 composer 可选文本能力（text_generate/prompt_optimize） |
+| U03 | P0 | 集成 | 操作节点编辑器打开、能力选 `text_generate` | 出现「专属 Agent」下拉与「内置角色」按钮组；点「分镜」 | 提示词框被内置分镜指令填充（含选中节点文本），可继续编辑 |
+| U04 | P0 | 集成 | U03，已配置 ManagedAgent | 选一个专属 agent，发起任务 | 任务 `agentId` 写入；后端 `canvas:task:generate-text` 用该 agent 人设作 system，未指定时沿用其 provider/model |
+| U05 | P1 | 集成 | 未选 agent | 直接用内置角色提示词发起 | 走通用影视创作助手 system，正常产出文本节点 |
+| U06 | P0 | 单元 | 无 | `planSegmentSplit(12s 片段, { maxClipSec:5 })` | 拆 3 段，每段 ≤5s，in/out 连续且末段 out 对齐 12s，对白只在首段，资源/风格引用各段继承 |
+| U07 | P0 | 单元 | 无 | `splitSegmentAt(10s 片段, 4)` | 切两段 0–4s / 4–10s；越界切点退化为均分 |
+| U08 | P0 | 集成 | 分组有一个 12s 片段 | 分镜表/卡片点「拆分」，上限填 5，确认 | 原片段被替换为 3 个连续短片段（标题带 1/3、2/3、3/3） |
+| U09 | P0 | 集成 | 分组有多个片段 | 切到「分镜表」视图 | 表格按累计时间码展示镜号/时长/画面/镜头/对白/角色，超 5s 的镜标黄告警，底部显示总镜数与总时长 |
+| U10 | P0 | 单元 | 无 | `parseShotTable(标准 Markdown 分镜表)` | 解析为结构化行：镜号/时长/景别+运镜→shotPrompt/画面/对白/角色名；忽略分隔行与合计行 |
+| U11 | P1 | 单元 | 无 | `parseShotTable(列乱序 / 含角度列的增强表 / 无表头默认列序)` | 均能按表头识别或默认列序兜底解析 |
+| U12 | P0 | 集成 | 分镜 agent 已产出分镜表文本 | 点「导入分镜表」，粘贴表格 | 预览解析行；确认后批量创建分镜片段，角色名自动匹配同名角色资产为 `characterAssetIds` |
+| U13 | P0 | 单元 | 无 | `buildStoryboardGridPrompt({ group: 9 镜 })` | 提示词含「9 key-frame panels」「3-column by 3-row grid」「Panel 9 [key frame]」，逐格画面+镜头+时长+对白 |
+| U14 | P1 | 单元 | 无 | `buildStoryboardGridPrompt({ nameById })` | 角色/场景 assetId 解析为名字写进每格（cast/scene） |
+| U15 | P0 | 集成 | 分组有片段 | 点「生成分镜图」 | 发起 `text_to_image`，prompt 为多宫格关键帧分镜图，角色/场景名由画布资产标题解析，继承 Style Bible |
+
+#### U-E2E. 分镜 agent → 分镜表 → 分镜图 端到端
+
+| ID | 优先级 | 类型 | 前置条件 | 步骤 | 预期结果 |
+|---|---|---|---|---|---|
+| UE01 | P0 | E2E | 已有一段场次剧本文本节点、文本+图片 Provider 可用 | ①选中剧本节点开操作节点编辑器，能力选 `text_generate`，内置角色点「分镜」，可选专属分镜 agent，发起 | 产出一份 Markdown 分镜表文本节点（精确到秒，每镜 ≤ 上限） |
+| UE02 | P0 | E2E | UE01 | ②分镜面板「导入分镜表」粘贴上一步输出，确认 | 批量生成分镜片段，角色名匹配角色资产 |
+| UE03 | P0 | E2E | UE02 | ③切「分镜表」查看，对超时长镜「拆分」 | 长镜被拆为多段连续短镜，便于逐段出视频 |
+| UE04 | P0 | E2E | UE03 | ④点「生成分镜图」 | 发起多宫格关键帧分镜图生成，落画布；继续可对各镜出关键帧/视频接回既有链路（I/J 段） |
+
+### V. 文本节点右键专用流水线操作（2026-06-21 大改造）
+
+涉及模块：`canvasPipelineOps`、`canvasEntityExtract`、`canvasPipeline`(getNodePipelineActions)、`CanvasContextMenu`、
+`CanvasWorkspaceView`(handleNodePipelineAction / handleExtractEntities / handleGenerateShotScript)、`canvas.api`(任务/产物角色透传)。
+
+| ID | 优先级 | 类型 | 前置条件 | 步骤 | 预期结果 |
+|---|---|---|---|---|---|
+| V01 | P0 | 单元 | 无 | `getOpsForNode({type:'text'})` | 含 `screenplay.to_shot_script`/`extract_characters`/`extract_scenes`/`storyboard_grid`（无 role 文本节点也有入口） |
+| V02 | P0 | 单元 | 无 | `getOpsForNode({type:'image',data:{pipelineRole:'character'}})` | 仅 `character.three_view` |
+| V03 | P0 | 单元 | 无 | `buildOpPrompt('screenplay.extract_characters',{upstreamText})` | 委托抽取提示词，含「抽取其中出现的全部角色」 |
+| V04 | P0 | 单元 | 无 | `parseExtractedEntities('character', 模型输出)` | 一对多解析多个角色、字段归一、同名合并、无名称返回空 |
+| V05 | P0 | 集成 | 画布有一个剧本/纯文本节点 | 右键 | 菜单出现专用项（专属图标）：生成分镜脚本/提取角色/提取场景/生成分镜关键帧图 |
+| V06 | P0 | 集成 | V05，文本含场次/对白 | 点「生成分镜脚本」 | 源节点→任务节点(进度)→分镜脚本产物文本节点(pipelineRole=shot)，血缘连线完整 |
+| V07 | P0 | 集成 | V05 | 点「提取角色」 | 一个抽取任务节点 fan-out 多个角色节点；资产库出现对应角色；任务→各角色 generated 连线 |
+| V08 | P1 | 集成 | V07 已提取出同名角色 | 再次「提取角色」 | 同名不重复建资产（去重），仍生成/复用节点 |
+| V09 | P0 | 集成 | 画布有角色节点（关联角色资产） | 右键「生成三视图」 | text_to_image 任务，标题「生成三视图」，产物图片 pipelineRole=design_card；有基准图时走 I2I |
+| V10 | P0 | 集成 | 画布有场景节点 | 右键「生成场景图」 | text_to_image 任务，标题「生成场景图」，产物为设计图卡 |
+| V11 | P1 | 集成 | 已有分镜分组 | 文本节点右键「生成分镜关键帧图」 | 用最近分镜分组发起宫格分镜图；无分镜时提示先生成分镜 |
+| V12 | P1 | 集成 | 章→剧本改写完成 | 查看产出的剧本文本节点 | 节点 pipelineRole=screenplay（着色），右键直接出剧本类专用操作 |
+| V13 | P1 | 异常 | 文本为空的节点 | 右键执行任一文本/抽取操作 | 明确提示「没有可用文本」，不创建任务 |
+| V14 | P1 | 集成 | 执行若干右键操作后 | 打开「制作面板」 | 角色/场景/分镜阶段完成度随产物推进 |
+
 ## 4. 回归准入建议
 
-- 每次修改纯逻辑文件时，至少运行对应 Vitest：`canvasManuscript`、`canvasShotPlanner`、`canvasFilmTimeline`、`canvasPipeline`、`canvasPipelineProgress`、`canvasFilmAssets`。
-- 每次修改影视资产中心或导演台 UI 时，至少执行 P0 集成用例：A07-A13、C01-C03、D01-D05、H04-H10、I01-I03、J01-J04、N01-N05、P01-P06。
+- 每次修改纯逻辑文件时，至少运行对应 Vitest：`canvasManuscript`、`canvasShotPlanner`、`canvasFilmTimeline`、`canvasPipeline`、`canvasPipelineProgress`、`canvasFilmAssets`、`canvasAgentPromptPresets`、`canvasShotSplit`、`canvasShotTableParse`、`canvasStoryboardGrid`、`canvasPipelineOps`、`canvasEntityExtract`。
+- 每次修改文本节点右键专用流水线（canvasPipelineOps / handleNodePipelineAction）时，执行 V01-V10 与 V12。
+- 每次修改影视资产中心或导演台 UI 时，至少执行 P0 集成用例：A07-A13、C01-C03、D01-D05、H04-H10、I01-I03、J01-J04、N01-N05、P01-P06、U03/U08/U09/U12/U15。
 - 每次修改媒体任务或 Provider 适配时，执行 R01-R07 与 S01-S07。
-- 每次发布前，至少完成 S01-S07 主链路，以及 T01/T02/T06/T08 稳定性检查。
+- 每次修改操作节点 agent 选择或文本任务链路时，执行 U01-U05 与 UE01。
+- 每次发布前，至少完成 S01-S07 主链路、UE01-UE04，以及 T01/T02/T06/T08 稳定性检查。

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -3781,6 +3781,12 @@ export interface CanvasTextTaskCreateRequest {
   providerProfileId?: string | null
   /** 指定模型；缺省用 provider defaultModel */
   modelId?: string | null
+  /**
+   * 指定专属 agent（应用内 agent 管理配置的 ManagedAgent）。
+   * 命中时：用 agent 的人设 prompt 作为 system，并在未显式指定 provider/model 时
+   * 优先沿用 agent 绑定的 provider / model（实现「操作节点内指定专属 agent」）。
+   */
+  agentId?: string | null
 }
 
 export interface CanvasTextTaskCreateResponse {
@@ -3790,6 +3796,8 @@ export interface CanvasTextTaskCreateResponse {
   model: string
   /** 生成的文本（成功时） */
   text: string
+  /** 非敏感调用摘要：用于画布任务详情排查 prompt / agent / model。 */
+  rawResponse?: unknown
   error?: { code: string; message: string }
 }
 


### PR DESCRIPTION
Add core extraction/transformation modules for the canvas screenplay-to-video pipeline, with unit tests:

- canvasEntityExtract: parse screenplay text into structured entities
- canvasShotSplit / canvasShotTableParse: split scenes into shots and parse shot tables
- canvasStoryboardGrid: build storyboard grid layout
- canvasPipelineOps: pipeline operation helpers
- canvasAgentPromptPresets: agent prompt presets for pipeline roles

Wire new capabilities into canvas components (FilmAssetCenter, OperationPanel, WorkspaceView, InlineAiComposer, ContextMenu, TaskQueue, Node, BottomDock), canvas api/store/types, IPC layer, and refresh related design docs and test cases.