### PR TITLE
Fix side chat workspace validation

### DIFF
--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -938,16 +938,27 @@ export function ChatView({
     () => sessions.find((session) => session.id === sideChatSessionId) ?? null,
     [sessions, sideChatSessionId],
   )
+  const activeSideChatWorkspaceId =
+    activeSessionWorkspace?.id ?? activeWorkspace?.id ?? activeWorkspaceId ?? null
+  const sideChatSessionWorkspaceId = sideChatSession?.workspaceIds[0] ?? null
+  const sideChatMatchesActiveWorkspace =
+    sideChatSession != null && sideChatSessionWorkspaceId === activeSideChatWorkspaceId
   const sideChatWorkspace = useMemo(() => {
-    const workspaceId =
-      sideChatSession?.workspaceIds[0] ?? activeSessionWorkspace?.id ?? activeWorkspace?.id
+    const workspaceId = sideChatSessionWorkspaceId ?? activeSideChatWorkspaceId
     if (workspaceId == null) return activeSessionWorkspace ?? activeWorkspace
     return (
       workspaces.find((workspace) => workspace.id === workspaceId) ??
       activeSessionWorkspace ??
       activeWorkspace
     )
-  }, [activeSessionWorkspace, activeWorkspace, sideChatSession?.workspaceIds, workspaces])
+  }, [
+    activeSessionWorkspace,
+    activeSideChatWorkspaceId,
+    activeWorkspace,
+    sideChatSessionWorkspaceId,
+    workspaces,
+  ])
+
   const createSideChatSession = useCallback(
     async (overrides: Record<string, unknown> = {}) => {
       const workspaceId = activeSessionWorkspace?.id ?? activeWorkspace?.id ?? activeWorkspaceId
@@ -984,11 +995,16 @@ export function ChatView({
   const openSideChatPanel = useCallback(
     async (options: { replace?: boolean } = {}) => {
       setShowSideChatPanel(true)
-      if (sideChatSessionId != null && options.replace !== true) return
+      if (sideChatSessionId != null && options.replace !== true && sideChatMatchesActiveWorkspace) {
+        return
+      }
       setSideChatCreating(true)
-      if (options.replace === true) {
+      if (options.replace === true || !sideChatMatchesActiveWorkspace) {
         setSideChatSessionId(null)
         setSideChatMessages([])
+        setSideChatContextInputTokens(0)
+        setSideChatContextUsage(null)
+        setSideChatAgentStatus('')
       }
       try {
         await createSideChatSession()
@@ -996,7 +1012,7 @@ export function ChatView({
         setSideChatCreating(false)
       }
     },
-    [createSideChatSession, sideChatSessionId],
+    [createSideChatSession, sideChatMatchesActiveWorkspace, sideChatSessionId],
   )
   const handleSideChatSent = useCallback(
     (sessionId: SessionId) => {
@@ -1331,7 +1347,9 @@ export function ChatView({
             void openSideChatPanel({ replace: true })
           }}
         >
-          {sideChatSessionId != null && sideChatSession != null ? (
+          {sideChatSessionId != null &&
+          sideChatSession != null &&
+          sideChatMatchesActiveWorkspace ? (
             <>
               <ChatStream
                 key={`side-chat-stream-${sideChatSessionId}`}


### PR DESCRIPTION
### Motivation

- Fix a P1 bug where a previously opened side chat session is reused after switching the active project/workspace, causing the side `ChatStream`/`ComposerV2` to operate against the wrong workspace and session.

### Description

- Update `apps/desktop/src/renderer/design/views/ChatView.tsx` to compute `activeSideChatWorkspaceId`, `sideChatSessionWorkspaceId`, and `sideChatMatchesActiveWorkspace` to verify the stored side-chat session belongs to the current workspace.
- Change the `sideChatWorkspace` `useMemo` to use the validated workspace id and update hook dependencies accordingly.
- Update `openSideChatPanel` to clear side-chat runtime state (`sideChatSessionId`, messages, usage, agent status) when the stored side session does not match the active workspace and to force creation when appropriate.
- Prevent rendering the side `ChatStream` and `ComposerV2` unless the side-chat session still matches the active workspace to avoid showing/using stale session UI.

### Testing

- Ran `pnpm --filter @spark/desktop typecheck` which completed successfully.
- Ran `git diff --check` and local formatting (`prettier`) as part of the change validation which passed.
- Ran `pnpm --filter @spark/desktop lint` but the repo contains pre-existing lint errors unrelated to this change, so lint run surfaced unrelated issues (not introduced by this PR).
- Attempted GitNexus `detect_changes` / `impact` analysis via `npx gitnexus`, but installation/run was blocked by a network/install failure for native dependency `onnxruntime-node` in this environment, so a GitNexus blast-radius report could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a390476969083239e48bcaf1fd5eb8b)