### PR TITLE
fix(desktop): pin Windows CI to VS 2022 and detect WSL in local build

### DIFF
--- a/.github/workflows/publish-desktop-release.yml
+++ b/.github/workflows/publish-desktop-release.yml
@@ -111,7 +111,12 @@ jobs:
             name: mac-x64
             arch: x64
             platform: mac
-          - os: windows-latest
+          # Pin to windows-2022 (VS 2022): electron-rebuild@3 bundles an old
+          # @electron/node-gyp that cannot detect Visual Studio 2026 (v18),
+          # which became the default on windows-latest in May 2026 — see
+          # actions/runner-images#14017. node-pty rebuild then fails with
+          # "Could not find any Visual Studio installation to use".
+          - os: windows-2022
             name: win-x64
             arch: x64
             platform: win

--- a/apps/desktop/scripts/build-win-release.sh
+++ b/apps/desktop/scripts/build-win-release.sh
@@ -18,6 +18,12 @@
 # unsigned so Windows installer packaging can still be tested locally and in CI.
 set -euo pipefail
 
+# Windows hardened environments may export NoDefaultCurrentDirectoryInExePath,
+# which makes cmd.exe refuse to run executables from the current directory.
+# This breaks native module gyp actions (e.g. node-pty winpty's GetCommitHash.bat).
+# Clear it for the whole build process tree (inherited by electron-rebuild / electron-builder).
+unset NoDefaultCurrentDirectoryInExePath
+
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
@@ -188,6 +194,28 @@ echo "  Publish   : ${BUILDER_ARGS[*]:-(electron-builder default)}"
 echo "  App dir   : $APP_DIR"
 
 if ! is_windows_runner; then
+  # WSL bash reports a Linux kernel (uname -s = Linux), so is_windows_runner()
+  # returns false even though the host is Windows. Detect it explicitly and give
+  # an actionable message: Windows native modules must be compiled with the
+  # MSVC toolchain, which only Git Bash / MSYS provides — not WSL (gcc/Linux).
+  if grep -qiE "(microsoft|wsl)" /proc/version 2>/dev/null; then
+    cat <<EOF
+
+You are running this build inside WSL. Windows release builds must use the
+Windows (MSVC) toolchain so Electron native modules are compiled correctly,
+but WSL only provides the Linux toolchain.
+
+Run the build from a real Windows shell using Git Bash / MSYS2 instead:
+
+    "C:\\Program Files\\Git\\bin\\bash.exe" apps/desktop/scripts/build-win-release.sh x64 --publish never
+
+If 'pnpm run build:win' picks up WSL's bash (C:\\Windows\\System32\\bash.exe),
+make sure Git Bash (e.g. D:\\Git\\usr\\bin\\bash.exe) appears earlier in PATH
+than C:\\Windows\\System32.
+
+EOF
+    fail "Windows release build cannot run inside WSL; use Git Bash / MSYS2."
+  fi
   fail "Windows release builds must run on Windows so Electron native modules are rebuilt for the correct OS/arch."
 fi
 

--- a/apps/desktop/scripts/rebuild-native-for-electron.sh
+++ b/apps/desktop/scripts/rebuild-native-for-electron.sh
@@ -7,6 +7,14 @@
 # during startup when Electron tries to load better-sqlite3/keytar/node-pty.
 set -euo pipefail
 
+# Windows hardened environments may export NoDefaultCurrentDirectoryInExePath,
+# which makes cmd.exe refuse to run executables from the current directory.
+# node-pty's winpty.gyp runs `cmd /c "cd shared && GetCommitHash.bat"` and fails
+# with "'GetCommitHash.bat' is not recognized as a command" when this is set.
+# Clear it for this process tree so gyp actions resolve local .bat files.
+# Harmless no-op on macOS/Linux.
+unset NoDefaultCurrentDirectoryInExePath
+
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
CI: windows-latest now defaults to Visual Studio 2026 (v18), which the old @electron/node-gyp bundled in electron-rebuild@3 cannot detect, causing node-pty rebuild to fail with 'Could not find any Visual Studio installation to use'. Pin the Windows job to windows-2022 (VS 2022).

Local: build-win-release.sh now detects WSL (uname Linux but Windows host) and emits an actionable error pointing to Git Bash, instead of the generic 'not Windows' message. Windows native modules need the MSVC toolchain that only MSYS/Git Bash provides, not WSL's Linux toolchain.