### PR TITLE
Improve responsive chat gutters

### DIFF
--- a/apps/desktop/src/renderer/design/styles/styles.css
+++ b/apps/desktop/src/renderer/design/styles/styles.css
@@ -877,10 +877,12 @@ body.floating-sidebar-resizing * { pointer-events: none !important; }
     padding-right 0.18s ease;
 }
 
-/* Sidebar hidden: inset all page content with horizontal breathing room */
+/* Sidebar hidden: keep breathing room on wide windows, but give narrow
+   chat/browser layouts their space back. The 8px floor matches the chat
+   content gutters so a fully collapsed shell never becomes edge-to-edge. */
 .app.sidebar-hidden .main-content-area {
-  padding-left: 80px;
-  padding-right: 80px;
+  padding-left: clamp(8px, 5vw, 80px);
+  padding-right: clamp(8px, 5vw, 80px);
 }
 
 .app.sidebar-hidden .main-content-area.main-content-canvas-workspace {

--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -1100,7 +1100,7 @@ body.sidebar-resizing {
   width: min(100%, 900px);
   min-width: 0;
   margin: 0 auto;
-  padding: 0 var(--pad-xl);
+  padding: 0 clamp(8px, 2.4vw, var(--pad-xl));
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -2403,7 +2403,7 @@ body.sidebar-resizing {
   width: 100%;
   min-width: 0;
   margin: 0 auto;
-  padding: 0 var(--pad-xl) var(--pad-lg);
+  padding: 0 clamp(8px, 2.4vw, var(--pad-xl)) var(--pad-lg);
 }
 .composer {
   border: 0px solid var(--border);
@@ -2649,6 +2649,43 @@ body.sidebar-resizing {
 .chat-main-empty .composer-v2.has-workspace-picks textarea {
   padding-right: 80px;
   padding-bottom: 88px;
+}
+
+/* Responsive chat gutters:
+   - When the floating sidebar is hidden and no right panel is open, use the
+     full application width with an 8px minimum gutter on both sides.
+   - When the browser side panel is open, keep the same compact right gutter so
+     the conversation/input can expand up to the panel edge. */
+.app.sidebar-hidden .main-with-browser:not(:has(.browser-panel)) .chat-stream-inner,
+.app.sidebar-hidden .main-with-browser:not(:has(.browser-panel)) .composer-inner,
+.app.sidebar-hidden .main-with-browser:has(.browser-panel) .chat-stream-inner,
+.app.sidebar-hidden .main-with-browser:has(.browser-panel) .composer-inner {
+  max-width: none;
+  width: 100%;
+}
+
+@media (max-width: 900px) {
+  .chat-main {
+    --chat-main-min-width: 0px;
+  }
+
+  .chat-layout {
+    overflow-x: hidden;
+  }
+
+  .chat-main-empty {
+    padding-inline: 8px;
+  }
+
+  .chat-main-empty .composer-v2 textarea {
+    min-height: 52px;
+    padding-top: 12px;
+    padding-bottom: 44px;
+  }
+
+  .chat-main-empty .composer-v2.has-workspace-picks textarea {
+    padding-bottom: 72px;
+  }
 }
 
 /* 渐变消失的网格背景（用双层 linear-gradient + radial mask 营造从中心向四周淡出的效果） */

--- a/apps/desktop/src/renderer/design/views/BrowserPanelView.less
+++ b/apps/desktop/src/renderer/design/views/BrowserPanelView.less
@@ -10,7 +10,7 @@
 
 /* When browser is open, padding goes on .main instead of .main-content-area */
 .app.sidebar-hidden .main-with-browser > .main {
-  padding-left: 80px;
+  padding-left: clamp(8px, 5vw, 80px);
   padding-right: 0;
 }
 


### PR DESCRIPTION
### Motivation
- Reduce wasted horizontal space when the floating sidebar is hidden by making the left/right content insets adaptive instead of a fixed 80px. 
- Ensure the chat stream and composer can expand to the available application width when the sidebar and right panels are collapsed, while keeping a minimum gutter of 8px. 
- Improve narrow-window behavior by removing forced horizontal overflow and reducing empty-state composer height so the UI remains usable on small widths.

### Description
- Replace fixed hidden-sidebar padding with responsive clamps in `apps/desktop/src/renderer/design/styles/styles.css` to use `padding-left/right: clamp(8px, 5vw, 80px)`. 
- Mirror the responsive left inset when the browser side panel is used by updating `apps/desktop/src/renderer/design/views/BrowserPanelView.less` to `padding-left: clamp(8px, 5vw, 80px)`. 
- Make chat and composer gutters adaptive by changing `chat-stream-inner` and `composer-inner` padding to `padding: 0 clamp(8px, 2.4vw, var(--pad-xl))` and add rules so the conversation area can expand to the panel edge when the sidebar is hidden in `apps/desktop/src/renderer/design/styles/views.css`. 
- Add responsive rules and a media query (<=900px) to remove the chat minimum width, disable horizontal overflow, and reduce empty-state composer textarea height/padding for narrow windows in `apps/desktop/src/renderer/design/styles/views.css`.

### Testing
- Ran `npx gitnexus impact` against relevant symbols (`chat-main`, `composer-inner`, `main-content-area`, `App`) as required by repository guidance, but in this execution environment the GitNexus CLI only emitted install/warning output and did not produce a detailed impact report. 
- Ran `timeout 90s npx gitnexus detect_changes` (executed) and `git diff --check`, with `git diff --check` returning no issues. 
- Ran `pnpm --filter @spark/desktop typecheck`, which failed due to pre-existing/unrelated TypeScript issues (invalid placement string in `App.tsx`, missing module `@file-viewer/react`, and an implicit `any` parameter in `FilePreviewPanel.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39047c5c34832882919c9be7d02f41)