### PR TITLE
Introduce unified session side panel (terminal / review / side-chat)

### DIFF
--- a/apps/desktop/src/renderer/design/views/ChatView.less
+++ b/apps/desktop/src/renderer/design/views/ChatView.less
@@ -2813,3 +2813,216 @@ body.side-chat-resizing {
   line-height: 1.4;
   word-break: break-word;
 }
+
+/* Unified session side panel: terminal / review / side-chat share one tabbed dock. */
+.unified-side-panel {
+  width: var(--side-chat-width, min(44vw, 620px));
+  min-width: 360px;
+  max-width: 900px;
+  height: 100vh;
+  flex: 0 0 auto;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background: color-mix(in srgb, var(--panel) 96%, var(--bg));
+  border-left: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+.platform-win32 .unified-side-panel {
+  height: calc(100vh - 32px);
+}
+
+.unified-side-panel-tabbar {
+  flex: 0 0 44px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  -webkit-app-region: no-drag;
+}
+
+.unified-side-panel-shortcuts {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+}
+
+.unified-side-panel-shortcut {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.unified-side-panel-shortcut:hover,
+.unified-side-panel-shortcut.opened {
+  background: color-mix(in srgb, var(--text) 7%, transparent);
+  color: var(--text);
+}
+
+.unified-side-panel-shortcut.active {
+  background: color-mix(in srgb, var(--text) 12%, transparent);
+  color: var(--text);
+}
+
+.unified-side-panel-active-tab {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+}
+
+.unified-side-panel-tab {
+  height: 30px;
+  min-width: 0;
+  max-width: 220px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px 0 10px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+  cursor: pointer;
+}
+
+.unified-side-panel-tab span:not(.unified-side-panel-tab-close) {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.unified-side-panel-tab:hover,
+.unified-side-panel-tab.active {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text);
+}
+
+.unified-side-panel-tab.active {
+  border-color: color-mix(in srgb, var(--border) 78%, transparent);
+}
+
+.unified-side-panel-active-tab .unified-side-panel-tab {
+  cursor: default;
+}
+
+.unified-side-panel-tab-close,
+.unified-side-panel-add {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  color: var(--text-muted);
+}
+
+.unified-side-panel-tab-close:hover,
+.unified-side-panel-add:hover {
+  background: color-mix(in srgb, var(--text) 12%, transparent);
+  color: var(--text);
+}
+
+.unified-side-panel-add-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.unified-side-panel-add {
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.unified-side-panel-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.unified-side-panel-picker {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.unified-side-panel-menu {
+  width: min(100%, 520px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.unified-side-panel-menu.compact {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 30;
+  width: 240px;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: 14px;
+  background: var(--panel);
+  box-shadow: var(--shadow-lg);
+}
+
+.unified-side-panel-menu-item {
+  height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 18px;
+  border: 0;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--text) 5%, transparent);
+  color: var(--text);
+  font-size: var(--font-lg);
+  font-weight: 650;
+  cursor: pointer;
+  text-align: left;
+}
+
+.unified-side-panel-menu.compact .unified-side-panel-menu-item {
+  height: 42px;
+  font-size: var(--font-md);
+  background: transparent;
+}
+
+.unified-side-panel-menu-item:hover {
+  background: color-mix(in srgb, var(--text) 9%, transparent);
+}
+
+.unified-side-panel .builtin-terminal-panel,
+.unified-side-panel .git-review-frame,
+.unified-side-panel .side-chat-panel.embedded {
+  width: 100% !important;
+  min-width: 0;
+  max-width: none;
+  height: 100%;
+  flex: 1 1 auto;
+}
+
+.unified-side-panel .builtin-terminal-panel .terminal-resize-handle,
+.unified-side-panel .git-review-frame > .inspector-resize-handle,
+.unified-side-panel .side-chat-panel.embedded > .side-chat-resize-handle {
+  display: none;
+}
+
+.unified-side-panel .side-chat-panel.embedded {
+  background: transparent;
+}

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -222,6 +222,8 @@ type ComposerDraftSnapshot = {
   attachments: ComposerAttachment[]
   manualExpanded: boolean
 }
+
+type UnifiedSidePanelKind = 'terminal' | 'side-chat' | 'review'
 const EMPTY_COMPOSER_DRAFT: ComposerDraftSnapshot = {
   value: '',
   attachments: [],
@@ -388,6 +390,10 @@ export function ChatView({
   // 仅在有活跃会话且绑定 workspace 时启用；切会话会保留各自的 terminals（后端负责）。
   const [showTerminalPanel, setShowTerminalPanel] = useState(false)
   const [showGitReviewPanel, setShowGitReviewPanel] = useState(false)
+  const [unifiedSideTabs, setUnifiedSideTabs] = useState<UnifiedSidePanelKind[]>([])
+  const [activeUnifiedSideTab, setActiveUnifiedSideTab] = useState<UnifiedSidePanelKind | null>(
+    null,
+  )
   const [showGitEnvPanel, setShowGitEnvPanel] = useState(false)
   const [gitCommitModalOpen, setGitCommitModalOpen] = useState(false)
   const [gitBranchModalOpen, setGitBranchModalOpen] = useState(false)
@@ -404,6 +410,27 @@ export function ChatView({
     null,
   )
   const [sideChatScrollToBottomTrigger, setSideChatScrollToBottomTrigger] = useState(0)
+  const openUnifiedSidePanel = useCallback((kind: UnifiedSidePanelKind) => {
+    setUnifiedSideTabs((tabs) => (tabs.includes(kind) ? tabs : [...tabs, kind]))
+    setActiveUnifiedSideTab(kind)
+    if (kind === 'terminal') setShowTerminalPanel(true)
+    if (kind === 'review') setShowGitReviewPanel(true)
+    if (kind === 'side-chat') setShowSideChatPanel(true)
+  }, [])
+
+  const closeUnifiedSidePanel = useCallback((kind: UnifiedSidePanelKind) => {
+    setUnifiedSideTabs((tabs) => {
+      const next = tabs.filter((tab) => tab !== kind)
+      setActiveUnifiedSideTab((activeTab) =>
+        activeTab !== kind ? activeTab : (next.at(-1) ?? null),
+      )
+      return next
+    })
+    if (kind === 'terminal') setShowTerminalPanel(false)
+    if (kind === 'review') setShowGitReviewPanel(false)
+    if (kind === 'side-chat') setShowSideChatPanel(false)
+  }, [])
+
   // 代码还原点时间线抽屉：把「按会话撤回代码」做成集中可还原视图，按钮在 ChatTabbar 右上。
   const [showCheckpointTimeline, setShowCheckpointTimeline] = useState(false)
   // Team Mode 配置。
@@ -893,11 +920,11 @@ export function ChatView({
   }, [isGitRepo, activeSessionWorkspaceId])
 
   const handleOpenGitReview = useCallback(() => {
-    setShowGitReviewPanel(true)
-    setInspectorWidth((width) => Math.max(width, 480))
+    openUnifiedSidePanel('review')
+    setSideChatWidth((width) => Math.max(width, 520))
     setShowInspector(false)
     setShowConfigPanel(false)
-  }, [])
+  }, [openUnifiedSidePanel])
 
   // 窗口重新聚焦时刷新分支：用户切到外部终端/IDE 改了分支后回到应用，会话内分支显示
   // 需要同步。用 document.visibilityState 兜住最小化后还原的情况。
@@ -1243,9 +1270,10 @@ export function ChatView({
       teamConfig,
     ],
   )
+
   const openSideChatPanel = useCallback(
     async (options: { replace?: boolean } = {}) => {
-      setShowSideChatPanel(true)
+      openUnifiedSidePanel('side-chat')
       if (sideChatSessionId != null && options.replace !== true && sideChatMatchesActiveWorkspace) {
         return
       }
@@ -1263,7 +1291,12 @@ export function ChatView({
         setSideChatCreating(false)
       }
     },
-    [createSideChatSession, sideChatMatchesActiveWorkspace, sideChatSessionId],
+    [
+      createSideChatSession,
+      openUnifiedSidePanel,
+      sideChatMatchesActiveWorkspace,
+      sideChatSessionId,
+    ],
   )
   const handleSideChatSent = useCallback(
     (sessionId: SessionId) => {
@@ -1422,7 +1455,11 @@ export function ChatView({
                 title={activeWorkspace ? '内置终端' : '请先选择项目文件夹'}
                 aria-label="内置终端"
                 disabled={!activeWorkspace}
-                onClick={() => setShowTerminalPanel(!showTerminalPanel)}
+                onClick={() =>
+                  showTerminalPanel
+                    ? closeUnifiedSidePanel('terminal')
+                    : openUnifiedSidePanel('terminal')
+                }
               >
                 <Icons.Terminal size={14} />
               </button>
@@ -1432,7 +1469,7 @@ export function ChatView({
                 aria-label="侧边聊天"
                 disabled={!activeWorkspace}
                 onClick={() => {
-                  if (showSideChatPanel) setShowSideChatPanel(false)
+                  if (showSideChatPanel) closeUnifiedSidePanel('side-chat')
                   else void openSideChatPanel()
                 }}
               >
@@ -1512,10 +1549,12 @@ export function ChatView({
                   if (v) setShowGitReviewPanel(false)
                 }}
                 showTerminalPanel={showTerminalPanel}
-                setShowTerminalPanel={setShowTerminalPanel}
+                setShowTerminalPanel={(v) =>
+                  v ? openUnifiedSidePanel('terminal') : closeUnifiedSidePanel('terminal')
+                }
                 showSideChatPanel={showSideChatPanel}
                 onToggleSideChat={() => {
-                  if (showSideChatPanel) setShowSideChatPanel(false)
+                  if (showSideChatPanel) closeUnifiedSidePanel('side-chat')
                   else void openSideChatPanel()
                 }}
                 showCheckpointTimeline={showCheckpointTimeline}
@@ -1648,118 +1687,127 @@ export function ChatView({
         />
       )}
 
-      {showGitReviewPanel && (
-        <GitReviewPanel
-          workspaceId={activeSessionWorkspaceId}
-          status={gitStatus}
-          width={inspectorWidth}
-          onWidthChange={setInspectorWidth}
-          onRefresh={refreshGitStatus}
-          onClose={() => setShowGitReviewPanel(false)}
-        />
-      )}
-
-      {showSideChatPanel && (active != null || activeWorkspace != null) && (
-        <SideChatPanel
-          workspaceName={sideChatWorkspace?.name ?? activeWorkspace?.name ?? '当前项目'}
-          agentStatus={sideChatAgentStatus}
-          creating={sideChatCreating}
+      {unifiedSideTabs.length > 0 && (active != null || activeWorkspace != null) && (
+        <UnifiedSessionSidePanel
+          tabs={unifiedSideTabs}
+          activeTab={activeUnifiedSideTab ?? unifiedSideTabs[0] ?? 'terminal'}
           width={sideChatWidth}
           onWidthChange={setSideChatWidth}
-          onClose={() => setShowSideChatPanel(false)}
-          onNew={() => {
-            void openSideChatPanel({ replace: true })
-          }}
+          onSelect={setActiveUnifiedSideTab}
+          onOpen={openUnifiedSidePanel}
+          onCloseTab={closeUnifiedSidePanel}
         >
-          {sideChatSessionId != null &&
-          sideChatSession != null &&
-          sideChatMatchesActiveWorkspace ? (
-            <>
-              <ChatStream
-                key={`side-chat-stream-${sideChatSessionId}`}
-                sessionId={sideChatSessionId}
-                onStatusChange={setSideChatAgentStatus}
-                onUsageChange={setSideChatContextInputTokens}
-                onUsageDataChange={() => {}}
-                onMessagesChange={setSideChatMessages}
-                onSessionStatusChange={(status) => setSessionStatus(sideChatSessionId, status)}
-                onContextUsageChange={setSideChatContextUsage}
-                onContextLedgerChange={setSideChatContextLedger}
-                onProjectContextChange={() => {}}
-                onPlanProposed={() => {}}
-                onTurnPromptSnapshotsChange={() => {}}
-                scrollToBottomTrigger={sideChatScrollToBottomTrigger}
-                teamConfig={teamConfig}
-                onFilePreview={handleFilePreview}
-                onLoadingChange={() => {}}
-              />
-              <ComposerV2
-                session={sideChatSession}
-                workspace={sideChatWorkspace}
-                providers={providers}
-                agents={agents}
-                selectedProviderId={selectedProviderId}
-                setSelectedProviderId={setSelectedProviderId}
-                branchState={branchState}
-                contextInputTokens={sideChatContextInputTokens}
-                contextUsage={sideChatContextUsage}
-                contextLedger={sideChatContextLedger}
-                isWorking={isComposerSessionWorking(sideChatSession.status)}
-                messages={sideChatMessages}
-                approvalRequest={null}
-                onCreateSession={(options) =>
-                  createSideChatSession(options as Record<string, unknown>)
-                }
-                onUpdateSession={async (patch) => {
-                  await updateSession({ sessionId: sideChatSessionId, ...patch })
-                  await sessionCtx.refreshData()
-                }}
-                onCommandComplete={(summary) => {
-                  sessionCtx.updateSessionInList(summary.id, summary)
-                }}
-                onSwitchBranch={handleComposerSwitchBranch}
-                onCancelSession={handleCancelSession}
-                onSent={handleSideChatSent}
-                showProjectPicker={false}
-                workspaces={workspaces}
-                activeWorkspaceId={sideChatWorkspace?.id ?? activeWorkspaceId}
-                onPickProject={pickProjectFolder}
-                onUseNoProject={() => {}}
-                onSwitchWorkspace={switchToWorkspace}
-                teamConfig={teamConfig}
-                effectiveHostAgentId={effectiveHostAgentId}
-                onChangeTeamConfig={updateTeamConfig}
-                onOpenTeamInspector={() => setShowInspector(true)}
-                runningTeamAgentIds={[]}
-                onOpenSkillStore={openSkillStore}
-                hideBranchSelect={hideComposerBranchSelect}
-                replyTo={null}
-              />
-            </>
-          ) : (
-            <div className="side-chat-panel-empty">
-              <Icons.Chat size={32} />
-              <h3>{sideChatCreating ? '正在创建侧边会话…' : '新的侧边会话'}</h3>
-              <p>侧边会话会自动继承当前项目、模型、Agent、权限、推理强度与团队配置。</p>
-            </div>
-          )}
-        </SideChatPanel>
-      )}
-
-      {showTerminalPanel &&
-        (active != null || activeWorkspace != null) &&
-        (() => {
-          // 空会话（active == null）下用稳定的伪 sessionId 挂载终端面板，
-          // 让 PTY 能正确创建/复用；真实会话存在时仍用真实 sessionId。
-          const terminalSessionId = active != null ? active : EMPTY_HERO_TERMINAL_SESSION_ID
-          return (
-            <BuiltInTerminalPanel
-              sessionId={terminalSessionId}
-              workspace={activeSessionWorkspace ?? activeWorkspace}
-              onClose={() => setShowTerminalPanel(false)}
+          {activeUnifiedSideTab === 'review' && showGitReviewPanel ? (
+            <GitReviewPanel
+              workspaceId={activeSessionWorkspaceId}
+              status={gitStatus}
+              width={sideChatWidth}
+              onWidthChange={setSideChatWidth}
+              onRefresh={refreshGitStatus}
+              onClose={() => closeUnifiedSidePanel('review')}
             />
-          )
-        })()}
+          ) : activeUnifiedSideTab === 'terminal' && showTerminalPanel ? (
+            (() => {
+              const terminalSessionId = active != null ? active : EMPTY_HERO_TERMINAL_SESSION_ID
+              return (
+                <BuiltInTerminalPanel
+                  sessionId={terminalSessionId}
+                  workspace={activeSessionWorkspace ?? activeWorkspace}
+                  onClose={() => closeUnifiedSidePanel('terminal')}
+                />
+              )
+            })()
+          ) : activeUnifiedSideTab === 'side-chat' && showSideChatPanel ? (
+            <SideChatPanel
+              workspaceName={sideChatWorkspace?.name ?? activeWorkspace?.name ?? '当前项目'}
+              agentStatus={sideChatAgentStatus}
+              creating={sideChatCreating}
+              width={sideChatWidth}
+              onWidthChange={setSideChatWidth}
+              onClose={() => closeUnifiedSidePanel('side-chat')}
+              onNew={() => {
+                void openSideChatPanel({ replace: true })
+              }}
+              embedded
+            >
+              {sideChatSessionId != null &&
+              sideChatSession != null &&
+              sideChatMatchesActiveWorkspace ? (
+                <>
+                  <ChatStream
+                    key={`side-chat-stream-${sideChatSessionId}`}
+                    sessionId={sideChatSessionId}
+                    onStatusChange={setSideChatAgentStatus}
+                    onUsageChange={setSideChatContextInputTokens}
+                    onUsageDataChange={() => {}}
+                    onMessagesChange={setSideChatMessages}
+                    onSessionStatusChange={(status) => setSessionStatus(sideChatSessionId, status)}
+                    onContextUsageChange={setSideChatContextUsage}
+                    onContextLedgerChange={setSideChatContextLedger}
+                    onProjectContextChange={() => {}}
+                    onPlanProposed={() => {}}
+                    onTurnPromptSnapshotsChange={() => {}}
+                    scrollToBottomTrigger={sideChatScrollToBottomTrigger}
+                    teamConfig={teamConfig}
+                    onFilePreview={handleFilePreview}
+                    onLoadingChange={() => {}}
+                  />
+                  <ComposerV2
+                    session={sideChatSession}
+                    workspace={sideChatWorkspace}
+                    providers={providers}
+                    agents={agents}
+                    selectedProviderId={selectedProviderId}
+                    setSelectedProviderId={setSelectedProviderId}
+                    branchState={branchState}
+                    contextInputTokens={sideChatContextInputTokens}
+                    contextUsage={sideChatContextUsage}
+                    contextLedger={sideChatContextLedger}
+                    isWorking={isComposerSessionWorking(sideChatSession.status)}
+                    messages={sideChatMessages}
+                    approvalRequest={null}
+                    onCreateSession={(options) =>
+                      createSideChatSession(options as Record<string, unknown>)
+                    }
+                    onUpdateSession={async (patch) => {
+                      await updateSession({ sessionId: sideChatSessionId, ...patch })
+                      await sessionCtx.refreshData()
+                    }}
+                    onCommandComplete={(summary) => {
+                      sessionCtx.updateSessionInList(summary.id, summary)
+                    }}
+                    onSwitchBranch={handleComposerSwitchBranch}
+                    onCancelSession={handleCancelSession}
+                    onSent={handleSideChatSent}
+                    showProjectPicker={false}
+                    workspaces={workspaces}
+                    activeWorkspaceId={sideChatWorkspace?.id ?? activeWorkspaceId}
+                    onPickProject={pickProjectFolder}
+                    onUseNoProject={() => {}}
+                    onSwitchWorkspace={switchToWorkspace}
+                    teamConfig={teamConfig}
+                    effectiveHostAgentId={effectiveHostAgentId}
+                    onChangeTeamConfig={updateTeamConfig}
+                    onOpenTeamInspector={() => setShowInspector(true)}
+                    runningTeamAgentIds={[]}
+                    onOpenSkillStore={openSkillStore}
+                    hideBranchSelect={hideComposerBranchSelect}
+                    replyTo={null}
+                  />
+                </>
+              ) : (
+                <div className="side-chat-panel-empty">
+                  <Icons.Chat size={32} />
+                  <h3>{sideChatCreating ? '正在创建侧边会话…' : '新的侧边会话'}</h3>
+                  <p>侧边会话会自动继承当前项目、模型、Agent、权限、推理强度与团队配置。</p>
+                </div>
+              )}
+            </SideChatPanel>
+          ) : (
+            <UnifiedSidePanelPicker onOpen={openUnifiedSidePanel} />
+          )}
+        </UnifiedSessionSidePanel>
+      )}
 
       {proposedPlan != null && active != null && proposedPlan.sessionId === active && (
         <PlanApprovalModal
@@ -2323,6 +2371,191 @@ function TeamModeEmptyHero({
   )
 }
 
+const UNIFIED_SIDE_PANEL_QUICK_ITEMS: UnifiedSidePanelKind[] = ['review', 'terminal', 'side-chat']
+
+const getUnifiedSidePanelMeta = (
+  kind: UnifiedSidePanelKind,
+): { label: string; title: string; icon: ReactNode; shortcutLabel: string } => {
+  if (kind === 'review')
+    return {
+      label: '审查',
+      title: '代码审查',
+      shortcutLabel: '打开代码审查面板',
+      icon: <Icons.GitBranch size={14} />,
+    }
+  if (kind === 'terminal')
+    return {
+      label: '终端',
+      title: '终端',
+      shortcutLabel: '打开终端面板',
+      icon: <Icons.Terminal size={14} />,
+    }
+  return {
+    label: '侧边聊天',
+    title: '侧边聊天',
+    shortcutLabel: '打开侧边聊天面板',
+    icon: <Icons.Chat size={14} />,
+  }
+}
+
+function UnifiedSessionSidePanel({
+  tabs,
+  activeTab,
+  width,
+  onWidthChange,
+  onSelect,
+  onOpen,
+  onCloseTab,
+  children,
+}: {
+  tabs: UnifiedSidePanelKind[]
+  activeTab: UnifiedSidePanelKind
+  width: number
+  onWidthChange: (width: number) => void
+  onSelect: (kind: UnifiedSidePanelKind) => void
+  onOpen: (kind: UnifiedSidePanelKind) => void
+  onCloseTab: (kind: UnifiedSidePanelKind) => void
+  children: ReactNode
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const handleResizeStart = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current = { startX: event.clientX, startWidth: width }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    document.body.classList.add('side-chat-resizing')
+  }
+  const handleResizeMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragRef.current == null) return
+    const delta = dragRef.current.startX - event.clientX
+    onWidthChange(clamp(dragRef.current.startWidth + delta, 360, 900))
+  }
+  const handleResizeEnd = (event: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null
+    event.currentTarget.releasePointerCapture(event.pointerId)
+    document.body.classList.remove('side-chat-resizing')
+  }
+  const openKind = (kind: UnifiedSidePanelKind) => {
+    onOpen(kind)
+    setPickerOpen(false)
+  }
+  return (
+    <aside
+      className="unified-side-panel"
+      aria-label="会话侧边面板"
+      style={{ '--side-chat-width': `${width}px` } as React.CSSProperties}
+    >
+      <div
+        className="side-chat-resize-handle"
+        title="拖拽调整侧边栏宽度"
+        onPointerDown={handleResizeStart}
+        onPointerMove={handleResizeMove}
+        onPointerUp={handleResizeEnd}
+        onPointerCancel={handleResizeEnd}
+      />
+      <div className="unified-side-panel-tabbar">
+        <div className="unified-side-panel-shortcuts" aria-label="侧边面板快捷入口">
+          {UNIFIED_SIDE_PANEL_QUICK_ITEMS.map((kind) => {
+            const meta = getUnifiedSidePanelMeta(kind)
+            const opened = tabs.includes(kind)
+            const active = kind === activeTab
+            return (
+              <button
+                key={kind}
+                type="button"
+                className={`unified-side-panel-shortcut ${active ? 'active' : ''} ${opened ? 'opened' : ''}`}
+                aria-label={meta.shortcutLabel}
+                title={meta.shortcutLabel}
+                onClick={() => (opened ? onSelect(kind) : openKind(kind))}
+              >
+                {meta.icon}
+              </button>
+            )
+          })}
+        </div>
+        <div className="unified-side-panel-active-tab">
+          {(() => {
+            const meta = getUnifiedSidePanelMeta(activeTab)
+            return (
+              <button type="button" className="unified-side-panel-tab active" title={meta.title}>
+                {meta.icon}
+                <span>{meta.label}</span>
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="unified-side-panel-tab-close"
+                  aria-label={`关闭${meta.label}`}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onCloseTab(activeTab)
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      event.preventDefault()
+                      event.stopPropagation()
+                      onCloseTab(activeTab)
+                    }
+                  }}
+                >
+                  <Icons.X size={11} />
+                </span>
+              </button>
+            )
+          })()}
+        </div>
+        <div className="unified-side-panel-add-wrap">
+          <button
+            type="button"
+            className="unified-side-panel-add"
+            aria-label="新建侧边面板"
+            title="新建侧边面板"
+            onClick={() => setPickerOpen((open) => !open)}
+          >
+            <Icons.Plus size={16} />
+          </button>
+          {pickerOpen && <UnifiedSidePanelMenu onOpen={openKind} compact />}
+        </div>
+      </div>
+      <div className="unified-side-panel-content">{children}</div>
+    </aside>
+  )
+}
+
+function UnifiedSidePanelPicker({ onOpen }: { onOpen: (kind: UnifiedSidePanelKind) => void }) {
+  return (
+    <div className="unified-side-panel-picker">
+      <UnifiedSidePanelMenu onOpen={onOpen} />
+    </div>
+  )
+}
+
+function UnifiedSidePanelMenu({
+  onOpen,
+  compact = false,
+}: {
+  onOpen: (kind: UnifiedSidePanelKind) => void
+  compact?: boolean
+}) {
+  const items = UNIFIED_SIDE_PANEL_QUICK_ITEMS
+  return (
+    <div className={`unified-side-panel-menu ${compact ? 'compact' : ''}`}>
+      {items.map((kind) => {
+        const meta = getUnifiedSidePanelMeta(kind)
+        return (
+          <button
+            key={kind}
+            type="button"
+            className="unified-side-panel-menu-item"
+            onClick={() => onOpen(kind)}
+          >
+            {meta.icon}
+            <span>{meta.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 function SideChatPanel({
   workspaceName,
   agentStatus,
@@ -2332,6 +2565,7 @@ function SideChatPanel({
   onClose,
   onNew,
   children,
+  embedded = false,
 }: {
   workspaceName: string
   agentStatus: string
@@ -2341,6 +2575,7 @@ function SideChatPanel({
   onClose: () => void
   onNew: () => void
   children: ReactNode
+  embedded?: boolean
 }) {
   // 侧边聊天面板宽度可拖拽伸缩，逻辑与 inspector-resize-handle 完全一致（左侧把手、向左拖增宽）。
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
@@ -2365,7 +2600,7 @@ function SideChatPanel({
 
   return (
     <aside
-      className="side-chat-panel"
+      className={embedded ? 'side-chat-panel embedded' : 'side-chat-panel'}
       aria-label="侧边聊天"
       style={{ '--side-chat-width': `${width}px` } as React.CSSProperties}
     >


### PR DESCRIPTION
### Motivation

- Consolidate multiple per-session side panels into a single tabbed dock to simplify UI and avoid overlapping/resizing conflicts.
- Provide a persistent, resizable container for terminal, code review and side-chat that supports quick-open shortcuts and a picker.

### Description

- Added layout and styles for the new unified side panel in `ChatView.less` under the `.unified-side-panel` family of classes. 
- Introduced `UnifiedSidePanelKind` type and local state `unifiedSideTabs` / `activeUnifiedSideTab` and helper functions `openUnifiedSidePanel` / `closeUnifiedSidePanel` in `ChatView.tsx` to manage tab lifecycle. 
- Implemented `UnifiedSessionSidePanel`, `UnifiedSidePanelPicker` and `UnifiedSidePanelMenu` components and wired them into `ChatView` to replace the previous separate render paths for `GitReviewPanel`, `BuiltInTerminalPanel` and `SideChatPanel`, including integrated resize handling and quick shortcuts. 
- Made `SideChatPanel` support an `embedded` mode and updated toggle handlers and props to open/close panels via the unified panel API, and adjusted width/resize/clamping logic accordingly.

### Testing

- Ran a TypeScript build (`yarn build`) to validate types and the frontend bundle which completed successfully. 
- Ran the unit test suite (`yarn test`) and all tests passed. 
- Performed a minimal UI integration smoke build (dev server) to ensure the new panel mounts and toggle flows work without runtime errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39ec0620488328b36b96541b0c5fcf)