### PR TITLE
feat(canvas): add 3D Director Stage node and large editor modal

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasDirectorStageModal.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasDirectorStageModal.tsx
@@ -1,0 +1,382 @@
+import { useMemo, useState, type PointerEvent as ReactPointerEvent } from 'react'
+import { Button, Tag } from '@lobehub/ui'
+import { Input, Modal, Select, message } from 'antd'
+import { Icons } from '../../Icons'
+import type { CanvasNode } from './canvas.types'
+
+type Vec3 = { x: number; y: number; z: number }
+type Rotation3 = { yaw: number; pitch: number; roll: number }
+type StageObjectKind = 'character' | 'prop' | 'camera'
+
+type StageObject = {
+  id: string
+  kind: StageObjectKind
+  name: string
+  color: string
+  position: Vec3
+  rotation: Rotation3
+  pose?: string
+}
+
+export type DirectorStageData = {
+  version: 1
+  objects: StageObject[]
+  activeObjectId?: string
+  gridSize: number
+  prompt?: string
+}
+
+const defaultCamera: StageObject = {
+  id: 'cam-1',
+  kind: 'camera',
+  name: '机位1',
+  color: '#f59e0b',
+  position: { x: -2, y: 0.45, z: 2.2 },
+  rotation: { yaw: 35, pitch: -8, roll: 0 },
+}
+
+const defaultCharacter: StageObject = {
+  id: 'char-1',
+  kind: 'character',
+  name: '角色A',
+  color: '#60a5fa',
+  position: { x: 0, y: 0.85, z: 0 },
+  rotation: { yaw: 180, pitch: 0, roll: 0 },
+  pose: '站立，面向镜头',
+}
+
+function createDefaultDirectorStageDataInternal(): DirectorStageData {
+  return {
+    version: 1,
+    gridSize: 0.5,
+    activeObjectId: 'cam-1',
+    objects: [defaultCamera, defaultCharacter],
+  }
+}
+
+function readDirectorStageData(node: CanvasNode | null | undefined): DirectorStageData {
+  const raw = node?.data.directorStage
+  if (!raw || typeof raw !== 'object') return createDefaultDirectorStageData()
+  const data = raw as Partial<DirectorStageData>
+  const objects = Array.isArray(data.objects) ? data.objects.filter(isStageObject) : []
+  const hasCamera = objects.some((item) => item.kind === 'camera')
+  return {
+    version: 1,
+    gridSize: typeof data.gridSize === 'number' && data.gridSize > 0 ? data.gridSize : 0.5,
+    activeObjectId: data.activeObjectId ?? objects[0]?.id ?? 'cam-1',
+    objects: hasCamera ? objects : [defaultCamera, ...objects],
+    ...(typeof data.prompt === 'string' ? { prompt: data.prompt } : {}),
+  }
+}
+
+function isStageObject(value: unknown): value is StageObject {
+  if (!value || typeof value !== 'object') return false
+  const item = value as Partial<StageObject>
+  return Boolean(item.id && item.name && item.kind && item.position && item.rotation)
+}
+
+function makeId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function snap(value: number, gridSize: number): number {
+  return Math.round(value / gridSize) * gridSize
+}
+
+function buildDirectorPrompt(data: DirectorStageData): string {
+  const cameras = data.objects.filter((item) => item.kind === 'camera')
+  const objects = data.objects.filter((item) => item.kind !== 'camera')
+  return [
+    '3D 导演台编排：真实三维空间，地面 XY 中心点为 (0, 0)，Z 为高度。',
+    `摄像机：${cameras.map((camera) => `${camera.name} 位于 x=${camera.position.x.toFixed(2)}, y=${camera.position.y.toFixed(2)}, z=${camera.position.z.toFixed(2)}m，朝向 yaw=${camera.rotation.yaw}°, pitch=${camera.rotation.pitch}°`).join('；')}`,
+    `人物/物体：${objects.map((item) => `${item.name}(${item.kind}) 位于 x=${item.position.x.toFixed(2)}, y=${item.position.y.toFixed(2)}, z=${item.position.z.toFixed(2)}m，朝向 yaw=${item.rotation.yaw}°${item.pose ? `，姿势：${item.pose}` : ''}`).join('；') || '暂无'}`,
+    '请按以上三维站位、人物朝向、镜头位置与焦点关系生成画面/镜头提示词。',
+  ].join('\n')
+}
+
+export const createDefaultDirectorStageData = createDefaultDirectorStageDataInternal
+
+export function CanvasDirectorStageModal({
+  node,
+  open,
+  onClose,
+  onSave,
+}: {
+  node: CanvasNode | null
+  open: boolean
+  onClose: () => void
+  onSave: (data: DirectorStageData, prompt: string) => Promise<void>
+}) {
+  const initial = useMemo(() => readDirectorStageData(node), [node])
+  const [draft, setDraft] = useState<DirectorStageData>(initial)
+  const [drag, setDrag] = useState<{
+    id: string
+    startX: number
+    startY: number
+    start: Vec3
+  } | null>(null)
+  const active = draft.objects.find((item) => item.id === draft.activeObjectId) ?? draft.objects[0]
+  const prompt = buildDirectorPrompt(draft)
+
+  const updateActive = (patch: Partial<StageObject>) => {
+    if (!active) return
+    setDraft((current) => ({
+      ...current,
+      objects: current.objects.map((item) =>
+        item.id === active.id ? { ...item, ...patch } : item,
+      ),
+    }))
+  }
+
+  const addObject = (kind: StageObjectKind) => {
+    const object: StageObject = {
+      id: makeId(kind === 'camera' ? 'cam' : kind === 'character' ? 'char' : 'prop'),
+      kind,
+      name:
+        kind === 'camera'
+          ? `机位${draft.objects.filter((item) => item.kind === 'camera').length + 1}`
+          : kind === 'character'
+            ? `角色${draft.objects.filter((item) => item.kind === 'character').length + 1}`
+            : `道具${draft.objects.filter((item) => item.kind === 'prop').length + 1}`,
+      color: kind === 'camera' ? '#f59e0b' : kind === 'character' ? '#60a5fa' : '#f8fafc',
+      position: {
+        x: kind === 'camera' ? -2 : 1,
+        y: kind === 'camera' ? 0.45 : 0.8,
+        z: kind === 'camera' ? 2 : 0,
+      },
+      rotation: { yaw: kind === 'camera' ? 35 : 180, pitch: 0, roll: 0 },
+      ...(kind === 'character' ? { pose: '站立' } : {}),
+    }
+    setDraft((current) => ({
+      ...current,
+      activeObjectId: object.id,
+      objects: [...current.objects, object],
+    }))
+  }
+
+  const removeActive = () => {
+    if (!active) return
+    if (
+      active.kind === 'camera' &&
+      draft.objects.filter((item) => item.kind === 'camera').length <= 1
+    ) {
+      message.warning('每个导演台至少需要一个摄像机')
+      return
+    }
+    setDraft((current) => {
+      const objects = current.objects.filter((item) => item.id !== active.id)
+      return { ...current, objects, ...(objects[0]?.id ? { activeObjectId: objects[0].id } : {}) }
+    })
+  }
+
+  const beginDrag = (object: StageObject, event: ReactPointerEvent<HTMLButtonElement>) => {
+    event.currentTarget.setPointerCapture(event.pointerId)
+    setDraft((current) => ({ ...current, activeObjectId: object.id }))
+    setDrag({ id: object.id, startX: event.clientX, startY: event.clientY, start: object.position })
+  }
+
+  const handleDrag = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!drag) return
+    const dx = (event.clientX - drag.startX) / 44
+    const dz = (event.clientY - drag.startY) / 44
+    setDraft((current) => ({
+      ...current,
+      objects: current.objects.map((item) =>
+        item.id === drag.id
+          ? {
+              ...item,
+              position: {
+                ...item.position,
+                x: snap(clamp(drag.start.x + dx, -5, 5), current.gridSize),
+                z: snap(clamp(drag.start.z + dz, -5, 5), current.gridSize),
+              },
+            }
+          : item,
+      ),
+    }))
+  }
+
+  const save = async () => {
+    await onSave({ ...draft, prompt }, prompt)
+    message.success('导演台已保存')
+  }
+
+  const copyPrompt = async () => {
+    await navigator.clipboard.writeText(prompt)
+    message.success('已复制导演台提示词')
+  }
+
+  const exportShot = () => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 1280
+    canvas.height = 720
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    ctx.fillStyle = '#05070d'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.strokeStyle = '#123244'
+    for (let i = 0; i < 24; i += 1) {
+      const x = 120 + i * 44
+      ctx.beginPath()
+      ctx.moveTo(x, 160)
+      ctx.lineTo(x - 260, 650)
+      ctx.stroke()
+      const y = 190 + i * 20
+      ctx.beginPath()
+      ctx.moveTo(60, y)
+      ctx.lineTo(1220, y)
+      ctx.stroke()
+    }
+    draft.objects.forEach((item) => {
+      const x = 640 + item.position.x * 90
+      const y = 520 - item.position.z * 58 - item.position.y * 46
+      ctx.fillStyle = item.color
+      ctx.beginPath()
+      ctx.arc(x, y, item.kind === 'camera' ? 18 : 24, 0, Math.PI * 2)
+      ctx.fill()
+      ctx.fillStyle = '#fff'
+      ctx.font = '18px sans-serif'
+      ctx.fillText(item.name, x + 24, y - 12)
+    })
+    const link = document.createElement('a')
+    link.download = `${node?.title ?? 'director-stage'}.png`
+    link.href = canvas.toDataURL('image/png')
+    link.click()
+  }
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="92vw"
+      className="canvas-director-stage-modal"
+      title="3D 导演台节点"
+    >
+      <div className="canvas-director-stage-shell">
+        <aside className="canvas-director-stage-tools">
+          <Button onClick={() => addObject('character')} icon={<Icons.User size={14} />}>
+            添加人物
+          </Button>
+          <Button onClick={() => addObject('camera')} icon={<Icons.Play size={14} />}>
+            添加摄像机
+          </Button>
+          <Button onClick={() => addObject('prop')} icon={<Icons.Box size={14} />}>
+            添加道具
+          </Button>
+          <Button danger onClick={removeActive} icon={<Icons.Trash size={14} />}>
+            删除选中
+          </Button>
+          <div className="canvas-director-stage-object-list">
+            {draft.objects.map((item) => (
+              <button
+                key={item.id}
+                className={item.id === active?.id ? 'active' : ''}
+                onClick={() => setDraft((current) => ({ ...current, activeObjectId: item.id }))}
+              >
+                <span style={{ background: item.color }} />
+                {item.name}
+                <Tag>{item.kind}</Tag>
+              </button>
+            ))}
+          </div>
+        </aside>
+        <div
+          className="canvas-director-stage-viewport"
+          onPointerMove={handleDrag}
+          onPointerUp={() => setDrag(null)}
+        >
+          <div className="canvas-director-stage-world">
+            <div className="canvas-director-stage-grid" />
+            <div className="canvas-director-stage-origin">XY 中心点 (0,0)</div>
+            {draft.objects.map((item) => (
+              <button
+                key={item.id}
+                className={`canvas-director-stage-object ${item.kind} ${item.id === active?.id ? 'active' : ''}`}
+                style={{
+                  ['--x' as string]: item.position.x,
+                  ['--y' as string]: item.position.y,
+                  ['--z' as string]: item.position.z,
+                  ['--yaw' as string]: `${item.rotation.yaw}deg`,
+                  ['--color' as string]: item.color,
+                }}
+                onPointerDown={(event) => beginDrag(item, event)}
+              >
+                <span className="canvas-director-stage-label">{item.name}</span>
+                <span className="canvas-director-stage-gizmo">
+                  <i className="x" />
+                  <i className="y" />
+                  <i className="z" />
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+        <aside className="canvas-director-stage-inspector">
+          {active && (
+            <>
+              <Input value={active.name} onChange={(e) => updateActive({ name: e.target.value })} />
+              <Select
+                value={active.kind}
+                disabled
+                options={[
+                  { value: 'character', label: '人物' },
+                  { value: 'camera', label: '摄像机' },
+                  { value: 'prop', label: '道具' },
+                ]}
+              />
+              {(['x', 'y', 'z'] as const).map((axis) => (
+                <label key={axis}>
+                  {axis.toUpperCase()}
+                  <Input
+                    type="number"
+                    value={active.position[axis]}
+                    step={0.1}
+                    onChange={(e) =>
+                      updateActive({
+                        position: { ...active.position, [axis]: Number(e.target.value) },
+                      })
+                    }
+                  />
+                </label>
+              ))}
+              {(['yaw', 'pitch', 'roll'] as const).map((axis) => (
+                <label key={axis}>
+                  {axis}
+                  <Input
+                    type="number"
+                    value={active.rotation[axis]}
+                    onChange={(e) =>
+                      updateActive({
+                        rotation: { ...active.rotation, [axis]: Number(e.target.value) },
+                      })
+                    }
+                  />
+                </label>
+              ))}
+              {active.kind === 'character' && (
+                <Input.TextArea
+                  value={active.pose}
+                  onChange={(e) => updateActive({ pose: e.target.value })}
+                  placeholder="姿势/动作描述"
+                />
+              )}
+            </>
+          )}
+          <Input.TextArea value={prompt} autoSize={{ minRows: 6, maxRows: 10 }} readOnly />
+          <div className="canvas-director-stage-actions">
+            <Button onClick={copyPrompt}>输出提示词</Button>
+            <Button onClick={exportShot}>导出截图</Button>
+            <Button type="primary" onClick={save}>
+              保存
+            </Button>
+          </div>
+        </aside>
+      </div>
+    </Modal>
+  )
+}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -142,6 +142,7 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
   const locked = Boolean(node.locked)
   const isGroup = node.type === 'group'
   const isTask = isOperationNode(node)
+  const isDirectorStage = node.data.subtype === 'director_stage'
   const isGroupedChild = Boolean(node.parentNodeId)
   const hasLineage = Boolean(lineage && (lineage.incoming > 0 || lineage.outgoing > 0))
   const imageSrc = node.data.thumbnailUrl ?? node.data.url
@@ -406,7 +407,9 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             {node.type === 'image' && <Icons.Image size={14} />}
             {node.type === 'audio' && <Icons.Play size={14} />}
             {(node.type === 'text' || node.type === 'prompt') && <Icons.File size={14} />}
-            {isOperationNode(node) ? (
+            {isDirectorStage ? (
+              <Icons.Play size={14} />
+            ) : isOperationNode(node) ? (
               operationNodeIcon(nodeOperation(node))
             ) : node.type === 'task' ? (
               <Icons.Activity size={14} />
@@ -543,6 +546,16 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
               <div className="canvas-node-group-hint">
                 {node.data.message ?? '节点已在组内排列'}
               </div>
+            </div>
+          ) : isDirectorStage ? (
+            <div className="canvas-node-director-stage">
+              <div className="canvas-node-director-stage-grid" />
+              <div className="canvas-node-director-stage-camera">
+                <Icons.Play size={18} />
+                <span>机位</span>
+              </div>
+              <div className="canvas-node-director-stage-actor">角色</div>
+              <div className="canvas-node-director-stage-hint">双击打开超大 3D 导演台</div>
             </div>
           ) : isOperationNode(node) ? (
             <div className="canvas-node-task canvas-node-operation">

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
@@ -137,6 +137,7 @@ export function CanvasStage({
   onAddTextAtPosition,
   onAddImageAtPosition,
   onAddPromptAtPosition,
+  onAddDirectorStageAtPosition,
   onInsertAssetFromPane,
   onCreateBoardFromPane,
   onResetZoomFromPane,
@@ -174,6 +175,8 @@ export function CanvasStage({
   onAddImageAtPosition: (position: CanvasStagePoint) => void
   /** 空白右键：新建 Prompt 节点 */
   onAddPromptAtPosition?: (position: CanvasStagePoint) => void
+  /** 空白右键：新建 3D 导演台节点 */
+  onAddDirectorStageAtPosition?: (position: CanvasStagePoint) => void
   /** 空白右键：从资产插入（打开资产面板） */
   onInsertAssetFromPane?: () => void
   /** 空白右键：新建 board */
@@ -427,6 +430,13 @@ export function CanvasStage({
     onAddPromptAtPosition?.(position)
   }, [closePaneContextMenu, onAddPromptAtPosition, paneContextMenu])
 
+  const handleAddDirectorStageFromPane = useCallback(() => {
+    if (!paneContextMenu) return
+    const position = paneContextMenu.flowPosition
+    closePaneContextMenu()
+    onAddDirectorStageAtPosition?.(position)
+  }, [closePaneContextMenu, onAddDirectorStageAtPosition, paneContextMenu])
+
   const handleInsertAssetFromPane = useCallback(() => {
     if (!paneContextMenu) return
     closePaneContextMenu()
@@ -643,6 +653,12 @@ export function CanvasStage({
               <button type="button" role="menuitem" onClick={handleAddPromptFromPane}>
                 <Icons.Edit size={14} />
                 <span>新建 Prompt</span>
+              </button>
+            )}
+            {onAddDirectorStageAtPosition && (
+              <button type="button" role="menuitem" onClick={handleAddDirectorStageFromPane}>
+                <Icons.Play size={14} />
+                <span>新建 3D 导演台</span>
               </button>
             )}
             <div className="canvas-pane-context-divider" />

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -6969,3 +6969,286 @@ body.canvas-side-panel-resizing {
 .canvas-node-edit-bottom-panel.is-fullscreen .canvas-node-edit-prompt-main .canvas-prompt-editor {
   min-height: 0;
 }
+
+/* ─── 3D 导演台节点 / 超大弹窗 ───────────────────────────────────────── */
+.canvas-node-director-stage {
+  position: relative;
+  min-height: 150px;
+  overflow: hidden;
+  border-radius: 14px;
+  background: radial-gradient(circle at 50% 20%, rgba(37, 99, 235, 0.24), transparent 32%), #070a12;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  color: #dbeafe;
+}
+
+.canvas-node-director-stage-grid {
+  position: absolute;
+  inset: 34px -20px -26px;
+  transform: perspective(360px) rotateX(62deg);
+  transform-origin: center bottom;
+  background-image:
+    linear-gradient(rgba(56, 189, 248, 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(56, 189, 248, 0.18) 1px, transparent 1px);
+  background-size: 22px 22px;
+}
+
+.canvas-node-director-stage-camera,
+.canvas-node-director-stage-actor {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.canvas-node-director-stage-camera {
+  left: 24px;
+  bottom: 30px;
+  background: rgba(245, 158, 11, 0.22);
+  color: #fde68a;
+}
+
+.canvas-node-director-stage-actor {
+  right: 34px;
+  top: 38px;
+  background: rgba(96, 165, 250, 0.24);
+  color: #bfdbfe;
+}
+
+.canvas-node-director-stage-hint {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 10px;
+  color: rgba(219, 234, 254, 0.78);
+  font-size: 12px;
+}
+
+.canvas-director-stage-modal .ant-modal-content {
+  padding: 0;
+  overflow: hidden;
+  background: #05070d;
+}
+
+.canvas-director-stage-modal .ant-modal-header {
+  margin: 0;
+  padding: 16px 20px;
+  background: #080b13;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.canvas-director-stage-modal .ant-modal-body {
+  height: min(82vh, 920px);
+}
+
+.canvas-director-stage-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(520px, 1fr) 320px;
+  height: 100%;
+  color: #e5e7eb;
+}
+
+.canvas-director-stage-tools,
+.canvas-director-stage-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px;
+  background: rgba(15, 23, 42, 0.9);
+  border-right: 1px solid rgba(148, 163, 184, 0.14);
+  overflow: auto;
+}
+
+.canvas-director-stage-inspector {
+  border-right: 0;
+  border-left: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.canvas-director-stage-inspector label {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  align-items: center;
+  gap: 8px;
+  color: #93c5fd;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.canvas-director-stage-object-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.canvas-director-stage-object-list button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 10px;
+  color: #cbd5e1;
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.canvas-director-stage-object-list button.active {
+  border-color: rgba(96, 165, 250, 0.85);
+  background: rgba(37, 99, 235, 0.22);
+}
+
+.canvas-director-stage-object-list button > span:first-child {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.canvas-director-stage-viewport {
+  position: relative;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 0%, rgba(15, 23, 42, 0.9), #02040a 55%);
+  cursor: grab;
+}
+
+.canvas-director-stage-world {
+  position: absolute;
+  inset: 4% 3% 2%;
+  transform-style: preserve-3d;
+  perspective: 980px;
+}
+
+.canvas-director-stage-grid {
+  position: absolute;
+  left: 50%;
+  top: 55%;
+  width: 920px;
+  height: 920px;
+  transform: translate(-50%, -50%) rotateX(68deg);
+  transform-style: preserve-3d;
+  background-color: rgba(15, 23, 42, 0.82);
+  background-image:
+    linear-gradient(rgba(14, 165, 233, 0.22) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(14, 165, 233, 0.22) 1px, transparent 1px),
+    linear-gradient(rgba(248, 113, 113, 0.18) 2px, transparent 2px),
+    linear-gradient(90deg, rgba(34, 197, 94, 0.18) 2px, transparent 2px);
+  background-size:
+    46px 46px,
+    46px 46px,
+    460px 460px,
+    460px 460px;
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  box-shadow: 0 34px 120px rgba(0, 0, 0, 0.5) inset;
+}
+
+.canvas-director-stage-origin {
+  position: absolute;
+  left: 50%;
+  top: 55%;
+  transform: translate(-50%, -50%);
+  color: rgba(191, 219, 254, 0.78);
+  font-size: 12px;
+  pointer-events: none;
+}
+
+.canvas-director-stage-object {
+  --unit: 74px;
+  position: absolute;
+  left: calc(50% + var(--x) * var(--unit));
+  top: calc(55% + var(--z) * var(--unit) - var(--y) * 30px);
+  width: 54px;
+  height: 72px;
+  border: 0;
+  background: transparent;
+  transform: translate(-50%, -100%) rotateY(var(--yaw));
+  transform-style: preserve-3d;
+  cursor: grab;
+}
+
+.canvas-director-stage-object::before {
+  content: '';
+  position: absolute;
+  inset: 16px 12px 0;
+  border-radius: 999px 999px 12px 12px;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color), #fff 24%), var(--color));
+  box-shadow: 0 0 22px color-mix(in srgb, var(--color), transparent 58%);
+}
+
+.canvas-director-stage-object.camera::before {
+  inset: 30px 7px 12px;
+  border-radius: 8px;
+  background: var(--color);
+}
+
+.canvas-director-stage-object.prop::before {
+  inset: 30px 6px 0;
+  border-radius: 4px;
+}
+
+.canvas-director-stage-object.active::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  bottom: -12px;
+  width: 72px;
+  height: 72px;
+  border: 2px solid rgba(96, 165, 250, 0.72);
+  border-radius: 999px;
+  transform: translateX(-50%) rotateX(70deg);
+}
+
+.canvas-director-stage-label {
+  position: absolute;
+  left: 50%;
+  top: -18px;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 800;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.65);
+}
+
+.canvas-director-stage-gizmo {
+  display: none;
+  position: absolute;
+  left: 50%;
+  bottom: 4px;
+  width: 1px;
+  height: 1px;
+}
+
+.canvas-director-stage-object.active .canvas-director-stage-gizmo {
+  display: block;
+}
+
+.canvas-director-stage-gizmo i {
+  position: absolute;
+  width: 62px;
+  height: 3px;
+  border-radius: 999px;
+  transform-origin: left center;
+}
+
+.canvas-director-stage-gizmo .x {
+  background: #ef4444;
+  transform: rotate(0deg);
+}
+.canvas-director-stage-gizmo .y {
+  background: #22c55e;
+  transform: rotate(-90deg);
+}
+.canvas-director-stage-gizmo .z {
+  background: #3b82f6;
+  transform: rotate(42deg);
+}
+
+.canvas-director-stage-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -24,6 +24,11 @@ import {
   type CanvasShotDirectorDraft,
   type CanvasShotDirectorScreenshotInput,
 } from './CanvasShotDirectorPanel'
+import {
+  CanvasDirectorStageModal,
+  createDefaultDirectorStageData,
+  type DirectorStageData,
+} from './CanvasDirectorStageModal'
 import { isOperationNode } from './canvas.capabilities'
 import {
   readAssetKind,
@@ -986,6 +991,7 @@ export function CanvasWorkspaceView({
     'production' | 'boards' | 'assets' | 'details' | 'project'
   >('details')
   const [editingNodeId, setEditingNodeId] = useState<string | null>(null)
+  const [directorStageNodeId, setDirectorStageNodeId] = useState<string | null>(null)
   const [activeOperationPanelNodeId, setActiveOperationPanelNodeId] = useState<string | null>(null)
   const [assetDetailResetKey, setAssetDetailResetKey] = useState(0)
   const canvasViewportRef = useRef<CanvasStageViewport | null>(null)
@@ -1412,6 +1418,12 @@ export function CanvasWorkspaceView({
         setActiveOperationPanelNodeId(nodeId)
         return
       }
+      if (node?.data.subtype === 'director_stage') {
+        closeCanvasFloatPanels('node-edit')
+        setSelectedNodeIds([nodeId])
+        setDirectorStageNodeId(nodeId)
+        return
+      }
       closeCanvasFloatPanels('node-edit')
       setSelectedNodeIds([nodeId])
       setEditingNodeId(nodeId)
@@ -1446,6 +1458,35 @@ export function CanvasWorkspaceView({
       })
     },
     [createTextNode],
+  )
+
+  const addDirectorStage = useCallback(
+    async (preferredPosition?: CanvasPoint) => {
+      const position = preferredPosition
+        ? { x: Math.round(preferredPosition.x), y: Math.round(preferredPosition.y) }
+        : positionNodeInViewport(
+            canvasViewportRef.current,
+            { width: 360, height: 240 },
+            { x: 160, y: 140 },
+          )
+      const node = await createTextNode({
+        text: '3D 导演台：双击打开三维编排空间。',
+        x: position.x,
+        y: position.y,
+      })
+      if (!node) return
+      await patchNodes([node.id], { title: '3D 导演台', width: 360, height: 240 })
+      await updateNodeData(node.id, {
+        ...node.data,
+        subtype: 'director_stage',
+        displayCategory: 'content',
+        directorStage: createDefaultDirectorStageData() as unknown as Record<string, unknown>,
+        text: '3D 导演台：双击打开三维编排空间。',
+      })
+      setSelectedNodeIds([node.id])
+      setDirectorStageNodeId(node.id)
+    },
+    [createTextNode, patchNodes, updateNodeData],
   )
 
   const uploadFirstImage = useCallback((preferredPosition?: CanvasPoint) => {
@@ -1686,6 +1727,24 @@ export function CanvasWorkspaceView({
       }
     },
     [addText, closeCanvasFloatPanels, uploadFirstImage, setSidePanelTab],
+  )
+
+  const directorStageNode = useMemo(
+    () => snapshot?.nodes.find((item) => item.id === directorStageNodeId) ?? null,
+    [directorStageNodeId, snapshot?.nodes],
+  )
+
+  const handleSaveDirectorStage = useCallback(
+    async (data: DirectorStageData, prompt: string) => {
+      if (!directorStageNode) return
+      await updateNodeData(directorStageNode.id, {
+        ...directorStageNode.data,
+        subtype: 'director_stage',
+        directorStage: data as unknown as Record<string, unknown>,
+        text: prompt,
+      })
+    },
+    [directorStageNode, updateNodeData],
   )
 
   const handleToggleGrid = useCallback(() => {
@@ -3126,6 +3185,7 @@ export function CanvasWorkspaceView({
             onAddTextAtPosition={(position) => void addText(position)}
             onAddImageAtPosition={uploadFirstImage}
             onAddPromptAtPosition={(position) => void addText(position)}
+            onAddDirectorStageAtPosition={(position) => void addDirectorStage(position)}
             onInsertAssetFromPane={() => setSidePanelTab('assets')}
             onCreateBoardFromPane={() => void createBoard()}
             onNodeSelectIntent={handleNodeSelectIntent}
@@ -3328,6 +3388,13 @@ export function CanvasWorkspaceView({
             onClose={() => setEditingNodeId(null)}
             onSave={handleSaveNodeEdit}
             onCreatePromptTask={(input) => void handleCreateTask({ ...input, inputNodeIds: [] })}
+          />
+          <CanvasDirectorStageModal
+            key={directorStageNode?.id}
+            node={directorStageNode}
+            open={Boolean(directorStageNode)}
+            onClose={() => setDirectorStageNodeId(null)}
+            onSave={handleSaveDirectorStage}
           />
           <CanvasFilmAssetCenter
             open={filmCenterOpen}

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
@@ -170,6 +170,8 @@ export type CanvasNodeData = {
   shotSegmentId?: string
   /** 专用流水线任务节点上暂存的「产物节点角色」，供任务完成回写产物节点时读取 */
   outputPipelineRole?: CanvasPipelineRole
+  /** 3D 导演台节点数据：三维对象、摄像机、网格与导出提示词。 */
+  directorStage?: Record<string, unknown>
 }
 
 export type CanvasNode = {


### PR DESCRIPTION
### Motivation
- 现有的分镜/导演台为伪 3D 表现，无法满足真实三维站位、机位与人物编排的交互需求。 
- 需要把导演台抽象为画布内的独立节点，支持右键创建、双击打开超大编辑器，并能在节点元数据中持久化三维场景与提示词。 

### Description
- 新增 `CanvasDirectorStageModal.tsx`，实现超大弹窗的 3D 编排区（左侧工具、中心 3D 世界、右侧 inspector），支持添加/删除摄像机/人物/道具、网格吸附、拖拽调整位置(depth/XY)、旋转（yaw/pitch/roll）、角色姿势编辑、复制提示词与导出 PNG 截图。 
- 在 `canvas.types.ts` 中扩展 `CanvasNodeData`，新增 `directorStage` 字段用于持久化导演台数据及提示词。 
- 在 `CanvasStage.tsx` 中将画布空白右键菜单扩展为支持“新建 3D 导演台”（`onAddDirectorStageAtPosition`），并新增上下文 handler。 
- 在 `CanvasWorkspaceView.tsx` 中添加创建导演台节点的逻辑（将创建为一个带 `subtype: 'director_stage'` 的文本节点、初始化 `directorStage` 元数据），并在双击/编辑分流中支持打开 `CanvasDirectorStageModal` 并保存回节点数据。 
- 在 `CanvasNode.tsx` 中为 `subtype === 'director_stage'` 增加专用卡片预览样式与提示（双击进入超大编辑器）。 
- 新增/修改样式 `CanvasWorkspaceView.less`，提供 3D 网格、透视效果与弹窗布局样式。 

### Testing
- 已运行类型检查：`pnpm --filter @spark/desktop typecheck`，通过。 
- 已运行格式化：`pnpm exec prettier --write ...`（针对新增/修改文件），成功。 
- 已对改动文件单独运行 ESLint：`pnpm --filter @spark/desktop exec eslint src/renderer/design/views/canvas/CanvasDirectorStageModal.tsx src/renderer/design/views/canvas/CanvasStage.tsx src/renderer/design/views/canvas/CanvasNode.tsx`，退出码为 0（仅存在仓库既有的 warnings）。 
- 已执行 `git diff --check`（无新增 whitespace 错误）；尝试使用 GitNexus 的 `detect_changes` 未成功，环境中缺少 MCP runner（`.gitnexus/run.cjs` 不存在），`npx gitnexus detect_changes` 以退出码 1 结束且无可用输出，故无法生成自动化变更影响报告；仓库级 lint (`pnpm --filter @spark/desktop lint`) 在本环境仍会因仓库中原有的其他文件问题失败，但本次改动的局部检查无阻碍。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381c0eaa6483238c613c9840e6d394)