### PR TITLE
feat(desktop): add in-session side chat panel

### DIFF
--- a/apps/desktop/src/renderer/design/SessionSidebarContext.tsx
+++ b/apps/desktop/src/renderer/design/SessionSidebarContext.tsx
@@ -519,9 +519,12 @@ export function SessionSidebarProvider({ children }: { children: ReactNode }) {
         }
 
         // 如果该项目下有未使用的会话（没有消息、未归档），直接复用
-        const unusedSession = sessions.find(
-          (s) => s.workspaceIds.includes(wsId!) && s.messageCount === 0 && s.archivedAt == null,
-        )
+        const shouldReuseUnusedSession = options.forceNew !== true
+        const unusedSession = shouldReuseUnusedSession
+          ? sessions.find(
+              (s) => s.workspaceIds.includes(wsId!) && s.messageCount === 0 && s.archivedAt == null,
+            )
+          : undefined
         if (unusedSession) {
           if (options.activate !== false) setActive(unusedSession.id)
           setActiveWorkspaceId(uiWorkspaceId)

--- a/apps/desktop/src/renderer/design/views/ChatView.less
+++ b/apps/desktop/src/renderer/design/views/ChatView.less
@@ -1299,11 +1299,129 @@
   background: color-mix(in srgb, var(--color-fill-secondary, #f8fafc) 80%, transparent);
   font-size: 12px;
 }
-.goal-control-bar .goal-dot { width: 8px; height: 8px; border-radius: 999px; background: #22c55e; flex: 0 0 auto; }
-.goal-control-bar.goal-paused .goal-dot { background: #f59e0b; }
+.goal-control-bar .goal-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #22c55e;
+  flex: 0 0 auto;
+}
+.goal-control-bar.goal-paused .goal-dot {
+  background: #f59e0b;
+}
 .goal-control-bar.goal-stopped_by_budget .goal-dot,
-.goal-control-bar.goal-failed .goal-dot { background: #ef4444; }
-.goal-control-bar .goal-title { max-width: 240px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
-.goal-control-bar .goal-status { color: var(--text-tertiary, #64748b); }
-.goal-control-bar .goal-latest { max-width: 240px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-secondary, #475569); }
-.goal-control-bar .danger { color: #ef4444; }
+.goal-control-bar.goal-failed .goal-dot {
+  background: #ef4444;
+}
+.goal-control-bar .goal-title {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 600;
+}
+.goal-control-bar .goal-status {
+  color: var(--text-tertiary, #64748b);
+}
+.goal-control-bar .goal-latest {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary, #475569);
+}
+.goal-control-bar .danger {
+  color: #ef4444;
+}
+
+/* Codex-like side chat dock: a lightweight in-session companion panel. */
+.side-chat-panel {
+  width: min(42vw, 520px);
+  min-width: 360px;
+  height: 100vh;
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background: color-mix(in srgb, var(--panel) 94%, var(--bg));
+  overflow: hidden;
+}
+
+.platform-win32 .side-chat-panel {
+  height: calc(100vh - 32px);
+}
+
+.side-chat-panel-header {
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px 0 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.side-chat-panel-title {
+  font-size: var(--font-sm);
+  font-weight: 650;
+  color: var(--text);
+}
+
+.side-chat-panel-subtitle {
+  margin-top: 2px;
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
+.side-chat-panel-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 28px;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.side-chat-panel-body > svg {
+  color: var(--primary);
+}
+
+.side-chat-panel-body h3 {
+  margin: 0;
+  font-size: 18px;
+  color: var(--text);
+}
+
+.side-chat-panel-body p {
+  max-width: 360px;
+  margin: 0;
+  line-height: 1.7;
+}
+
+.side-chat-panel-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.side-chat-panel-meta span {
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  font-size: var(--font-xs);
+  color: var(--text-muted);
+}
+
+.side-chat-panel-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -349,6 +349,10 @@ export function ChatView({
   // 内置终端面板：会话级 dock，按钮在 ChatTabbar 右上。
   // 仅在有活跃会话且绑定 workspace 时启用；切会话会保留各自的 terminals（后端负责）。
   const [showTerminalPanel, setShowTerminalPanel] = useState(false)
+  // Codex-like side chat: a second in-project session docked beside the current chat.
+  const [showSideChatPanel, setShowSideChatPanel] = useState(false)
+  const [sideChatSessionId, setSideChatSessionId] = useState<SessionId | null>(null)
+  const [sideChatCreating, setSideChatCreating] = useState(false)
   // 代码还原点时间线抽屉：把「按会话撤回代码」做成集中可还原视图，按钮在 ChatTabbar 右上。
   const [showCheckpointTimeline, setShowCheckpointTimeline] = useState(false)
   // Team Mode 配置。
@@ -668,12 +672,9 @@ export function ChatView({
       .catch(console.error)
   }, [active, clearEvents, sessionCtx])
 
-  const handleFilePreview = useCallback(
-    (filePath: string, fileType: PreviewFileType) => {
-      setFilePreview({ filePath, fileType })
-    },
-    [],
-  )
+  const handleFilePreview = useCallback((filePath: string, fileType: PreviewFileType) => {
+    setFilePreview({ filePath, fileType })
+  }, [])
 
   const pickProjectFolder = useCallback(async () => {
     try {
@@ -928,6 +929,56 @@ export function ChatView({
     ],
   )
   const composerIsWorking = isComposerSessionWorking(activeSession?.status)
+  const sideChatSession = useMemo(
+    () => sessions.find((session) => session.id === sideChatSessionId) ?? null,
+    [sessions, sideChatSessionId],
+  )
+  const sideChatWorkspace = useMemo(() => {
+    const workspaceId =
+      sideChatSession?.workspaceIds[0] ?? activeSessionWorkspace?.id ?? activeWorkspace?.id
+    if (workspaceId == null) return activeSessionWorkspace ?? activeWorkspace
+    return (
+      workspaces.find((workspace) => workspace.id === workspaceId) ??
+      activeSessionWorkspace ??
+      activeWorkspace
+    )
+  }, [activeSessionWorkspace, activeWorkspace, sideChatSession?.workspaceIds, workspaces])
+  const openSideChatPanel = useCallback(async () => {
+    setShowSideChatPanel(true)
+    if (sideChatSessionId != null) return
+    setSideChatCreating(true)
+    try {
+      const workspaceId = activeSessionWorkspace?.id ?? activeWorkspace?.id ?? activeWorkspaceId
+      const createdId = await sessionCtx.handleNewSession(workspaceId, {
+        activate: false,
+        forceNew: true,
+        skipRefresh: false,
+        ...(activeSession != null
+          ? {
+              providerProfileId: activeSession.providerProfileId,
+              ...(activeSession.modelId != null ? { modelId: activeSession.modelId } : {}),
+              agentId: activeSession.agentId,
+              agentAdapter: activeSession.agentAdapter,
+              permissionMode: activeSession.permissionMode,
+              chatMode: activeSession.chatMode,
+              reasoningEffort: activeSession.reasoningEffort,
+              ...(teamConfig.enabled ? { teamConfig } : {}),
+            }
+          : {}),
+      })
+      if (createdId != null) setSideChatSessionId(createdId)
+    } finally {
+      setSideChatCreating(false)
+    }
+  }, [
+    activeSession,
+    activeSessionWorkspace?.id,
+    activeWorkspace?.id,
+    activeWorkspaceId,
+    sessionCtx,
+    sideChatSessionId,
+    teamConfig,
+  ])
   const openSkillStore = useCallback(
     (tab: 'installed' | 'create') => {
       if (typeof window !== 'undefined') {
@@ -1077,6 +1128,18 @@ export function ChatView({
                 <Icons.Terminal size={14} />
               </button>
               <button
+                className={`icon-btn ${showSideChatPanel ? 'active' : ''}`}
+                title={activeWorkspace ? '侧边聊天' : '请先选择项目文件夹'}
+                aria-label="侧边聊天"
+                disabled={!activeWorkspace}
+                onClick={() => {
+                  if (showSideChatPanel) setShowSideChatPanel(false)
+                  else void openSideChatPanel()
+                }}
+              >
+                <Icons.Chat size={14} />
+              </button>
+              <button
                 className={`icon-btn ${showInspector ? 'active' : ''}`}
                 title="会话检查器"
                 aria-label="会话检查器"
@@ -1118,7 +1181,9 @@ export function ChatView({
           showEmptyHero && (
             <>
               <h1 className="chat-hero-title chat-hero-greeting">{getHeroGreeting()}</h1>
-              <span className="chat-hero-span">您还可以让我创建Agent、安装Skill、检查工作环境！</span>
+              <span className="chat-hero-span">
+                您还可以让我创建Agent、安装Skill、检查工作环境！
+              </span>
             </>
           )
         )}
@@ -1143,6 +1208,11 @@ export function ChatView({
                 }}
                 showTerminalPanel={showTerminalPanel}
                 setShowTerminalPanel={setShowTerminalPanel}
+                showSideChatPanel={showSideChatPanel}
+                onToggleSideChat={() => {
+                  if (showSideChatPanel) setShowSideChatPanel(false)
+                  else void openSideChatPanel()
+                }}
                 showCheckpointTimeline={showCheckpointTimeline}
                 setShowCheckpointTimeline={setShowCheckpointTimeline}
                 teamConfig={teamConfig}
@@ -1223,6 +1293,24 @@ export function ChatView({
         />
       )}
 
+      {showSideChatPanel && (active != null || activeWorkspace != null) && (
+        <SideChatPanel
+          session={sideChatSession}
+          workspaceName={sideChatWorkspace?.name ?? activeWorkspace?.name ?? '当前项目'}
+          creating={sideChatCreating}
+          onClose={() => setShowSideChatPanel(false)}
+          onOpen={() => {
+            if (sideChatSessionId == null) return
+            sessionCtx.setActiveSession(sideChatSessionId)
+            if (sideChatWorkspace?.id != null) sessionCtx.setActiveWorkspace(sideChatWorkspace.id)
+          }}
+          onNew={() => {
+            setSideChatSessionId(null)
+            void openSideChatPanel()
+          }}
+        />
+      )}
+
       {showTerminalPanel &&
         (active != null || activeWorkspace != null) &&
         (() => {
@@ -1259,9 +1347,7 @@ export function ChatView({
         open={showCheckpointTimeline}
         onClose={() => setShowCheckpointTimeline(false)}
         onRestore={(checkpointId) =>
-          active != null
-            ? executeCheckpointRestore(active, checkpointId)
-            : Promise.resolve()
+          active != null ? executeCheckpointRestore(active, checkpointId) : Promise.resolve()
         }
       />
     </div>
@@ -1508,6 +1594,59 @@ function TeamModeEmptyHero({
   )
 }
 
+function SideChatPanel({
+  session,
+  workspaceName,
+  creating,
+  onClose,
+  onOpen,
+  onNew,
+}: {
+  session: SessionSummary | null
+  workspaceName: string
+  creating: boolean
+  onClose: () => void
+  onOpen: () => void
+  onNew: () => void
+}) {
+  return (
+    <aside className="side-chat-panel" aria-label="侧边聊天">
+      <div className="side-chat-panel-header">
+        <div>
+          <div className="side-chat-panel-title">侧边聊天</div>
+          <div className="side-chat-panel-subtitle">同项目 · {workspaceName}</div>
+        </div>
+        <button className="icon-btn" aria-label="关闭侧边聊天" title="关闭" onClick={onClose}>
+          <Icons.X size={14} />
+        </button>
+      </div>
+      <div className="side-chat-panel-body">
+        <Icons.Chat size={28} />
+        <h3>{creating ? '正在创建侧边会话…' : session?.title || '新的侧边会话'}</h3>
+        <p>
+          侧边会话会自动继承当前项目、模型、Agent、权限、推理强度与团队配置，适合并行探索、让另一个
+          Agent 做验证，或保留主线上下文不被打断。
+        </p>
+        {session != null && (
+          <div className="side-chat-panel-meta">
+            <span>{session.agentAdapter}</span>
+            <span>{session.modelId ?? '默认模型'}</span>
+            <span>{session.reasoningEffort}</span>
+          </div>
+        )}
+      </div>
+      <div className="side-chat-panel-actions">
+        <button className="btn ghost sm" onClick={onNew} disabled={creating}>
+          新建侧边会话
+        </button>
+        <button className="btn sm" onClick={onOpen} disabled={creating || session == null}>
+          打开并继续
+        </button>
+      </div>
+    </aside>
+  )
+}
+
 function ChatTabbar({
   session,
   workspace,
@@ -1518,6 +1657,8 @@ function ChatTabbar({
   setShowConfigPanel,
   showTerminalPanel,
   setShowTerminalPanel,
+  showSideChatPanel,
+  onToggleSideChat,
   showCheckpointTimeline,
   setShowCheckpointTimeline,
   teamConfig,
@@ -1534,6 +1675,8 @@ function ChatTabbar({
   setShowConfigPanel: (v: boolean) => void
   showTerminalPanel: boolean
   setShowTerminalPanel: (v: boolean) => void
+  showSideChatPanel: boolean
+  onToggleSideChat: () => void
   showCheckpointTimeline: boolean
   setShowCheckpointTimeline: (v: boolean) => void
   teamConfig: TeamModeConfig
@@ -1629,6 +1772,14 @@ function ChatTabbar({
               onClick={() => setShowTerminalPanel(!showTerminalPanel)}
             >
               <Icons.Terminal size={14} />
+            </button>
+            <button
+              className={`icon-btn ${showSideChatPanel ? 'active' : ''}`}
+              title="侧边聊天"
+              aria-label="侧边聊天"
+              onClick={onToggleSideChat}
+            >
+              <Icons.Chat size={14} />
             </button>
           </>
         )}
@@ -8917,7 +9068,9 @@ function AgentPicker({
   // 会话已有内容时锁定团队：弹窗只读展示「当前团队 + 成员（主持人置顶）」，
   // 不再提供切换团队、切换主持人、退出团队模式等操作。
   const lockedTeam = locked === true && teamMode
-  const hostAgent = teamMode ? (agents.find((a) => a.id === teamConfig.hostAgentId) ?? selected) : selected
+  const hostAgent = teamMode
+    ? (agents.find((a) => a.id === teamConfig.hostAgentId) ?? selected)
+    : selected
   const rosterMembers = (() => {
     if (!teamMode) return []
     const memberSet = new Set(teamConfig.memberAgentIds)
@@ -9077,132 +9230,136 @@ function AgentPicker({
             </div>
           ) : (
             <>
-          {teamMode ? (
-            <button
-              type="button"
-              className="composer-menu-item team-mode-entry team-mode-exit"
-              onClick={() => {
-                setOpen(false)
-                onDisableTeamMode()
-              }}
-            >
-              <span className="composer-menu-item-copy">
-                <span className="composer-menu-item-label">
-                  <Icons.X size={14} />
-                  <span>退出团队模式</span>
-                </span>
-              </span>
-            </button>
-          ) : (
-            <button
-              type="button"
-              className="composer-menu-item team-mode-entry"
-              onClick={() => {
-                setOpen(false)
-                onEnableTeamMode()
-              }}
-            >
-              <span className="composer-menu-item-copy">
-                <span className="composer-menu-item-label">
-                  <Icons.Team size={13} />
-                  <span>团队模式（多 Agent 协作）</span>
-                </span>
-                <span className="composer-menu-item-desc">让当前对话 Agent 调用其他成员协作</span>
-              </span>
-            </button>
-          )}
-          {teams.length > 0 && (
-            <>
-              <div className="composer-menu-group-title">已保存团队</div>
-              {teams.map((team) => {
-                const host = agents.find((a) => a.id === team.hostAgentId)
-                const active = teamMode && teamConfig.teamId === team.id
-                const teamHasAvatar = hasCustomAvatar(team.metadata)
+              {teamMode ? (
+                <button
+                  type="button"
+                  className="composer-menu-item team-mode-entry team-mode-exit"
+                  onClick={() => {
+                    setOpen(false)
+                    onDisableTeamMode()
+                  }}
+                >
+                  <span className="composer-menu-item-copy">
+                    <span className="composer-menu-item-label">
+                      <Icons.X size={14} />
+                      <span>退出团队模式</span>
+                    </span>
+                  </span>
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="composer-menu-item team-mode-entry"
+                  onClick={() => {
+                    setOpen(false)
+                    onEnableTeamMode()
+                  }}
+                >
+                  <span className="composer-menu-item-copy">
+                    <span className="composer-menu-item-label">
+                      <Icons.Team size={13} />
+                      <span>团队模式（多 Agent 协作）</span>
+                    </span>
+                    <span className="composer-menu-item-desc">
+                      让当前对话 Agent 调用其他成员协作
+                    </span>
+                  </span>
+                </button>
+              )}
+              {teams.length > 0 && (
+                <>
+                  <div className="composer-menu-group-title">已保存团队</div>
+                  {teams.map((team) => {
+                    const host = agents.find((a) => a.id === team.hostAgentId)
+                    const active = teamMode && teamConfig.teamId === team.id
+                    const teamHasAvatar = hasCustomAvatar(team.metadata)
+                    return (
+                      <button
+                        key={team.id}
+                        type="button"
+                        className={`composer-menu-item ${active ? 'active' : ''}`}
+                        onClick={() => {
+                          setOpen(false)
+                          onApplyTeam(team)
+                        }}
+                      >
+                        <span className="composer-menu-item-copy">
+                          <span className="composer-menu-item-label">
+                            {teamHasAvatar ? (
+                              <AvatarImage
+                                className="composer-menu-avatar"
+                                src={resolveAvatarSrc(
+                                  getAgentAvatarConfig(team.metadata, team.id, team.name),
+                                )}
+                                seed={team.id}
+                                name={team.name}
+                                alt={`${team.name} 头像`}
+                              />
+                            ) : (
+                              <Icons.Team size={13} />
+                            )}
+                            <span>{team.name}</span>
+                            {team.builtIn && <span className="composer-menu-item-tag">内置</span>}
+                          </span>
+                          <span className="composer-menu-item-desc">
+                            {host ? `主持：${host.name}` : ''}
+                            {host && team.memberAgentIds.length > 0 ? ' · ' : ''}
+                            {team.memberAgentIds.length > 0
+                              ? `${team.memberAgentIds.length} 成员`
+                              : ''}
+                          </span>
+                        </span>
+                        {active && <Icons.Check size={14} className="composer-menu-check" />}
+                      </button>
+                    )
+                  })}
+                </>
+              )}
+              <div className="composer-menu-divider" />
+              <div className="composer-menu-group-title">
+                {teamMode ? '主持人 Agent' : '选择 Agent'}
+              </div>
+              {agents.map((agent) => {
+                const agentHasAvatar = hasCustomAvatar(agent.metadata)
                 return (
                   <button
-                    key={team.id}
+                    key={agent.id}
                     type="button"
-                    className={`composer-menu-item ${active ? 'active' : ''}`}
+                    className={`composer-menu-item ${agent.id === selected?.id ? 'active' : ''}`}
                     onClick={() => {
                       setOpen(false)
-                      onApplyTeam(team)
+                      if (teamMode) onChangeHost(agent.id)
+                      else void onChange(agent.id)
                     }}
                   >
                     <span className="composer-menu-item-copy">
                       <span className="composer-menu-item-label">
-                        {teamHasAvatar ? (
+                        {agentHasAvatar ? (
                           <AvatarImage
                             className="composer-menu-avatar"
                             src={resolveAvatarSrc(
-                              getAgentAvatarConfig(team.metadata, team.id, team.name),
+                              getAgentAvatarConfig(agent.metadata, agent.id, agent.name),
                             )}
-                            seed={team.id}
-                            name={team.name}
-                            alt={`${team.name} 头像`}
+                            seed={agent.id}
+                            name={agent.name}
+                            alt={`${agent.name} 头像`}
                           />
+                        ) : agent.builtIn ? (
+                          <Icons.Code size={13} />
                         ) : (
-                          <Icons.Team size={13} />
+                          <Icons.Bot size={13} />
                         )}
-                        <span>{team.name}</span>
-                        {team.builtIn && <span className="composer-menu-item-tag">内置</span>}
+                        <span>{agent.name}</span>
                       </span>
-                      <span className="composer-menu-item-desc">
-                        {host ? `主持：${host.name}` : ''}
-                        {host && team.memberAgentIds.length > 0 ? ' · ' : ''}
-                        {team.memberAgentIds.length > 0 ? `${team.memberAgentIds.length} 成员` : ''}
-                      </span>
+                      <span className="composer-menu-item-desc">{agent.description || '-'}</span>
                     </span>
-                    {active && <Icons.Check size={14} className="composer-menu-check" />}
+                    {agent.workflowId && <Icons.Workflow size={13} />}
+                    {agent.id === selected?.id && (
+                      <Icons.Check size={14} className="composer-menu-check" />
+                    )}
                   </button>
                 )
               })}
-            </>
-          )}
-          <div className="composer-menu-divider" />
-          <div className="composer-menu-group-title">
-            {teamMode ? '主持人 Agent' : '选择 Agent'}
-          </div>
-          {agents.map((agent) => {
-            const agentHasAvatar = hasCustomAvatar(agent.metadata)
-            return (
-              <button
-                key={agent.id}
-                type="button"
-                className={`composer-menu-item ${agent.id === selected?.id ? 'active' : ''}`}
-                onClick={() => {
-                  setOpen(false)
-                  if (teamMode) onChangeHost(agent.id)
-                  else void onChange(agent.id)
-                }}
-              >
-                <span className="composer-menu-item-copy">
-                  <span className="composer-menu-item-label">
-                    {agentHasAvatar ? (
-                      <AvatarImage
-                        className="composer-menu-avatar"
-                        src={resolveAvatarSrc(
-                          getAgentAvatarConfig(agent.metadata, agent.id, agent.name),
-                        )}
-                        seed={agent.id}
-                        name={agent.name}
-                        alt={`${agent.name} 头像`}
-                      />
-                    ) : agent.builtIn ? (
-                      <Icons.Code size={13} />
-                    ) : (
-                      <Icons.Bot size={13} />
-                    )}
-                    <span>{agent.name}</span>
-                  </span>
-                  <span className="composer-menu-item-desc">{agent.description || '-'}</span>
-                </span>
-                {agent.workflowId && <Icons.Workflow size={13} />}
-                {agent.id === selected?.id && (
-                  <Icons.Check size={14} className="composer-menu-check" />
-                )}
-              </button>
-            )
-          })}
             </>
           )}
         </div>
@@ -9913,8 +10070,13 @@ function formatTokenCount(value: number): string {
   return `${value}`
 }
 
-
-function GoalControlBar({ sessionId, disabled }: { sessionId: SessionId | null; disabled: boolean }) {
+function GoalControlBar({
+  sessionId,
+  disabled,
+}: {
+  sessionId: SessionId | null
+  disabled: boolean
+}) {
   const { toast } = useToast()
   const [goal, setGoal] = useState<SessionGoal | null>(null)
   const [busy, setBusy] = useState(false)
@@ -9924,13 +10086,17 @@ function GoalControlBar({ sessionId, disabled }: { sessionId: SessionId | null; 
       return
     }
     try {
-      const res = await window.spark.invoke('session:get-goal', { sessionId }) as { goal: SessionGoal | null }
+      const res = (await window.spark.invoke('session:get-goal', { sessionId })) as {
+        goal: SessionGoal | null
+      }
       setGoal(res.goal)
     } catch {
       setGoal(null)
     }
   }, [sessionId])
-  useEffect(() => { void refresh() }, [refresh])
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
 
   const start = async () => {
     if (sessionId == null || busy) return
@@ -9938,12 +10104,12 @@ function GoalControlBar({ sessionId, disabled }: { sessionId: SessionId | null; 
     if (!objective) return
     setBusy(true)
     try {
-      const res = await window.spark.invoke('session:set-goal', {
+      const res = (await window.spark.invoke('session:set-goal', {
         sessionId,
         objective,
         budget: { maxIterations: 12, maxConsecutiveFailures: 3, noProgressLimit: 3 },
         mode: 'auto',
-      }) as { goal: SessionGoal | null }
+      })) as { goal: SessionGoal | null }
       setGoal(res.goal)
       toast.success('Goal 已创建并开始执行。')
     } catch (err) {
@@ -9957,7 +10123,9 @@ function GoalControlBar({ sessionId, disabled }: { sessionId: SessionId | null; 
     if (sessionId == null || busy) return
     setBusy(true)
     try {
-      const res = await window.spark.invoke('session:goal-control', { sessionId, action }) as { goal: SessionGoal | null }
+      const res = (await window.spark.invoke('session:goal-control', { sessionId, action })) as {
+        goal: SessionGoal | null
+      }
       setGoal(res.goal)
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Goal 操作失败')
@@ -9968,22 +10136,52 @@ function GoalControlBar({ sessionId, disabled }: { sessionId: SessionId | null; 
 
   if (sessionId == null) return null
   if (goal == null) {
-    return <button className="btn sm" disabled={disabled || busy} onClick={start}>Goal</button>
+    return (
+      <button className="btn sm" disabled={disabled || busy} onClick={start}>
+        Goal
+      </button>
+    )
   }
   const latest = goal.progressLog.at(-1)
   return (
     <div className={`goal-control-bar goal-${goal.status}`} title={goal.objective}>
       <span className="goal-dot" />
       <span className="goal-title">{goal.objective}</span>
-      <span className="goal-status">{goal.status} · #{goal.progressLog.length}</span>
+      <span className="goal-status">
+        {goal.status} · #{goal.progressLog.length}
+      </span>
       {latest && <span className="goal-latest">{latest.summary}</span>}
       {goal.status === 'active' ? (
-        <button className="btn ghost sm" disabled={disabled || busy} onClick={() => void control('pause')}>暂停</button>
+        <button
+          className="btn ghost sm"
+          disabled={disabled || busy}
+          onClick={() => void control('pause')}
+        >
+          暂停
+        </button>
       ) : (
-        <button className="btn ghost sm" disabled={disabled || busy} onClick={() => void control('resume')}>恢复</button>
+        <button
+          className="btn ghost sm"
+          disabled={disabled || busy}
+          onClick={() => void control('resume')}
+        >
+          恢复
+        </button>
       )}
-      <button className="btn ghost sm" disabled={disabled || busy} onClick={() => void control('complete')}>完成</button>
-      <button className="btn ghost sm danger" disabled={disabled || busy} onClick={() => void control('clear')}>清除</button>
+      <button
+        className="btn ghost sm"
+        disabled={disabled || busy}
+        onClick={() => void control('complete')}
+      >
+        完成
+      </button>
+      <button
+        className="btn ghost sm danger"
+        disabled={disabled || busy}
+        onClick={() => void control('clear')}
+      >
+        清除
+      </button>
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Provide a Codex-style in-session side chat so users can run a parallel, project-scoped conversation without interrupting the main session, with the entry placed next to the built-in terminal button. 
- Ensure the side chat automatically inherits the current session/project runtime configuration (provider, model, agent, adapter, permission mode, chat mode, reasoning effort, and team config) for seamless parallel exploration. 
- Prevent accidental reuse of an empty session when creating side chats by forcing creation of a distinct session in this flow.

### Description
- Add UI/state and actions in `ChatView` to open a side-chat panel, including `showSideChatPanel`, `sideChatSessionId`, `sideChatCreating`, and `openSideChatPanel` which calls `sessionCtx.handleNewSession(..., { forceNew: true, activate: false })`. (files: `apps/desktop/src/renderer/design/views/ChatView.tsx`)
- Implement a lightweight `SideChatPanel` component and related styles to display session metadata and provide `Close / New / Open and continue` actions. (files: `apps/desktop/src/renderer/design/views/ChatView.tsx`, `apps/desktop/src/renderer/design/views/ChatView.less`)
- Add a side-chat entry button beside the built-in terminal in both the empty-hero toolbar and the active-session `ChatTabbar`. (file: `apps/desktop/src/renderer/design/views/ChatView.tsx`)
- Add `forceNew` handling to session creation in `SessionSidebarContext.handleNewSession` so callers can opt out of reusing an unused/empty session; default behavior unchanged. (file: `apps/desktop/src/renderer/design/SessionSidebarContext.tsx`)
- Minor formatting/cleanup changes to keep style consistent and avoid introducing new lint noise.

### Testing
- Ran a TypeScript check with `pnpm --filter @spark/desktop exec tsc --noEmit --pretty false`, which reported existing unrelated blockers (`@file-viewer/react` missing types and an implicit `any` in `FilePreviewPanel.tsx`), and reported no new TypeScript errors from the side-chat changes. (result: existing failures remain, no new errors introduced)
- Ran `pnpm exec prettier --write` on the modified files to format changes. (result: success)
- Ran `git diff --check` and basic git diff summary to validate the working tree; changes were committed as `feat(desktop): add in-session side chat panel`. (result: success)
- Attempted `npx gitnexus detect_changes` for impact/diff mapping but the GitNexus runner/CLI produced no report in this environment; a source-based impact analysis was performed and the risk was assessed as `MEDIUM` because the change modifies ChatView UI and session creation paths. (result: no GitNexus report; manual analysis completed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a389bdc1d948325b50fde24ec466f9e)