### PR TITLE
feat(desktop): add global quick task capture (Cmd/Ctrl+B)

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -42,6 +42,7 @@ import { OnboardingView, shouldShowOnboarding } from './design/views/OnboardingV
 import { CommandPalette, PermissionModal } from './design/views/overlays'
 import { SidebarExpandButton } from './design/SidebarExpandButton'
 import { SidebarSessionList } from './design/SidebarSessionList'
+import { GlobalQuickTaskModal } from './design/components/GlobalQuickTaskModal'
 import { Icons } from './design/Icons'
 import { useI18n, type TranslationKey } from './design/i18n'
 import './FloatingSidebar.less'
@@ -790,11 +791,17 @@ function Shell() {
     [setTweak],
   )
 
-  // Toggle left sidebar visibility (Ctrl/Cmd+B). Reads the current value from
-  // the tweak snapshot and flips it; setTweak persists to localStorage.
+  const [quickTaskOpen, setQuickTaskOpen] = useState(false)
+
+  // Toggle left sidebar visibility. Kept for non-shortcut UI entry points; Ctrl/Cmd+B
+  // is now reserved for global quick task capture.
   const handleToggleSidebar = useCallback(() => {
     setTweak('sidebarHidden', !t.sidebarHidden)
   }, [setTweak, t.sidebarHidden])
+
+  const handleQuickTask = useCallback(() => {
+    setQuickTaskOpen(true)
+  }, [])
 
   // Global keyboard shortcuts.
   // The "newSession" shortcut (Cmd/Ctrl+N) now behaves the same as the sidebar
@@ -803,12 +810,14 @@ function Shell() {
     setTweak: setTweak as (key: string, val: unknown) => void,
     onNewSession: handleNewBlankSession,
     onToggleSidebar: handleToggleSidebar,
+    onQuickTask: handleQuickTask,
     hasOverlayOpen: () =>
       hasDialogOpen ||
       t.showPalette ||
       t.showPerm ||
       t.showProviderEdit ||
       t.showProfileEdit ||
+      quickTaskOpen ||
       isModalOverlayVisible(),
   })
 
@@ -1005,6 +1014,7 @@ function Shell() {
         )}
 
         {/* Overlays */}
+        <GlobalQuickTaskModal open={quickTaskOpen} onClose={() => setQuickTaskOpen(false)} />
         {t.showPalette && (
           <CommandPalette
             onClose={() => setTweak('showPalette', false)}

--- a/apps/desktop/src/renderer/design/components/GlobalQuickTaskModal.less
+++ b/apps/desktop/src/renderer/design/components/GlobalQuickTaskModal.less
@@ -1,0 +1,123 @@
+.quick-task-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 4200;
+  pointer-events: auto;
+}
+
+.quick-task-backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 20%, color-mix(in srgb, var(--brand, #6366f1) 22%, transparent), transparent 34%),
+    color-mix(in srgb, var(--bg, #f8fafc) 32%, rgba(15, 23, 42, 0.18));
+  backdrop-filter: blur(18px) saturate(1.25);
+  -webkit-backdrop-filter: blur(18px) saturate(1.25);
+}
+
+.quick-task-modal {
+  position: fixed;
+  width: min(600px, calc(100vw - 32px));
+  border: 1px solid color-mix(in srgb, var(--border, rgba(148, 163, 184, 0.28)) 74%, transparent);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--panel, #ffffff) 84%, transparent);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.42);
+  color: var(--text, #0f172a);
+  overflow: hidden;
+}
+
+.quick-task-drag-handle {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 22px 14px;
+  cursor: grab;
+  user-select: none;
+}
+
+.quick-task-drag-handle:active { cursor: grabbing; }
+.quick-task-kicker { font-size: 12px; font-weight: 700; color: var(--brand, #6366f1); letter-spacing: .12em; }
+.quick-task-drag-handle h2 { margin: 4px 0 0; font-size: 22px; line-height: 1.2; }
+
+.quick-task-close {
+  display: inline-grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--muted, #e2e8f0) 64%, transparent);
+  color: var(--muted-foreground, #64748b);
+}
+
+.quick-task-input {
+  display: block;
+  width: calc(100% - 44px);
+  min-height: 160px;
+  margin: 0 22px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--border, #cbd5e1) 72%, transparent);
+  border-radius: 18px;
+  resize: vertical;
+  background: color-mix(in srgb, var(--bg, #f8fafc) 72%, transparent);
+  color: inherit;
+  outline: none;
+  font: inherit;
+}
+
+.quick-task-input:focus {
+  border-color: color-mix(in srgb, var(--brand, #6366f1) 68%, var(--border, #cbd5e1));
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--brand, #6366f1) 16%, transparent);
+}
+
+.quick-task-attachments {
+  display: flex;
+  gap: 10px;
+  padding: 12px 22px 0;
+  overflow-x: auto;
+}
+
+.quick-task-thumb {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  padding: 0;
+  border: 1px solid var(--border, #cbd5e1);
+  border-radius: 16px;
+  overflow: hidden;
+  background: transparent;
+}
+.quick-task-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.quick-task-thumb span { position: absolute; top: 5px; right: 5px; display: grid; place-items: center; width: 18px; height: 18px; border-radius: 50%; background: rgba(15, 23, 42, .72); color: white; }
+
+.quick-task-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  padding: 16px 22px;
+}
+.quick-task-fields label { display: grid; gap: 6px; font-size: 12px; font-weight: 700; color: var(--muted-foreground, #64748b); }
+
+.quick-task-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 22px 20px;
+  border-top: 1px solid color-mix(in srgb, var(--border, #cbd5e1) 62%, transparent);
+  color: var(--muted-foreground, #64748b);
+  font-size: 12px;
+}
+
+[data-theme='dark'] .quick-task-modal,
+.theme-dark .quick-task-modal {
+  background: color-mix(in srgb, var(--panel, #111827) 82%, transparent);
+  box-shadow: 0 24px 90px rgba(0, 0, 0, 0.48), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 680px) {
+  .quick-task-modal { left: 16px !important; right: 16px; width: auto; }
+  .quick-task-fields { grid-template-columns: 1fr; }
+  .quick-task-footer { align-items: stretch; flex-direction: column; }
+}

--- a/apps/desktop/src/renderer/design/components/GlobalQuickTaskModal.tsx
+++ b/apps/desktop/src/renderer/design/components/GlobalQuickTaskModal.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button } from '@lobehub/ui'
+import { DatePicker, Select } from 'antd'
+import { Icons } from '../Icons'
+import { useApp } from '../AppContext'
+import { useSessionSidebar } from '../SessionSidebarContext'
+import './GlobalQuickTaskModal.less'
+
+type Priority = 'low' | 'medium' | 'high' | 'urgent'
+type TaskAttachment = {
+  id: string
+  type: 'image' | 'file'
+  name: string
+  path: string
+  previewPath?: string
+}
+
+type QuickTaskDefaults = {
+  project: string
+  processingAgent: string
+}
+
+const PRIORITY_OPTIONS: Array<{ label: string; value: Priority }> = [
+  { label: '低', value: 'low' },
+  { label: '中', value: 'medium' },
+  { label: '高', value: 'high' },
+  { label: '紧急', value: 'urgent' },
+]
+
+function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(blob)
+  })
+}
+
+function resolveImageSrc(filePath: string): string {
+  if (!filePath) return ''
+  if (filePath.startsWith('file://') || filePath.startsWith('data:')) return filePath
+  return `file://${filePath}`
+}
+
+function getInitialPosition() {
+  if (typeof window === 'undefined') return { x: 0, y: 0 }
+  return {
+    x: Math.max(24, Math.round(window.innerWidth / 2 - 300)),
+    y: Math.max(24, Math.round(window.innerHeight / 2 - 260)),
+  }
+}
+
+export function GlobalQuickTaskModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { t } = useApp()
+  const sessionCtx = useSessionSidebar()
+  const [content, setContent] = useState('')
+  const [project, setProject] = useState('')
+  const [processingAgent, setProcessingAgent] = useState('')
+  const [dueDate, setDueDate] = useState('')
+  const [priority, setPriority] = useState<Priority>('medium')
+  const [attachments, setAttachments] = useState<TaskAttachment[]>([])
+  const [submitting, setSubmitting] = useState(false)
+  const [position, setPosition] = useState(getInitialPosition)
+  const dragRef = useRef<{ startX: number; startY: number; x: number; y: number } | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  const agentOptions = useMemo(
+    () => sessionCtx.agents.filter((agent) => agent.enabled).map((agent) => ({ label: agent.name, value: agent.name, id: agent.id })),
+    [sessionCtx.agents],
+  )
+
+  const projectOptions = useMemo(
+    () => sessionCtx.projectGroups
+      .map((group) => group.workspace)
+      .filter((workspace) => workspace.name && workspace.name !== '不使用项目' && workspace.name !== 'No project')
+      .map((workspace) => ({ label: workspace.name, value: workspace.name, id: workspace.id })),
+    [sessionCtx.projectGroups],
+  )
+
+  const resolveDefaults = useCallback((): QuickTaskDefaults => {
+    const activeSession = sessionCtx.sessions.find((session) => session.id === sessionCtx.activeSessionId) ?? null
+    const workspaceId = activeSession?.workspaceIds[0] ?? sessionCtx.activeWorkspaceId ?? null
+    const workspace = workspaceId != null ? sessionCtx.workspaces.find((item) => item.id === workspaceId) : null
+    const agent = activeSession?.agentId != null
+      ? sessionCtx.agents.find((item) => item.id === activeSession.agentId)
+      : sessionCtx.agents.find((item) => item.isDefault) ?? sessionCtx.agents[0]
+    return {
+      project: t.view === 'chat' ? (workspace?.name ?? '') : '',
+      processingAgent: t.view === 'chat' ? (agent?.name ?? '') : (sessionCtx.agents.find((item) => item.isDefault)?.name ?? ''),
+    }
+  }, [sessionCtx.activeSessionId, sessionCtx.activeWorkspaceId, sessionCtx.agents, sessionCtx.sessions, sessionCtx.workspaces, t.view])
+
+  useEffect(() => {
+    if (!open) return
+    const timer = window.setTimeout(() => {
+      const defaults = resolveDefaults()
+      setProject(defaults.project)
+      setProcessingAgent(defaults.processingAgent)
+      setDueDate('')
+      setPriority('medium')
+      setAttachments([])
+      setPosition(getInitialPosition())
+      textareaRef.current?.focus()
+    }, 0)
+    return () => window.clearTimeout(timer)
+  }, [open, resolveDefaults])
+
+  const handlePaste = useCallback(async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const imageItems = Array.from(event.clipboardData?.items ?? []).filter((item) => item.type.startsWith('image/'))
+    if (imageItems.length === 0) return
+    event.preventDefault()
+    const newAttachments: TaskAttachment[] = []
+    for (let i = 0; i < imageItems.length; i += 1) {
+      const file = imageItems[i]?.getAsFile()
+      if (!file) continue
+      const dataUrl = await readBlobAsDataUrl(file)
+      const result = await window.spark.invoke('file:save-pasted-image', {
+        dataUrl,
+        suggestedBaseName: `quick-task-image-${i + 1}`,
+        ...(file.type ? { mimeType: file.type } : {}),
+      })
+      newAttachments.push({
+        id: `${Date.now()}-${i}-${result.filePath}`,
+        type: 'image',
+        name: result.fileName,
+        path: result.filePath,
+        previewPath: result.filePath,
+      })
+    }
+    if (newAttachments.length > 0) setAttachments((prev) => [...prev, ...newAttachments])
+  }, [])
+
+  const handleSubmit = useCallback(async () => {
+    const text = content.trim()
+    if (!text || submitting) return
+    setSubmitting(true)
+    try {
+      await window.spark.invoke('board:create', {
+        title: text.split('\n').find(Boolean)?.slice(0, 80) ?? '快捷任务',
+        description: text,
+        status: 'todo',
+        priority,
+        assignee: processingAgent,
+        project,
+        tags: [],
+        dueDate,
+        processingAgent,
+        acceptanceCriteria: '',
+        testAgent: '',
+        attachments,
+        sortOrder: 0,
+      })
+      window.dispatchEvent(new CustomEvent('spark:refresh-view'))
+      setContent('')
+      onClose()
+    } finally {
+      setSubmitting(false)
+    }
+  }, [attachments, content, dueDate, onClose, priority, processingAgent, project, submitting])
+
+  const handleMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    dragRef.current = { startX: event.clientX, startY: event.clientY, x: position.x, y: position.y }
+    event.preventDefault()
+  }, [position.x, position.y])
+
+  useEffect(() => {
+    if (!open) return
+    const handleMove = (event: MouseEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+      setPosition({
+        x: Math.max(12, Math.min(window.innerWidth - 120, drag.x + event.clientX - drag.startX)),
+        y: Math.max(12, Math.min(window.innerHeight - 80, drag.y + event.clientY - drag.startY)),
+      })
+    }
+    const handleUp = () => { dragRef.current = null }
+    window.addEventListener('mousemove', handleMove)
+    window.addEventListener('mouseup', handleUp)
+    return () => {
+      window.removeEventListener('mousemove', handleMove)
+      window.removeEventListener('mouseup', handleUp)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div className="quick-task-overlay" onMouseDown={(event) => { if (event.target === event.currentTarget) onClose() }}>
+      <div className="quick-task-backdrop" />
+      <section className="quick-task-modal" style={{ left: position.x, top: position.y }} onMouseDown={(event) => event.stopPropagation()}>
+        <div className="quick-task-drag-handle" onMouseDown={handleMouseDown}>
+          <div>
+            <span className="quick-task-kicker">快捷录入</span>
+            <h2>新建任务</h2>
+          </div>
+          <button className="quick-task-close" onClick={onClose} aria-label="关闭快捷任务录入">
+            <Icons.X size={16} />
+          </button>
+        </div>
+
+        <textarea
+          ref={textareaRef}
+          className="quick-task-input"
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          onPaste={handlePaste}
+          placeholder="直接输入任务正文；支持 Ctrl/Cmd+V 粘贴图片…"
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) void handleSubmit()
+            if (event.key === 'Escape') onClose()
+          }}
+        />
+
+        {attachments.length > 0 && (
+          <div className="quick-task-attachments">
+            {attachments.map((attachment) => (
+              <button key={attachment.id} className="quick-task-thumb" onClick={() => setAttachments((prev) => prev.filter((item) => item.id !== attachment.id))} title="点击移除图片">
+                <img src={resolveImageSrc(attachment.previewPath ?? attachment.path)} alt={attachment.name} />
+                <span><Icons.X size={10} /></span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="quick-task-fields">
+          <label>
+            <span>项目</span>
+            <Select value={project || undefined} onChange={(value) => setProject(value ?? '')} allowClear showSearch placeholder="选择项目" options={projectOptions} />
+          </label>
+          <label>
+            <span>执行 Agent</span>
+            <Select value={processingAgent || undefined} onChange={(value) => setProcessingAgent(value ?? '')} allowClear showSearch placeholder="选择 Agent" options={agentOptions} />
+          </label>
+          <label>
+            <span>到期时间</span>
+            <DatePicker value={dueDate || undefined} onChange={(dateString) => setDueDate(dateString ?? '')} placeholder="选择日期" style={{ width: '100%' }} allowClear />
+          </label>
+          <label>
+            <span>优先级</span>
+            <Select value={priority} onChange={(value) => setPriority(value)} options={PRIORITY_OPTIONS} />
+          </label>
+        </div>
+
+        <div className="quick-task-footer">
+          <span>快捷键：⌘/Ctrl + B 呼出，⌘/Ctrl + Enter 创建</span>
+          <Button type="primary" onClick={handleSubmit} disabled={!content.trim()} loading={submitting}>创建任务</Button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/design/hooks/useKeyboard.ts
+++ b/apps/desktop/src/renderer/design/hooks/useKeyboard.ts
@@ -81,7 +81,7 @@ export const DEFAULT_SHORTCUTS: ShortcutBinding[] = [
   { id: 'viewSkills',    label: 'Skills 视图',    key: '5', mod: true,  shift: false, description: '切换到 Skills 视图',             group: 'navigation' },
   { id: 'viewMcp',       label: 'MCP 视图',       key: '6', mod: true,  shift: false, description: '切换到 MCP 视图',                group: 'navigation' },
   { id: 'viewSettings',  label: 'Settings 快捷', key: '7', mod: true,  shift: false, description: '切换到 Settings 视图',           group: 'navigation' },
-  { id: 'toggleSidebar', label: '切换侧边栏',    key: 'b', mod: true,  shift: false, description: '折叠/展开侧边栏',               group: 'action' },
+  { id: 'toggleSidebar', label: '快捷录入任务',  key: 'b', mod: true,  shift: false, description: '打开全局任务快捷录入浮窗',       group: 'action' },
   { id: 'search',        label: '搜索',           key: 'f', mod: true,  shift: false, description: '聚焦搜索框（Chat 页面）',        group: 'action' },
   { id: 'escape',        label: '关闭',           key: 'Escape', mod: false, shift: false, description: '关闭当前对话框/面板/命令面板', group: 'action' },
   { id: 'focusComposer', label: '聚焦输入框',     key: 'l', mod: true,  shift: false, description: '聚焦聊天输入框并滚动到底部',     group: 'action' },
@@ -142,7 +142,9 @@ type ShortcutActions = {
   onNewSession?: () => void
   /** Optional: trigger a custom new-project action */
   onNewProject?: () => void
-  /** Optional: toggle the left sidebar visibility (Ctrl/Cmd+B) */
+  /** Optional: open the global quick task modal (Ctrl/Cmd+B) */
+  onQuickTask?: () => void
+  /** Optional: toggle the left sidebar visibility (legacy fallback) */
   onToggleSidebar?: () => void
   /** Optional: check if any overlay panel is currently open */
   hasOverlayOpen?: () => boolean
@@ -198,7 +200,7 @@ export function useGlobalShortcuts(actions: ShortcutActions): ShortcutBinding[] 
     }
 
     const shortcuts = shortcutsRef.current
-    const { setTweak, onSearchFocus, onNewSession, onNewProject, onToggleSidebar, hasOverlayOpen } = actionsRef.current
+    const { setTweak, onSearchFocus, onNewSession, onNewProject, onQuickTask, onToggleSidebar, hasOverlayOpen } = actionsRef.current
 
     for (const sc of shortcuts) {
       const modPressed = isMac ? e.metaKey : e.ctrlKey
@@ -256,9 +258,9 @@ export function useGlobalShortcuts(actions: ShortcutActions): ShortcutBinding[] 
             break
           }
           case 'toggleSidebar': {
-            // 切换左侧栏显隐。交给 onToggleSidebar 回调读取当前 sidebarHidden 并翻转，
-            // 避免 setTweak 一个无效伪键（旧实现 setTweak('__toggleSidebar', ...) 无人消费）。
-            onToggleSidebar?.()
+            // Ctrl/Cmd+B 现在用于全局快捷录入任务；保留 onToggleSidebar 作为旧调用方兜底。
+            if (onQuickTask) onQuickTask()
+            else onToggleSidebar?.()
             break
           }
           case 'search':


### PR DESCRIPTION
### Motivation
- Provide a fast, system-wide way to create board tasks without opening the full Board page by adding a global quick-capture floating window triggered by `Cmd/Ctrl+B`.
- Capture simple task text, pasted images and minimal metadata (project/agent/due date/priority) to reduce friction for quick notes and bug reports.
- Ensure the floating UI respects the app theme, supports a glassmorphism backdrop, is draggable, and fills contextual defaults when invoked from a chat session.

### Description
- Add a new component `GlobalQuickTaskModal` (`apps/desktop/src/renderer/design/components/GlobalQuickTaskModal.tsx`) and styles (`GlobalQuickTaskModal.less`) implementing a draggable, themed, centered floating modal with paste-to-attach image handling and fields for project/agent/due-date/priority.
- Wire the modal into the app shell: introduce `quickTaskOpen` state in `App.tsx` and mount `<GlobalQuickTaskModal open={quickTaskOpen} onClose={...} />` at the top-level overlays area so it participates in global overlay visibility.
- Change the global shortcut binding for `b` (Ctrl/Cmd+B) in `useGlobalShortcuts` (`apps/desktop/src/renderer/design/hooks/useKeyboard.ts`) to open the quick-capture modal, while keeping the previous sidebar-toggle handler as a fallback (`onToggleSidebar`).
- On submit the modal calls the existing IPC/bridge `board:create` to create tasks and dispatches a `spark:refresh-view` event to refresh views; pasted images are saved via `file:save-pasted-image` and attached to the created task.

### Testing
- Ran `git diff --check` which produced no whitespace errors and verified the working tree changes were as intended. (success)
- Ran ESLint on the modified files via `pnpm --filter @spark/desktop exec eslint ...` which passed (reported only a pre-existing `SidebarState` unused warning). (success)
- Ran TypeScript type-check via `pnpm --filter @spark/desktop typecheck` which failed due to existing unrelated type issues in sidebar files (`rightTop` placement type mismatch in `SidebarFilterMenu.tsx` / `SidebarSessionList.tsx`), not caused by the new quick-capture changes. (failed — unrelated existing errors)
- Attempted `npx gitnexus detect_changes` as required by repository rules, but the command could not complete because the environment returned `403 Forbidden` when fetching the `gitnexus` package, so final impact/detect checks could not complete. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b80238ce0832ebfed422b815a7cb7)