### PR TITLE
fix(canvas): add collapsible side panel, enlarge task-queue modal, add image style-extract action, and enlarge prompt editors

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -20,7 +20,12 @@ function resolvePipelineIcon(iconKey: string | undefined, size = 14): React.Reac
 /** 操作节点图标：按 operation 类型映射 */
 function operationNodeIcon(operation: CanvasOperationType | null): React.ReactNode {
   if (!operation) return <Icons.Sparkles size={13} />
-  if (operation.startsWith('text_to_image') || operation === 'image_to_image' || operation === 'image_edit' || operation === 'image_compose') {
+  if (
+    operation.startsWith('text_to_image') ||
+    operation === 'image_to_image' ||
+    operation === 'image_edit' ||
+    operation === 'image_compose'
+  ) {
     return <Icons.Image size={13} />
   }
   if (operation.includes('video')) {
@@ -61,11 +66,18 @@ export type CanvasFlowNodeData = {
     dissolveGroup: (groupId: string) => void
     openAiComposer: (nodeId: string) => void
     saveToLibrary: (nodeId: string) => void
-    createOperationChild: (parentId: string, operation: import("./canvas.types").CanvasOperationType) => void
+    createOperationChild: (
+      parentId: string,
+      operation: import('./canvas.types').CanvasOperationType,
+      options?: { title?: string; prompt?: string },
+    ) => void
     /** 流水线一键编排（设计 §7）：actionId 来自 getPipelineActions */
     pipelineAction: (nodeId: string, actionId: string) => void
     /** 设置生产状态（设计 §9.2 确认/待更新契约） */
-    setProductionState: (nodeId: string, state: import("./canvas.types").CanvasProductionState) => void
+    setProductionState: (
+      nodeId: string,
+      state: import('./canvas.types').CanvasProductionState,
+    ) => void
   }
 }
 
@@ -123,9 +135,10 @@ const typeColor: Record<SparkCanvasNode['type'], string> = {
 export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps) {
   const { actions, canvasNode: node, lineage, selectedCount } = data as CanvasFlowNodeData
   const displayType = node.type === 'prompt' ? 'text' : node.type
-  const title = node.type === 'prompt' && (!node.title || node.title === 'Prompt')
-    ? 'Text note'
-    : node.title ?? displayType
+  const title =
+    node.type === 'prompt' && (!node.title || node.title === 'Prompt')
+      ? 'Text note'
+      : (node.title ?? displayType)
   const locked = Boolean(node.locked)
   const isGroup = node.type === 'group'
   const isTask = isOperationNode(node)
@@ -154,7 +167,15 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             { type: 'divider' as const },
           ]
         : []),
-      { key: 'duplicate', label: (<span className="canvas-menu-item"><Icons.Copy size={14} /> 复制节点</span>), onClick: () => actions.duplicateNode(node.id) },
+      {
+        key: 'duplicate',
+        label: (
+          <span className="canvas-menu-item">
+            <Icons.Copy size={14} /> 复制节点
+          </span>
+        ),
+        onClick: () => actions.duplicateNode(node.id),
+      },
       {
         key: 'edit',
         label: (
@@ -164,45 +185,198 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
         ),
         onClick: () => actions.editNode(node.id),
       },
+      ...(node.type === 'image' && !isTask
+        ? [
+            {
+              key: 'extract-style',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Sparkles size={14} /> 提取风格
+                </span>
+              ),
+              onClick: () =>
+                actions.createOperationChild(node.id, 'text_generate', {
+                  title: '风格提取',
+                  prompt:
+                    '请分析输入图片的视觉风格，并输出可复用的中文风格描述。重点包括：画面题材、艺术媒介、色彩倾向、光影氛围、构图镜头、材质细节、时代/类型气质，以及适合作为后续生成提示词的风格关键词。',
+                }),
+            },
+          ]
+        : []),
       ...(isTask
         ? []
-        : [{ key: 'ai', label: (<span className="canvas-menu-item"><Icons.Sparkles size={14} /> AI 操作</span>), onClick: () => actions.openAiComposer(node.id) }]),
-      ...(isTask ? [] : [{ key: 'add-operation', label: (<span className="canvas-menu-item"><Icons.Plus size={14} /> 新增 AI 操作 ▸</span>), children: [
-        { key: 'op-text_to_image', label: '文生图', onClick: () => actions.createOperationChild(node.id, 'text_to_image') },
-        { key: 'op-image_edit', label: '图生图', onClick: () => actions.createOperationChild(node.id, 'image_edit') },
-        { key: 'op-image_compose', label: '多图合成', onClick: () => actions.createOperationChild(node.id, 'image_compose') },
-        { key: 'op-text_generate', label: '文本生成', onClick: () => actions.createOperationChild(node.id, 'text_generate') },
-        { key: 'op-text_rewrite', label: '文本改写', onClick: () => actions.createOperationChild(node.id, 'text_rewrite') },
-        { key: 'op-prompt_optimize', label: 'Prompt 优化', onClick: () => actions.createOperationChild(node.id, 'prompt_optimize') },
-        { key: 'op-text_to_video', label: '文生视频', onClick: () => actions.createOperationChild(node.id, 'text_to_video') },
-        { key: 'op-image_to_video', label: '图生视频', onClick: () => actions.createOperationChild(node.id, 'image_to_video') },
-        { key: 'op-text_to_audio', label: '文生音频', onClick: () => actions.createOperationChild(node.id, 'text_to_audio') },
-        { key: 'op-audio_transcribe', label: '语音转写', onClick: () => actions.createOperationChild(node.id, 'audio_transcribe') },
-      ] }]),
-      ...(isTask ? [] : [{ key: 'group', disabled: selectedCount < 2, label: (<span className="canvas-menu-item"><Icons.Layers size={14} /> 创建组</span>), onClick: () => actions.createGroupFromSelection() }]),
-      { key: 'save-to-library', label: (<span className="canvas-menu-item"><Icons.Folder size={14} /> 保存到资源库…</span>), onClick: () => actions.saveToLibrary(node.id) },
+        : [
+            {
+              key: 'add-operation',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Plus size={14} /> 新增 AI 操作 ▸
+                </span>
+              ),
+              children: [
+                {
+                  key: 'op-text_to_image',
+                  label: '文生图',
+                  onClick: () => actions.createOperationChild(node.id, 'text_to_image'),
+                },
+                {
+                  key: 'op-image_edit',
+                  label: '图生图',
+                  onClick: () => actions.createOperationChild(node.id, 'image_edit'),
+                },
+                {
+                  key: 'op-image_compose',
+                  label: '多图合成',
+                  onClick: () => actions.createOperationChild(node.id, 'image_compose'),
+                },
+                {
+                  key: 'op-text_generate',
+                  label: '文本生成',
+                  onClick: () => actions.createOperationChild(node.id, 'text_generate'),
+                },
+                {
+                  key: 'op-text_rewrite',
+                  label: '文本改写',
+                  onClick: () => actions.createOperationChild(node.id, 'text_rewrite'),
+                },
+                {
+                  key: 'op-prompt_optimize',
+                  label: 'Prompt 优化',
+                  onClick: () => actions.createOperationChild(node.id, 'prompt_optimize'),
+                },
+                {
+                  key: 'op-text_to_video',
+                  label: '文生视频',
+                  onClick: () => actions.createOperationChild(node.id, 'text_to_video'),
+                },
+                {
+                  key: 'op-image_to_video',
+                  label: '图生视频',
+                  onClick: () => actions.createOperationChild(node.id, 'image_to_video'),
+                },
+                {
+                  key: 'op-text_to_audio',
+                  label: '文生音频',
+                  onClick: () => actions.createOperationChild(node.id, 'text_to_audio'),
+                },
+                {
+                  key: 'op-audio_transcribe',
+                  label: '语音转写',
+                  onClick: () => actions.createOperationChild(node.id, 'audio_transcribe'),
+                },
+              ],
+            },
+          ]),
+      ...(isTask
+        ? []
+        : [
+            {
+              key: 'group',
+              disabled: selectedCount < 2,
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Layers size={14} /> 创建组
+                </span>
+              ),
+              onClick: () => actions.createGroupFromSelection(),
+            },
+          ]),
+      {
+        key: 'save-to-library',
+        label: (
+          <span className="canvas-menu-item">
+            <Icons.Folder size={14} /> 保存到资源库…
+          </span>
+        ),
+        onClick: () => actions.saveToLibrary(node.id),
+      },
       ...(isGroup
         ? [
-            { key: 'add-to-group', disabled: selectedCount < 2, label: (<span className="canvas-menu-item"><Icons.Plus size={14} /> 加入选中节点</span>), onClick: () => actions.addSelectionToGroup(node.id) },
-            { key: 'dissolve-group', label: (<span className="canvas-menu-item"><Icons.FolderOpen size={14} /> 解散组</span>), onClick: () => actions.dissolveGroup(node.id) },
+            {
+              key: 'add-to-group',
+              disabled: selectedCount < 2,
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Plus size={14} /> 加入选中节点
+                </span>
+              ),
+              onClick: () => actions.addSelectionToGroup(node.id),
+            },
+            {
+              key: 'dissolve-group',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.FolderOpen size={14} /> 解散组
+                </span>
+              ),
+              onClick: () => actions.dissolveGroup(node.id),
+            },
           ]
         : []),
       ...(isGroupedChild
         ? [
-            { key: 'remove-from-group', label: (<span className="canvas-menu-item"><Icons.ArrowUp size={14} /> 移出组</span>), onClick: () => actions.removeNodeFromGroup(node.id) },
+            {
+              key: 'remove-from-group',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.ArrowUp size={14} /> 移出组
+                </span>
+              ),
+              onClick: () => actions.removeNodeFromGroup(node.id),
+            },
           ]
         : []),
       ...(isGroup
         ? []
         : [
             { type: 'divider' as const },
-            { key: 'confirm', label: (<span className="canvas-menu-item"><Icons.Check size={14} /> 确认（采用）</span>), onClick: () => actions.setProductionState(node.id, 'confirmed') },
-            { key: 'mark-stale', label: (<span className="canvas-menu-item"><Icons.RotateCcw size={14} /> 标记待更新</span>), onClick: () => actions.setProductionState(node.id, 'stale') },
+            {
+              key: 'confirm',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Check size={14} /> 确认（采用）
+                </span>
+              ),
+              onClick: () => actions.setProductionState(node.id, 'confirmed'),
+            },
+            {
+              key: 'mark-stale',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.RotateCcw size={14} /> 标记待更新
+                </span>
+              ),
+              onClick: () => actions.setProductionState(node.id, 'stale'),
+            },
             { type: 'divider' as const },
           ]),
-      { key: 'lock', label: (<span className="canvas-menu-item"><Icons.Lock size={14} /> {locked ? '解锁节点' : '锁定节点'}</span>), onClick: () => actions.toggleLockNode(node.id) },
-      { key: 'front', label: (<span className="canvas-menu-item"><Icons.Layers size={14} /> 置于顶层</span>), onClick: () => actions.bringNodeToFront(node.id) },
-      { key: 'delete', label: (<span className="canvas-menu-item canvas-menu-item-danger"><Icons.Trash size={14} /> 删除节点</span>), onClick: () => actions.deleteNode(node.id) },
+      {
+        key: 'lock',
+        label: (
+          <span className="canvas-menu-item">
+            <Icons.Lock size={14} /> {locked ? '解锁节点' : '锁定节点'}
+          </span>
+        ),
+        onClick: () => actions.toggleLockNode(node.id),
+      },
+      {
+        key: 'front',
+        label: (
+          <span className="canvas-menu-item">
+            <Icons.Layers size={14} /> 置于顶层
+          </span>
+        ),
+        onClick: () => actions.bringNodeToFront(node.id),
+      },
+      {
+        key: 'delete',
+        label: (
+          <span className="canvas-menu-item canvas-menu-item-danger">
+            <Icons.Trash size={14} /> 删除节点
+          </span>
+        ),
+        onClick: () => actions.deleteNode(node.id),
+      },
     ],
   }
 
@@ -324,11 +498,7 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
         <div className="canvas-node-body">
           {node.type === 'image' ? (
             node.data.url ? (
-              <img
-                className="canvas-node-image"
-                src={normalizedImageSrc}
-                alt={title}
-              />
+              <img className="canvas-node-image" src={normalizedImageSrc} alt={title} />
             ) : (
               <div className="canvas-node-image-placeholder">
                 <Icons.Image size={30} />
@@ -339,7 +509,12 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             node.data.url ? (
               <div className="canvas-node-audio">
                 <Icons.Play size={22} />
-                <audio className="canvas-node-audio-player" src={normalizedAudioSrc} controls preload="metadata" />
+                <audio
+                  className="canvas-node-audio-player"
+                  src={normalizedAudioSrc}
+                  controls
+                  preload="metadata"
+                />
                 <span className="canvas-node-audio-name">{node.data.message ?? 'audio'}</span>
               </div>
             ) : (
@@ -350,7 +525,12 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             )
           ) : node.type === 'video' ? (
             node.data.url ? (
-              <video className="canvas-node-image" src={normalizedVideoSrc} controls preload="metadata" />
+              <video
+                className="canvas-node-image"
+                src={normalizedVideoSrc}
+                controls
+                preload="metadata"
+              />
             ) : (
               <div className="canvas-node-image-placeholder">
                 <Icons.Play size={30} />
@@ -360,7 +540,9 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
           ) : node.type === 'group' ? (
             <div className="canvas-node-group-body">
               <div className="canvas-node-group-count">{node.data.text ?? '组'}</div>
-              <div className="canvas-node-group-hint">{node.data.message ?? '节点已在组内排列'}</div>
+              <div className="canvas-node-group-hint">
+                {node.data.message ?? '节点已在组内排列'}
+              </div>
             </div>
           ) : isOperationNode(node) ? (
             <div className="canvas-node-task canvas-node-operation">
@@ -371,10 +553,13 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
                 </span>
                 <Tag
                   color={
-                    node.data.status === 'completed' ? 'green'
-                      : node.data.status === 'failed' ? 'red'
-                      : node.data.status === 'running' ? 'blue'
-                      : 'default'
+                    node.data.status === 'completed'
+                      ? 'green'
+                      : node.data.status === 'failed'
+                        ? 'red'
+                        : node.data.status === 'running'
+                          ? 'blue'
+                          : 'default'
                   }
                   bordered
                 >

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
@@ -160,9 +160,16 @@ export function CanvasStage({
   onOpenAiComposer: (nodeId: string) => void
   onEditNode: (nodeId: string) => void
   onSaveNodeToLibrary: (nodeId: string) => void
-  onCreateOperationChild: (parentId: string, operation: import("./canvas.types").CanvasOperationType) => void
+  onCreateOperationChild: (
+    parentId: string,
+    operation: import('./canvas.types').CanvasOperationType,
+    options?: { title?: string; prompt?: string },
+  ) => void
   onPipelineAction: (nodeId: string, actionId: string) => void
-  onSetProductionState: (nodeId: string, state: import("./canvas.types").CanvasProductionState) => void
+  onSetProductionState: (
+    nodeId: string,
+    state: import('./canvas.types').CanvasProductionState,
+  ) => void
   onAddTextAtPosition: (position: CanvasStagePoint) => void
   onAddImageAtPosition: (position: CanvasStagePoint) => void
   /** 空白右键：新建 Prompt 节点 */
@@ -492,15 +499,21 @@ export function CanvasStage({
     [],
   )
 
-  const handleNodeDragStart = useCallback((_event: MouseEvent | TouchEvent, node: Node<CanvasFlowNodeData>) => {
-    nodeDragStateRef.current = { nodeId: node.id, dragging: true, endedAt: 0 }
-    setPaneContextMenu(null)
-  }, [])
+  const handleNodeDragStart = useCallback(
+    (_event: MouseEvent | TouchEvent, node: Node<CanvasFlowNodeData>) => {
+      nodeDragStateRef.current = { nodeId: node.id, dragging: true, endedAt: 0 }
+      setPaneContextMenu(null)
+    },
+    [],
+  )
 
-  const handleNodeDragStop = useCallback((_event: MouseEvent | TouchEvent, node: Node<CanvasFlowNodeData>) => {
-    nodeDragStateRef.current = { nodeId: node.id, dragging: false, endedAt: Date.now() }
-    clearAlignmentGuides()
-  }, [clearAlignmentGuides])
+  const handleNodeDragStop = useCallback(
+    (_event: MouseEvent | TouchEvent, node: Node<CanvasFlowNodeData>) => {
+      nodeDragStateRef.current = { nodeId: node.id, dragging: false, endedAt: Date.now() }
+      clearAlignmentGuides()
+    },
+    [clearAlignmentGuides],
+  )
 
   const handleNodeClick = useCallback(
     (event: ReactMouseEvent, node: Node<CanvasFlowNodeData>) => {

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
@@ -26,6 +26,7 @@ export function CanvasTaskQueue({
 }) {
   const [filter, setFilter] = useState<TaskFilter>('all')
   const [detailTaskId, setDetailTaskId] = useState<string | null>(null)
+  const [queueModalOpen, setQueueModalOpen] = useState(false)
   const orderedTasks = useMemo(
     () => [...tasks].sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
     [tasks],
@@ -37,7 +38,9 @@ export function CanvasTaskQueue({
     return true
   })
   const activeCount = tasks.filter(isTaskActive).length
-  const failedCount = tasks.filter((task) => task.status === 'failed' || task.status === 'cancelled').length
+  const failedCount = tasks.filter(
+    (task) => task.status === 'failed' || task.status === 'cancelled',
+  ).length
   const completedCount = tasks.filter((task) => task.status === 'completed').length
   const detailTask = tasks.find((task) => task.id === detailTaskId) ?? null
 
@@ -45,16 +48,44 @@ export function CanvasTaskQueue({
     <section className="canvas-panel-section canvas-task-center">
       <div className="canvas-panel-title-row">
         <h3>任务队列</h3>
-        <Tag color={activeCount > 0 ? 'blue' : 'default'}>
-          {activeCount} 运行
-        </Tag>
+        <Space size={6}>
+          <Tag color={activeCount > 0 ? 'blue' : 'default'}>{activeCount} 运行</Tag>
+          <Button
+            size="small"
+            type="text"
+            icon={<Icons.Maximize size={14} />}
+            onClick={() => setQueueModalOpen(true)}
+          >
+            放大
+          </Button>
+        </Space>
       </div>
 
       <div className="canvas-task-stat-grid">
-        <TaskStat label="全部" value={tasks.length} active={filter === 'all'} onClick={() => setFilter('all')} />
-        <TaskStat label="运行" value={activeCount} active={filter === 'active'} onClick={() => setFilter('active')} />
-        <TaskStat label="失败" value={failedCount} active={filter === 'failed'} onClick={() => setFilter('failed')} />
-        <TaskStat label="完成" value={completedCount} active={filter === 'completed'} onClick={() => setFilter('completed')} />
+        <TaskStat
+          label="全部"
+          value={tasks.length}
+          active={filter === 'all'}
+          onClick={() => setFilter('all')}
+        />
+        <TaskStat
+          label="运行"
+          value={activeCount}
+          active={filter === 'active'}
+          onClick={() => setFilter('active')}
+        />
+        <TaskStat
+          label="失败"
+          value={failedCount}
+          active={filter === 'failed'}
+          onClick={() => setFilter('failed')}
+        />
+        <TaskStat
+          label="完成"
+          value={completedCount}
+          active={filter === 'completed'}
+          onClick={() => setFilter('completed')}
+        />
       </div>
 
       <div className="canvas-task-queue-list">
@@ -81,14 +112,86 @@ export function CanvasTaskQueue({
               </div>
               <Progress percent={task.progress} size="small" status={progressStatus(task.status)} />
               {(task.errorMsg || task.errorDetail) && (
-                <div className="canvas-task-card-error">
-                  {task.errorDetail ?? task.errorMsg}
-                </div>
+                <div className="canvas-task-card-error">{task.errorDetail ?? task.errorMsg}</div>
               )}
             </button>
           ))
         )}
       </div>
+
+      <Modal
+        title="任务队列"
+        open={queueModalOpen}
+        onCancel={() => setQueueModalOpen(false)}
+        footer={null}
+        width="min(1080px, 92vw)"
+        className="canvas-task-queue-modal"
+      >
+        <div className="canvas-task-queue-modal-body">
+          <div className="canvas-task-stat-grid">
+            <TaskStat
+              label="全部"
+              value={tasks.length}
+              active={filter === 'all'}
+              onClick={() => setFilter('all')}
+            />
+            <TaskStat
+              label="运行"
+              value={activeCount}
+              active={filter === 'active'}
+              onClick={() => setFilter('active')}
+            />
+            <TaskStat
+              label="失败"
+              value={failedCount}
+              active={filter === 'failed'}
+              onClick={() => setFilter('failed')}
+            />
+            <TaskStat
+              label="完成"
+              value={completedCount}
+              active={filter === 'completed'}
+              onClick={() => setFilter('completed')}
+            />
+          </div>
+          <div className="canvas-task-queue-list canvas-task-queue-list-modal">
+            {visibleTasks.length === 0 ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="暂无任务" />
+            ) : (
+              visibleTasks.map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  className={`canvas-task-card canvas-task-card-${task.status}`}
+                  onClick={() => setDetailTaskId(task.id)}
+                >
+                  <div className="canvas-task-card-head">
+                    <span className="canvas-task-card-title">
+                      {task.title ?? operationLabel(task.operation)}
+                    </span>
+                    <TaskStatusTag status={task.status} />
+                  </div>
+                  <div className="canvas-task-card-meta">
+                    <span>{operationLabel(task.operation)}</span>
+                    {task.provider ? <span>{task.provider}</span> : null}
+                    {task.modelId ? <span>{task.modelId}</span> : null}
+                  </div>
+                  <Progress
+                    percent={task.progress}
+                    size="small"
+                    status={progressStatus(task.status)}
+                  />
+                  {(task.errorMsg || task.errorDetail) && (
+                    <div className="canvas-task-card-error">
+                      {task.errorDetail ?? task.errorMsg}
+                    </div>
+                  )}
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </Modal>
 
       <TaskDetailModal
         task={detailTask}
@@ -190,7 +293,11 @@ function TaskDetailModal({
 
         <Space size={8} wrap>
           {taskNode && (
-            <Button size="small" icon={<Icons.Activity size={14} />} onClick={() => onSelectNode(taskNode.id)}>
+            <Button
+              size="small"
+              icon={<Icons.Activity size={14} />}
+              onClick={() => onSelectNode(taskNode.id)}
+            >
               定位任务节点
             </Button>
           )}
@@ -266,12 +373,12 @@ function TaskDetailModal({
           <DetailBlock title="请求摘要">
             <div className="canvas-task-request-call">
               <div className="canvas-task-request-line">
-                <Tag size="small" color="blue">{task.requestCall.method}</Tag>
+                <Tag size="small" color="blue">
+                  {task.requestCall.method}
+                </Tag>
                 <code>{task.requestCall.url}</code>
               </div>
-              {task.requestCall.body != null && (
-                <pre>{formatJson(task.requestCall.body)}</pre>
-              )}
+              {task.requestCall.body != null && <pre>{formatJson(task.requestCall.body)}</pre>}
             </div>
           </DetailBlock>
         )}
@@ -296,7 +403,9 @@ function TaskDetailModal({
                   task.providerProfileId ? `Profile ${task.providerProfileId}` : '',
                   task.provider ? `Provider ${task.provider}` : '',
                   task.modelId ? `Model ${task.modelId}` : '',
-                ].filter(Boolean).join(' / ')}`}
+                ]
+                  .filter(Boolean)
+                  .join(' / ')}`}
               />
             )}
             {displayPrompt && (
@@ -305,7 +414,9 @@ function TaskDetailModal({
             {outputText && (
               <TaskLogItem time={task.updatedAt} label={`模型输出 ${outputText.length} 字符`} />
             )}
-            {task.requestId && <TaskLogItem time={task.updatedAt} label={`Provider request: ${task.requestId}`} />}
+            {task.requestId && (
+              <TaskLogItem time={task.updatedAt} label={`Provider request: ${task.requestId}`} />
+            )}
             <TaskLogItem time={task.updatedAt} label={`状态更新为 ${task.status}`} />
             {task.completedAt && <TaskLogItem time={task.completedAt} label="任务结束" />}
           </div>

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -1134,7 +1134,7 @@ body.canvas-side-panel-resizing {
 }
 
 .canvas-prompt-editor-textarea textarea {
-  min-height: 118px;
+  min-height: 180px;
   font-size: 13px;
 }
 
@@ -1149,7 +1149,7 @@ body.canvas-side-panel-resizing {
 }
 
 .canvas-negative-prompt-field textarea {
-  min-height: 86px;
+  min-height: 120px;
 }
 
 .canvas-prompt-editor.expanded .canvas-negative-prompt-field textarea {
@@ -4819,7 +4819,10 @@ body.canvas-side-panel-resizing {
   border: 1px solid var(--border);
   background: var(--canvas-field-bg);
   cursor: pointer;
-  transition: border-color 0.15s, box-shadow 0.15s, transform 0.05s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s,
+    transform 0.05s;
 }
 
 .canvas-film-manuscript-card:hover {
@@ -6715,4 +6718,82 @@ body.canvas-side-panel-resizing {
 
 .canvas-node-pipeline-action:active {
   transform: scale(0.96);
+}
+
+.canvas-side-panel-collapse-toggle {
+  position: absolute;
+  z-index: 8;
+  top: 50%;
+  right: var(--canvas-side-panel-width);
+  display: inline-flex;
+  width: 28px;
+  height: 48px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-right: 0;
+  border-radius: 14px 0 0 14px;
+  background: color-mix(in srgb, var(--panel-elev) 92%, transparent);
+  color: var(--text-muted);
+  cursor: pointer;
+  transform: translateY(-50%);
+  box-shadow: var(--shadow-sm);
+}
+
+.canvas-side-panel-collapse-toggle:hover {
+  color: var(--primary);
+  background: var(--panel);
+}
+
+.canvas-side-panel-collapse-toggle.is-collapsed {
+  right: 0;
+}
+
+.canvas-side-tabs {
+  order: 1;
+}
+
+.canvas-side-panel-content {
+  order: 2;
+}
+
+.canvas-side-panel-footer {
+  order: 3;
+  margin-top: auto;
+  border-top: 1px solid color-mix(in srgb, var(--divider) 84%, transparent);
+  border-bottom: 0;
+}
+
+.canvas-task-queue-modal .ant-modal-body {
+  padding-top: 8px;
+}
+
+.canvas-task-queue-modal-body {
+  display: flex;
+  max-height: min(72vh, 760px);
+  flex-direction: column;
+  gap: 14px;
+}
+
+.canvas-task-queue-list-modal {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  max-height: none;
+  min-height: 360px;
+  overflow: auto;
+}
+
+.canvas-node-edit-bottom-panel.is-fullscreen .canvas-node-edit-prompt-layout {
+  min-height: 0;
+  align-items: stretch;
+}
+
+.canvas-node-edit-bottom-panel.is-fullscreen .canvas-node-edit-prompt-library {
+  height: 100%;
+  max-height: none;
+}
+
+.canvas-node-edit-bottom-panel.is-fullscreen .canvas-node-edit-prompt-main,
+.canvas-node-edit-bottom-panel.is-fullscreen .canvas-node-edit-prompt-main .canvas-prompt-editor {
+  min-height: 0;
 }

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -522,7 +522,10 @@ function buildScriptBreakdownDraft(asset: CanvasAsset): ScriptBreakdownDraft {
   }
 
   const pushProp = (name: string, line: string) => {
-    const normalized = name.trim().replace(/[（）()【】[\]\s]/g, '').slice(0, 16)
+    const normalized = name
+      .trim()
+      .replace(/[（）()【】[\]\s]/g, '')
+      .slice(0, 16)
     if (!normalized || normalized.length < 2 || propMap.has(normalized)) return
     propMap.set(normalized, {
       name: normalized,
@@ -799,7 +802,9 @@ function buildShotSegmentKeyframePrompt(
     `镜号：#${segment.index} ${segment.title}`,
     segment.durationSec != null ? `镜头时长：${segment.durationSec} 秒` : '',
     segment.description ? `画面/动作：${segment.description}` : '',
-    frame === 'first' ? '取镜头开始瞬间的画面。' : '取镜头结束瞬间的画面，需与首帧保持同一场景与角色一致。',
+    frame === 'first'
+      ? '取镜头开始瞬间的画面。'
+      : '取镜头结束瞬间的画面，需与首帧保持同一场景与角色一致。',
     scene
       ? `场景：${scene.title ?? ''} ${scene.contentText ?? ''}${sceneRefs ? `；参考：${sceneRefs}` : ''}`
       : '',
@@ -950,6 +955,7 @@ export function CanvasWorkspaceView({
   const [assetDetailResetKey, setAssetDetailResetKey] = useState(0)
   const canvasViewportRef = useRef<CanvasStageViewport | null>(null)
   const [sidePanelWidth, setSidePanelWidth] = useState(readSidePanelWidth)
+  const [sidePanelCollapsed, setSidePanelCollapsed] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const pendingImagePositionRef = useRef<CanvasPoint | null>(null)
   const activeToolRef = useRef<CanvasTool>('select')
@@ -962,9 +968,9 @@ export function CanvasWorkspaceView({
   const sidePanelStyle = useMemo(
     () =>
       ({
-        '--canvas-side-panel-width': `${sidePanelWidth}px`,
+        '--canvas-side-panel-width': sidePanelCollapsed ? '0px' : `${sidePanelWidth}px`,
       }) as CSSProperties,
-    [sidePanelWidth],
+    [sidePanelCollapsed, sidePanelWidth],
   )
 
   useEffect(() => {
@@ -1155,10 +1161,7 @@ export function CanvasWorkspaceView({
   const canRemoveFromGroup = selectedGroupedNodes.length > 0
   const canDissolveGroup = selectedGroups.length === 1
   const shotDirectorDraft = useMemo(
-    () =>
-      snapshot
-        ? readShotDirectorDraft(snapshot.project.metadata, snapshot.board.id)
-        : null,
+    () => (snapshot ? readShotDirectorDraft(snapshot.project.metadata, snapshot.board.id) : null),
     [snapshot],
   )
   const toolSwitchHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -1960,7 +1963,9 @@ export function CanvasWorkspaceView({
         ...(result.message ? { message: result.message } : {}),
         ...(result.rawResponse !== undefined ? { rawResponse: result.rawResponse } : {}),
         ...(result.agentId !== undefined ? { agentId: result.agentId } : {}),
-        ...(result.providerProfileId !== undefined ? { providerProfileId: result.providerProfileId } : {}),
+        ...(result.providerProfileId !== undefined
+          ? { providerProfileId: result.providerProfileId }
+          : {}),
         ...(result.provider !== undefined ? { provider: result.provider } : {}),
         ...(result.modelId !== undefined ? { modelId: result.modelId } : {}),
       })
@@ -2191,7 +2196,9 @@ export function CanvasWorkspaceView({
       taskPipelineRole: 'screenplay',
       outputPipelineRole: 'screenplay',
     })
-    message.success(`已创建剧本「${scriptAsset.title}」，并发起剧本化改写；产出的剧本节点可右键继续编排`)
+    message.success(
+      `已创建剧本「${scriptAsset.title}」，并发起剧本化改写；产出的剧本节点可右键继续编排`,
+    )
   }
 
   const handleSetProductionState = async (
@@ -2224,7 +2231,12 @@ export function CanvasWorkspaceView({
   /** 从分镜节点的 shotRef 解析 {group, segment, characters, scene}（§S6 节点化） */
   const resolveShotFromNode = (
     node: CanvasNode,
-  ): { group: ShotGroup; segment: ShotSegment; characters: CanvasAsset[]; scene?: CanvasAsset } | null => {
+  ): {
+    group: ShotGroup
+    segment: ShotSegment
+    characters: CanvasAsset[]
+    scene?: CanvasAsset
+  } | null => {
     const groupId = node.data.shotGroupId
     const segmentId = node.data.shotSegmentId
     if (!groupId || !segmentId) return null
@@ -2263,7 +2275,11 @@ export function CanvasWorkspaceView({
     const node = snapshot.nodes.find((item) => item.id === nodeId)
     if (!node) return
     // 分镜 / 关键帧节点：从 shotRef 解析分镜后执行（§S6/§S7 节点化）
-    if (actionId === 'shot.to_keyframes' || actionId === 'shot.to_video' || actionId === 'keyframe.to_video') {
+    if (
+      actionId === 'shot.to_keyframes' ||
+      actionId === 'shot.to_video' ||
+      actionId === 'keyframe.to_video'
+    ) {
       const resolved = resolveShotFromNode(node)
       if (!resolved) {
         message.warning('该节点未关联分镜，无法执行')
@@ -2468,7 +2484,10 @@ export function CanvasWorkspaceView({
             count: created,
             outputNodeIds,
             outputAssetIds,
-            message: failed > 0 ? `已${label} ${created} 个（${failed} 个失败）` : `已${label} ${created} 个`,
+            message:
+              failed > 0
+                ? `已${label} ${created} 个（${failed} 个失败）`
+                : `已${label} ${created} 个`,
             agentId: runtime.agentId ?? null,
             providerProfileId: (response.providerProfileId || runtime.providerProfileId) ?? null,
             provider: response.provider || null,
@@ -2504,7 +2523,13 @@ export function CanvasWorkspaceView({
   const handleGenerateAssetReference = (asset: CanvasAsset, sourceNodeId?: string) => {
     const kind = readAssetKind(asset)
     const title =
-      kind === 'scene' ? '生成场景图' : kind === 'prop' ? '生成道具图' : kind === 'effect' ? '生成特效图' : '生成设计图'
+      kind === 'scene'
+        ? '生成场景图'
+        : kind === 'prop'
+          ? '生成道具图'
+          : kind === 'effect'
+            ? '生成特效图'
+            : '生成设计图'
     void handleCreateTask({
       operation: 'text_to_image',
       prompt: buildFilmAssetReferencePrompt(asset, readStyleBible(snapshot.project.metadata)),
@@ -2536,7 +2561,8 @@ export function CanvasWorkspaceView({
         ...(styleBible ? { styleBible } : {}),
         ...(stylePrompt ? { extraPrompt: stylePrompt } : {}),
       })
-      const sheetTitle = aspect === 'turnaround' ? `生成三视图 · ${asset.title ?? '角色'}` : '生成角色图'
+      const sheetTitle =
+        aspect === 'turnaround' ? `生成三视图 · ${asset.title ?? '角色'}` : '生成角色图'
       const needsBase = getCharacterSheetTemplate(aspect)?.needsBaseImage ?? false
       if (needsBase && baseImageNode) {
         i2iCount += 1
@@ -2572,7 +2598,12 @@ export function CanvasWorkspaceView({
     const ordered = [...refs.filter((r) => r.kind === 'concept'), ...refs]
     const imageNodeByAssetId = new Map<string, CanvasNode>()
     for (const node of snapshot.nodes) {
-      if (node.type === 'image' && node.assetId && node.data.url && !imageNodeByAssetId.has(node.assetId)) {
+      if (
+        node.type === 'image' &&
+        node.assetId &&
+        node.data.url &&
+        !imageNodeByAssetId.has(node.assetId)
+      ) {
         imageNodeByAssetId.set(node.assetId, node)
       }
     }
@@ -2886,10 +2917,7 @@ export function CanvasWorkspaceView({
         />
       </header>
 
-      <div
-        className="canvas-workspace-body"
-        style={sidePanelStyle}
-      >
+      <div className="canvas-workspace-body" style={sidePanelStyle}>
         <div className="canvas-stage-area">
           {toolSwitchHint && (
             <div
@@ -2920,7 +2948,7 @@ export function CanvasWorkspaceView({
             onOpenAiComposer={handleOpenInlineAi}
             onEditNode={handleEditNode}
             onSaveNodeToLibrary={(nodeId) => setSaveToLibraryNodeId(nodeId)}
-            onCreateOperationChild={(parentId, operation) => {
+            onCreateOperationChild={(parentId, operation, options) => {
               const parent = snapshot.nodes.find((n) => n.id === parentId)
               if (!parent) return
               void createOperationNode({
@@ -2929,14 +2957,12 @@ export function CanvasWorkspaceView({
                 inputNodeIds: [parentId],
                 x: parent.x + parent.width + 60,
                 y: parent.y,
+                ...(options?.title ? { title: options.title } : {}),
+                ...(options?.prompt ? { prompt: options.prompt } : {}),
               })
             }}
-            onPipelineAction={(nodeId, actionId) =>
-              void handleNodePipelineAction(nodeId, actionId)
-            }
-            onSetProductionState={(nodeId, state) =>
-              void handleSetProductionState(nodeId, state)
-            }
+            onPipelineAction={(nodeId, actionId) => void handleNodePipelineAction(nodeId, actionId)}
+            onSetProductionState={(nodeId, state) => void handleSetProductionState(nodeId, state)}
             onAddTextAtPosition={(position) => void addText(position)}
             onAddImageAtPosition={uploadFirstImage}
             onAddPromptAtPosition={(position) => void addText(position)}
@@ -3037,7 +3063,11 @@ export function CanvasWorkspaceView({
                     const sourceAsset = sourceNode.assetId
                       ? snapshot.assets.find((item) => item.id === sourceNode.assetId)
                       : undefined
-                    const sourceText = (sourceAsset?.contentText ?? sourceNode.data.text ?? '').trim()
+                    const sourceText = (
+                      sourceAsset?.contentText ??
+                      sourceNode.data.text ??
+                      ''
+                    ).trim()
                     await handleExtractEntities(
                       sourceNode,
                       sourceText,
@@ -3045,7 +3075,9 @@ export function CanvasWorkspaceView({
                       {
                         prompt: effectivePrompt,
                         ...(params.agentId ? { agentId: params.agentId } : {}),
-                        ...(params.providerProfileId ? { providerProfileId: params.providerProfileId } : {}),
+                        ...(params.providerProfileId
+                          ? { providerProfileId: params.providerProfileId }
+                          : {}),
                         ...(params.modelId ? { modelId: params.modelId } : {}),
                       },
                     )
@@ -3181,177 +3213,188 @@ export function CanvasWorkspaceView({
             }}
           />
         </div>
-        <aside className="canvas-side-panel" style={{ width: sidePanelWidth }}>
-          <div
-            aria-label="调整右侧面板宽度"
-            aria-orientation="vertical"
-            aria-valuemax={CANVAS_SIDE_PANEL_MAX_WIDTH}
-            aria-valuemin={CANVAS_SIDE_PANEL_MIN_WIDTH}
-            aria-valuenow={sidePanelWidth}
-            className="canvas-side-panel-resize-handle"
-            onDoubleClick={() => updateSidePanelWidth(CANVAS_SIDE_PANEL_DEFAULT_WIDTH)}
-            onKeyDown={handleSidePanelResizeKeyDown}
-            onPointerDown={handleSidePanelResizeStart}
-            role="separator"
-            tabIndex={0}
-            title="拖拽调整面板宽度"
-          />
-          <div className="canvas-side-tabs">
-            <Segmented
-              value={sidePanelTab}
-              onChange={(value) =>
-                setSidePanelTab(
-                  value as 'production' | 'boards' | 'assets' | 'details' | 'project',
-                )
-              }
-              options={[
-                { label: '制作', value: 'production' },
-                { label: '画布', value: 'boards' },
-                { label: '资产', value: 'assets' },
-                { label: '属性', value: 'details' },
-                { label: '项目信息', value: 'project' },
-              ]}
+        <button
+          type="button"
+          className={`canvas-side-panel-collapse-toggle${sidePanelCollapsed ? ' is-collapsed' : ''}`}
+          onClick={() => setSidePanelCollapsed((current) => !current)}
+          aria-label={sidePanelCollapsed ? '展开右侧面板' : '折叠右侧面板'}
+          title={sidePanelCollapsed ? '展开右侧面板' : '折叠右侧面板'}
+        >
+          {sidePanelCollapsed ? <Icons.ChevronLeft size={16} /> : <Icons.ChevronRight size={16} />}
+        </button>
+        {!sidePanelCollapsed && (
+          <aside className="canvas-side-panel" style={{ width: sidePanelWidth }}>
+            <div
+              aria-label="调整右侧面板宽度"
+              aria-orientation="vertical"
+              aria-valuemax={CANVAS_SIDE_PANEL_MAX_WIDTH}
+              aria-valuemin={CANVAS_SIDE_PANEL_MIN_WIDTH}
+              aria-valuenow={sidePanelWidth}
+              className="canvas-side-panel-resize-handle"
+              onDoubleClick={() => updateSidePanelWidth(CANVAS_SIDE_PANEL_DEFAULT_WIDTH)}
+              onKeyDown={handleSidePanelResizeKeyDown}
+              onPointerDown={handleSidePanelResizeStart}
+              role="separator"
+              tabIndex={0}
+              title="拖拽调整面板宽度"
             />
-          </div>
-          <div className="canvas-side-panel-footer">
-            <button
-              type="button"
-              className="canvas-side-utility-btn"
-              onClick={() => {
-                closeCanvasFloatPanels()
-                setHistoryOpen(true)
-              }}
-            >
-              <Icons.Clock size={16} />
-              <span>历史</span>
-            </button>
-            <button
-              type="button"
-              className="canvas-side-utility-btn"
-              onClick={() => void handleOpenProjectFolder()}
-            >
-              <Icons.Folder size={16} />
-              <span>目录</span>
-            </button>
-            <button
-              type="button"
-              className="canvas-side-utility-btn"
-              onClick={() => {
-                closeCanvasFloatPanels()
-                setTemplateOpen(true)
-              }}
-            >
-              <Icons.Layers size={16} />
-              <span>模板</span>
-            </button>
-            <button
-              type="button"
-              className="canvas-side-utility-btn"
-              onClick={() => message.info('帮助与快捷键')}
-            >
-              <Icons.HelpCircle size={16} />
-              <span>帮助</span>
-            </button>
-          </div>
-          {sidePanelTab === 'production' && (
-            <CanvasProductionPanel
-              snapshot={snapshot}
-              onOpenFilmCenter={(stageKey) => {
-                if (stageKey) setFilmCenterInitialTab(PRODUCTION_STAGE_TO_TAB[stageKey])
-                closeCanvasFloatPanels('film-center')
-                setFilmCenterOpen(true)
-              }}
-            />
-          )}
-          {sidePanelTab === 'boards' && (
-            <div className="canvas-side-panel-content">
-              <CanvasBoardSidebar
-                snapshot={snapshot}
-                activeBoardId={snapshot.board.id}
-                onSelectBoard={(boardId) => void handleSwitchBoard(boardId)}
-                onCreateBoard={(input) => void createBoard(input)}
-                onRenameBoard={(boardId, name) => void renameBoard(boardId, name)}
-                onDeleteBoard={(boardId) => void deleteBoard(boardId)}
-                onDuplicateBoard={(boardId) => void duplicateBoard(boardId)}
-                onSetDefaultBoard={(boardId) => void setDefaultBoard(boardId)}
-              />
-            </div>
-          )}
-          {sidePanelTab === 'assets' && (
-            <div className="canvas-side-panel-content">
-              <CanvasAssetManagerPanel
-                assets={snapshot.assets}
-                nodes={snapshot.nodes}
-                tasks={snapshot.tasks}
-                onInsertAssets={(assetIds) => {
-                  for (const assetId of assetIds) void handleInsertAsset(assetId)
-                }}
-                onInsertOne={(assetId) => void handleInsertAsset(assetId)}
-                onDownloadOne={(asset) => downloadAsset(asset)}
-                detailResetKey={assetDetailResetKey}
-                onOpenDetail={() => closeCanvasFloatPanels('asset-detail')}
-                onRemoveReferences={async (assetIds) => {
-                  const targetAssetSet = new Set(assetIds)
-                  const nodeIds = snapshot.nodes
-                    .filter((node) => node.assetId && targetAssetSet.has(node.assetId))
-                    .map((node) => node.id)
-                  if (nodeIds.length > 0) {
-                    await deleteNodes(nodeIds)
-                  }
-                }}
-              />
-            </div>
-          )}
-          {sidePanelTab === 'details' && (
-            <div className="canvas-side-panel-content">
-              <CanvasTaskQueue
-                tasks={snapshot.tasks}
-                nodes={snapshot.nodes}
-                assets={snapshot.assets}
-                onCompleteDemoTask={(taskId) => void completeDemoTask(taskId)}
-                onCancelTask={(taskId) => void cancelTask(taskId)}
-                onRetryTask={(task) => void handleRetryTask(task)}
-                onSelectNode={(nodeId) => setSelectedNodeIds([nodeId])}
-              />
-              <CanvasInspector
-                selectedNodes={selectedNodes}
-                nodes={snapshot.nodes}
-                edges={snapshot.edges}
-                assets={snapshot.assets}
-                tasks={snapshot.tasks}
-                onDuplicate={() => void duplicateNodes(selectedNodeIds)}
-                onToggleLock={() => void handleToggleLock()}
-                onBringToFront={() => void handleBringToFront()}
-                onCreateGroup={handleCreateGroup}
-                onAddToGroup={() => handleAddSelectionToGroup()}
-                onRemoveFromGroup={() => handleRemoveFromGroup()}
-                onDissolveGroup={() => handleDissolveGroup()}
-                canCreateGroup={canCreateGroup}
-                canAddToGroup={canAddToGroup}
-                canRemoveFromGroup={canRemoveFromGroup}
-                canDissolveGroup={canDissolveGroup}
-                onPatchNode={(node, patch) => {
-                  void patchNodes([node.id], patch)
-                }}
-              />
-            </div>
-          )}
-          {sidePanelTab === 'project' && (
-            <div className="canvas-side-panel-content">
-              <CanvasProjectInfoPanel
-                key={`${snapshot.project.id}:${snapshot.project.updatedAt}:project-info`}
-                project={snapshot.project}
-                onOpenProjectFolder={handleOpenProjectFolder}
-                onSave={(settings) => updateProjectSettings(settings)}
-                onSaveStyleBible={async (styleBible) => {
-                  await updateProjectMetadata(
-                    writeStyleBible(snapshot.project.metadata, styleBible),
+            <div className="canvas-side-tabs">
+              <Segmented
+                value={sidePanelTab}
+                onChange={(value) =>
+                  setSidePanelTab(
+                    value as 'production' | 'boards' | 'assets' | 'details' | 'project',
                   )
-                }}
+                }
+                options={[
+                  { label: '制作', value: 'production' },
+                  { label: '画布', value: 'boards' },
+                  { label: '资产', value: 'assets' },
+                  { label: '属性', value: 'details' },
+                  { label: '项目信息', value: 'project' },
+                ]}
               />
             </div>
-          )}
-        </aside>
+            <div className="canvas-side-panel-footer">
+              <button
+                type="button"
+                className="canvas-side-utility-btn"
+                onClick={() => {
+                  closeCanvasFloatPanels()
+                  setHistoryOpen(true)
+                }}
+              >
+                <Icons.Clock size={16} />
+                <span>历史</span>
+              </button>
+              <button
+                type="button"
+                className="canvas-side-utility-btn"
+                onClick={() => void handleOpenProjectFolder()}
+              >
+                <Icons.Folder size={16} />
+                <span>目录</span>
+              </button>
+              <button
+                type="button"
+                className="canvas-side-utility-btn"
+                onClick={() => {
+                  closeCanvasFloatPanels()
+                  setTemplateOpen(true)
+                }}
+              >
+                <Icons.Layers size={16} />
+                <span>模板</span>
+              </button>
+              <button
+                type="button"
+                className="canvas-side-utility-btn"
+                onClick={() => message.info('帮助与快捷键')}
+              >
+                <Icons.HelpCircle size={16} />
+                <span>帮助</span>
+              </button>
+            </div>
+            {sidePanelTab === 'production' && (
+              <CanvasProductionPanel
+                snapshot={snapshot}
+                onOpenFilmCenter={(stageKey) => {
+                  if (stageKey) setFilmCenterInitialTab(PRODUCTION_STAGE_TO_TAB[stageKey])
+                  closeCanvasFloatPanels('film-center')
+                  setFilmCenterOpen(true)
+                }}
+              />
+            )}
+            {sidePanelTab === 'boards' && (
+              <div className="canvas-side-panel-content">
+                <CanvasBoardSidebar
+                  snapshot={snapshot}
+                  activeBoardId={snapshot.board.id}
+                  onSelectBoard={(boardId) => void handleSwitchBoard(boardId)}
+                  onCreateBoard={(input) => void createBoard(input)}
+                  onRenameBoard={(boardId, name) => void renameBoard(boardId, name)}
+                  onDeleteBoard={(boardId) => void deleteBoard(boardId)}
+                  onDuplicateBoard={(boardId) => void duplicateBoard(boardId)}
+                  onSetDefaultBoard={(boardId) => void setDefaultBoard(boardId)}
+                />
+              </div>
+            )}
+            {sidePanelTab === 'assets' && (
+              <div className="canvas-side-panel-content">
+                <CanvasAssetManagerPanel
+                  assets={snapshot.assets}
+                  nodes={snapshot.nodes}
+                  tasks={snapshot.tasks}
+                  onInsertAssets={(assetIds) => {
+                    for (const assetId of assetIds) void handleInsertAsset(assetId)
+                  }}
+                  onInsertOne={(assetId) => void handleInsertAsset(assetId)}
+                  onDownloadOne={(asset) => downloadAsset(asset)}
+                  detailResetKey={assetDetailResetKey}
+                  onOpenDetail={() => closeCanvasFloatPanels('asset-detail')}
+                  onRemoveReferences={async (assetIds) => {
+                    const targetAssetSet = new Set(assetIds)
+                    const nodeIds = snapshot.nodes
+                      .filter((node) => node.assetId && targetAssetSet.has(node.assetId))
+                      .map((node) => node.id)
+                    if (nodeIds.length > 0) {
+                      await deleteNodes(nodeIds)
+                    }
+                  }}
+                />
+              </div>
+            )}
+            {sidePanelTab === 'details' && (
+              <div className="canvas-side-panel-content">
+                <CanvasTaskQueue
+                  tasks={snapshot.tasks}
+                  nodes={snapshot.nodes}
+                  assets={snapshot.assets}
+                  onCompleteDemoTask={(taskId) => void completeDemoTask(taskId)}
+                  onCancelTask={(taskId) => void cancelTask(taskId)}
+                  onRetryTask={(task) => void handleRetryTask(task)}
+                  onSelectNode={(nodeId) => setSelectedNodeIds([nodeId])}
+                />
+                <CanvasInspector
+                  selectedNodes={selectedNodes}
+                  nodes={snapshot.nodes}
+                  edges={snapshot.edges}
+                  assets={snapshot.assets}
+                  tasks={snapshot.tasks}
+                  onDuplicate={() => void duplicateNodes(selectedNodeIds)}
+                  onToggleLock={() => void handleToggleLock()}
+                  onBringToFront={() => void handleBringToFront()}
+                  onCreateGroup={handleCreateGroup}
+                  onAddToGroup={() => handleAddSelectionToGroup()}
+                  onRemoveFromGroup={() => handleRemoveFromGroup()}
+                  onDissolveGroup={() => handleDissolveGroup()}
+                  canCreateGroup={canCreateGroup}
+                  canAddToGroup={canAddToGroup}
+                  canRemoveFromGroup={canRemoveFromGroup}
+                  canDissolveGroup={canDissolveGroup}
+                  onPatchNode={(node, patch) => {
+                    void patchNodes([node.id], patch)
+                  }}
+                />
+              </div>
+            )}
+            {sidePanelTab === 'project' && (
+              <div className="canvas-side-panel-content">
+                <CanvasProjectInfoPanel
+                  key={`${snapshot.project.id}:${snapshot.project.updatedAt}:project-info`}
+                  project={snapshot.project}
+                  onOpenProjectFolder={handleOpenProjectFolder}
+                  onSave={(settings) => updateProjectSettings(settings)}
+                  onSaveStyleBible={async (styleBible) => {
+                    await updateProjectMetadata(
+                      writeStyleBible(snapshot.project.metadata, styleBible),
+                    )
+                  }}
+                />
+              </div>
+            )}
+          </aside>
+        )}
       </div>
       <Drawer
         title="历史记录"
@@ -3517,10 +3560,7 @@ function CanvasProjectInfoPanel({
           />
         </div>
         <div className="canvas-project-prompt-actions">
-          <Button
-            size="small"
-            onClick={() => setStyleBible(readStyleBible(project.metadata))}
-          >
+          <Button size="small" onClick={() => setStyleBible(readStyleBible(project.metadata))}>
             重置
           </Button>
           <Button
@@ -3688,7 +3728,11 @@ function CanvasNodeEditModal({
 
   if (!open || !node) return null
   const fullscreenLabel = editFullscreen ? '退出全屏' : '全屏编辑'
-  const fullscreenIcon = editFullscreen ? <Icons.Minimize size={14} /> : <Icons.Maximize size={14} />
+  const fullscreenIcon = editFullscreen ? (
+    <Icons.Minimize size={14} />
+  ) : (
+    <Icons.Maximize size={14} />
+  )
   const toggleFullscreen = () => setEditFullscreen((current) => !current)
 
   const content = (
@@ -3748,7 +3792,7 @@ function CanvasNodeEditModal({
           <span>组说明</span>
           <Input.TextArea
             value={text}
-            rows={3}
+            rows={5}
             placeholder="输入节点内容"
             onChange={(event) => setText(event.target.value)}
           />
@@ -3760,7 +3804,7 @@ function CanvasNodeEditModal({
             <span>任务指令</span>
             <Input.TextArea
               value={prompt}
-              rows={4}
+              rows={6}
               placeholder="任务使用的 prompt"
               onChange={(event) => setPrompt(event.target.value)}
             />
@@ -3788,7 +3832,7 @@ function CanvasNodeEditModal({
           <span>备注 / 展示文本</span>
           <Input.TextArea
             value={messageText}
-            rows={3}
+            rows={5}
             placeholder="节点内展示的辅助文本"
             onChange={(event) => setMessageText(event.target.value)}
           />

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -30,7 +30,11 @@ import {
   type FilmProjectData,
 } from './canvasFilmAssets'
 import type { FilmReference, ManuscriptChapterRef } from './canvasFilmTypes'
-import { upsertManuscriptChapters, readManuscriptIndex, clearManuscriptIndex } from './canvasPipeline'
+import {
+  upsertManuscriptChapters,
+  readManuscriptIndex,
+  clearManuscriptIndex,
+} from './canvasPipeline'
 import type { ParsedChapter } from './canvasManuscript'
 import type {
   CanvasMediaTaskCreateRequest,
@@ -2285,7 +2289,8 @@ export const canvasApi = {
     const before = db.assets.length
     db.assets = db.assets.filter(
       (asset) =>
-        !(asset.id === manuscriptAssetId && asset.projectId === projectId) && !isOwnedChapter(asset),
+        !(asset.id === manuscriptAssetId && asset.projectId === projectId) &&
+        !isOwnedChapter(asset),
     )
     const deletedChapters = before - db.assets.length - (manuscript ? 1 : 0)
 
@@ -3584,6 +3589,7 @@ export const canvasApi = {
     x: number
     y: number
     title?: string
+    prompt?: string
   }): Promise<CanvasSnapshot> {
     const db = readDb()
     const at = now()
@@ -3609,6 +3615,7 @@ export const canvasApi = {
       .filter(Boolean)
       .join('\n\n')
     const inheritedPrompt =
+      nonEmptyString(input.prompt) ||
       promptContext ||
       inputNodes
         .map((node) => nonEmptyString(node.data.prompt))
@@ -3911,7 +3918,8 @@ export const canvasApi = {
     if (request.prompt != null) taskNodeData.prompt = request.prompt
     // 专用流水线节点：任务节点角色 + 暂存产物节点角色（供完成回写读取）
     if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
-    if (request.outputPipelineRole != null) taskNodeData.outputPipelineRole = request.outputPipelineRole
+    if (request.outputPipelineRole != null)
+      taskNodeData.outputPipelineRole = request.outputPipelineRole
     let taskNode: CanvasNode
     const bindNode = options?.bindToNodeId
       ? db.nodes.find((n) => n.id === options.bindToNodeId && n.projectId === projectId)
@@ -4046,7 +4054,8 @@ export const canvasApi = {
     if (request.prompt != null) taskNodeData.prompt = request.prompt
     // 专用流水线节点：任务节点角色 + 暂存产物节点角色（供完成回写读取）
     if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
-    if (request.outputPipelineRole != null) taskNodeData.outputPipelineRole = request.outputPipelineRole
+    if (request.outputPipelineRole != null)
+      taskNodeData.outputPipelineRole = request.outputPipelineRole
     let taskNode: CanvasNode
     const bindNode = options?.bindToNodeId
       ? db.nodes.find((n) => n.id === options.bindToNodeId && n.projectId === projectId)

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
@@ -422,10 +422,7 @@ export function useCanvasWorkspace(projectId: string) {
   )
 
   const updateFilmAsset = useCallback(
-    async (
-      assetId: string,
-      patch: Parameters<typeof canvasApi.updateFilmAsset>[2],
-    ) => {
+    async (assetId: string, patch: Parameters<typeof canvasApi.updateFilmAsset>[2]) => {
       setSnapshot(await canvasApi.updateFilmAsset(projectId, assetId, patch))
     },
     [projectId],
@@ -512,6 +509,7 @@ export function useCanvasWorkspace(projectId: string) {
       x: number
       y: number
       title?: string
+      prompt?: string
     }) => {
       setSnapshot(await canvasApi.createOperationNode({ projectId, ...input }))
     },
@@ -544,7 +542,6 @@ export function useCanvasWorkspace(projectId: string) {
     },
     [projectId],
   )
-
 
   return {
     snapshot,
@@ -609,9 +606,7 @@ export function useCanvasWorkspace(projectId: string) {
  * 资产选择/视图模式。这些是纯 UI 状态，不进持久化热存储
  * （需要会话恢复时再写 snapshot.uiState）。
  */
-export function useCanvasWorkspaceUi(initial?: {
-  rightPanelTab?: CanvasRightPanelTab
-}) {
+export function useCanvasWorkspaceUi(initial?: { rightPanelTab?: CanvasRightPanelTab }) {
   const [rightPanelTab, setRightPanelTab] = useState<CanvasRightPanelTab>(
     initial?.rightPanelTab ?? 'inspector',
   )


### PR DESCRIPTION
### Motivation
- Make the canvas right-side utility actions (`历史/目录/模板/帮助`) fixed to the footer and support collapsing the side panel to free up canvas space. 
- Provide a way to inspect the full task queue in a large modal from the side-panel task widget. 
- Add a quick "提取风格" operation for image nodes to create a prefilled style-extraction AI operation node. 
- Improve editing ergonomics by increasing prompt / textarea heights and letting the prompt-library fill remaining modal space when editing in fullscreen.

### Description
- Added a collapsible right-side panel and toggle: `CanvasWorkspaceView` now tracks `sidePanelCollapsed` and renders a collapse toggle button; styles and layout updated in `CanvasWorkspaceView.less` to support collapse behavior and new footer ordering. (files: `CanvasWorkspaceView.tsx`, `CanvasWorkspaceView.less`)
- Task queue: `CanvasTaskQueue` header now includes a small "放大" button that opens a large modal replicating the queue UI (`Modal` + `.canvas-task-queue-modal` styles). (file: `CanvasTaskQueue.tsx`)
- Node actions/menu updates: removed the standalone `AI 操作` top-level context item and kept the typed `新增 AI 操作 ▸` submenu, and added a new `提取风格` item on `image` nodes that calls `createOperationChild` with a prefilled `title` and `prompt`. (file: `CanvasNode.tsx`)
- Operation node API and store: extended `createOperationNode` / store wrappers to accept optional `prompt`/`title` so prefilled operations (e.g. style extraction) are created with the intended prompt; inheritance logic now prefers `input.prompt` when present. (files: `canvas.api.ts`, `canvas.store.ts`)
- Prompt editor / modal sizing: increased default `textarea` heights (`min-height` / `rows`) for prompt editor, negative prompt and other textareas; when `CanvasNodeEditModal` is fullscreen, the prompt-library panel now stretches to fill remaining height. (files: `CanvasWorkspaceView.less`, `CanvasWorkspaceView.tsx`)
- Minor code formatting and a few small defensive formatting fixes across touched files to keep lint/format consistent. (files: several under `apps/desktop/src/renderer/design/views/canvas`)

### Testing
- Ran code formatting: `pnpm exec prettier --write apps/desktop/src/renderer/design/views/canvas/*` and files were formatted successfully. (succeeded)
- Ran type checks: `pnpm --filter @spark/desktop typecheck` (ran `tsc --noEmit`) and the TypeScript typecheck completed with no errors. (succeeded)
- Ran GitNexus safety steps: executed `npx gitnexus impact` and `npx gitnexus detect_changes` as required by repo guidelines; the CLI in this environment produced npm install/deprecation warnings and did not return detailed analysis output, but the commands were executed prior to edits. (ran; CLI returned only environment warnings)
- Verified UI-related changes compile under the project typecheck and no runtime type errors were reported during the typecheck step. (typecheck passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3801d27b648325b5db25dff7c77bb1)