### PR TITLE
Add quote-selection context menu, pass selected text to reply flow, improve attachment previews and dialog behavior; UI tweaks

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -3537,14 +3537,14 @@ export function registerAllIpcHandlers(): void {
     const workspace = new WorkspaceRepository(getDatabase()).findByIdOrFail(req.workspaceId)
     // git check-ignore 对所有路径都不被忽略时退出码=1 → tryGitStdout catch 返回 null
     // 被忽略时退出码=0，stdout 用 -z 按 NUL 分隔列出被忽略路径
-    const out = await tryGitStdout(workspace.root_path, [
-      'check-ignore',
-      '-z',
-      '--',
-      ...req.paths,
-    ])
+    const out = await tryGitStdout(workspace.root_path, ['check-ignore', '-z', '--', ...req.paths])
     if (out == null || out === '') return { ignoredPaths: [] }
-    return { ignoredPaths: out.split('\0').map((s) => s.trim()).filter(Boolean) }
+    return {
+      ignoredPaths: out
+        .split('\0')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    }
   })
 
   typedIpcHandle('workspace:git-commit', async (req) => {
@@ -3711,11 +3711,14 @@ export function registerAllIpcHandlers(): void {
   })
 
   typedIpcHandle('dialog:open-file', async (req) => {
-    // allowDirectories=true：同一个对话框同时允许选「文件」和「目录」（用于「添加相关文件或目录」）
+    // allowDirectories=true：macOS 支持同一个对话框同时选择文件和目录；Windows/Linux
+    // 同时传 openFile + openDirectory 会退化成目录选择器，导致用户点文件后无法完成选择。
+    const canPickFilesAndDirectoriesTogether =
+      req.allowDirectories === true && process.platform === 'darwin'
     const baseProperties: Array<'openFile' | 'openDirectory' | 'multiSelections'> =
-      req.allowDirectories === true
+      canPickFilesAndDirectoriesTogether
         ? ['openFile', 'openDirectory', 'multiSelections']
-        : req.multiple === true
+        : req.multiple === true || req.allowDirectories === true
           ? ['openFile', 'multiSelections']
           : ['openFile']
     const result = await dialog.showOpenDialog({
@@ -6461,8 +6464,7 @@ async function getWorkspaceGitFileDiff(
 ): Promise<WorkspaceGitFileDiffResponse> {
   let diff = ''
   if (untracked) {
-    diff =
-      (await tryGitStdout(rootPath, ['diff', '--no-index', '--', '/dev/null', filePath])) ?? ''
+    diff = (await tryGitStdout(rootPath, ['diff', '--no-index', '--', '/dev/null', filePath])) ?? ''
   } else {
     diff = (await tryGitStdout(rootPath, ['diff', 'HEAD', '--', filePath])) ?? ''
     if (!diff.trim()) {

--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -1154,7 +1154,7 @@ body.sidebar-resizing {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 8px;
+  gap: 6px;
   width: min(80%, 100%);
   margin-bottom: 8px;
 }
@@ -1167,9 +1167,12 @@ body.sidebar-resizing {
 }
 
 .msg-user-image-card {
-  width: 92px;
-  border-radius: var(--r-sm);
-  border: 0.5px solid var(--border);
+  width: 96px;
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+  border-radius: var(--r-lg);
+  background: color-mix(in srgb, var(--panel) 86%, var(--bg-soft));
+  box-shadow: 0 6px 18px color-mix(in srgb, black 8%, transparent);
 }
 
 .msg-user-image-button {
@@ -1185,15 +1188,14 @@ body.sidebar-resizing {
 
 .msg-user-image-thumb,
 .msg-user-image-fallback {
-  display: block;
   width: 100%;
   aspect-ratio: 1 / 1;
-  border-radius: var(--r-lg);
-  background: color-mix(in srgb, var(--panel) 92%, var(--bg-soft));
-  box-shadow: 0 1px 3px color-mix(in srgb, black 10%, transparent);
+  border-radius: calc(var(--r-lg) - 4px);
+  background: color-mix(in srgb, var(--bg-soft) 90%, var(--panel));
 }
 
 .msg-user-image-thumb {
+  display: block;
   object-fit: cover;
 }
 
@@ -1208,11 +1210,37 @@ body.sidebar-resizing {
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 8px;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
 }
 
 .msg-user-file-chip {
-  max-width: 320px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: min(320px, 100%);
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--panel) 84%, var(--bg-soft));
+  color: var(--text-muted);
+  font-size: var(--font-sm);
+  line-height: 1.2;
+  box-shadow: 0 6px 18px color-mix(in srgb, black 6%, transparent);
+}
+
+.msg-user-file-chip svg {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.msg-user-file-chip span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .msg-agent {

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -263,7 +263,7 @@ type ContextMenuItem = {
 }
 type ReplyToState = {
   messageId: string
-  role: 'user' | 'assistant'
+  role: 'user' | 'assistant' | 'selection'
   agentId?: string
   agentName?: string
   contentPreview: string
@@ -945,8 +945,7 @@ export function ChatView({
 
   const isGitRepo = gitStatus?.isGitRepo === true
   // 右上角环境面板（git / 进程 / 目标）只要三者其一有内容即可展示，不再强依赖 git 仓库。
-  const hasEnvPanelContent =
-    isGitRepo || activeSessionTasks.length > 0 || activeSessionGoal != null
+  const hasEnvPanelContent = isGitRepo || activeSessionTasks.length > 0 || activeSessionGoal != null
 
   useEffect(() => {
     // 新会话默认收起右上角 git 悬浮面板，需要时由用户手动展开。
@@ -1284,14 +1283,30 @@ export function ChatView({
     }
   }
 
-  const handleReplyTo = useCallback((msg: UIMessage, agentId?: string, agentName?: string) => {
-    const preview = extractTextFromBlocks(msg.blocks).slice(0, 80).replace(/\n/g, ' ')
+  const handleReplyTo = useCallback(
+    (msg: UIMessage, agentId?: string, agentName?: string, selectedText?: string) => {
+      const source = selectedText?.trim() || extractTextFromBlocks(msg.blocks)
+      const preview = compactQuotePreview(source)
+      setReplyTo({
+        messageId: msg.id,
+        role: msg.role,
+        ...(agentId != null ? { agentId } : {}),
+        ...(agentName != null ? { agentName } : {}),
+        contentPreview: preview || '(附件/图片)',
+      })
+      setComposerFocusTrigger((n) => n + 1)
+    },
+    [],
+  )
+
+  const handleQuoteSelection = useCallback((text: string, label = '引用') => {
+    const preview = compactQuotePreview(text)
+    if (preview.length === 0) return
     setReplyTo({
-      messageId: msg.id,
-      role: msg.role,
-      ...(agentId != null ? { agentId } : {}),
-      ...(agentName != null ? { agentName } : {}),
-      contentPreview: preview || '(附件/图片)',
+      messageId: `selection-${Date.now()}`,
+      role: 'selection',
+      agentName: label,
+      contentPreview: preview,
     })
     setComposerFocusTrigger((n) => n + 1)
   }, [])
@@ -1561,6 +1576,7 @@ export function ChatView({
       className={`chat-layout chat-layout-no-sidebar${teamConfig.enabled ? ' team-mode-active' : ''}`}
       ref={chatLayoutRef}
     >
+      <SelectionQuoteContextMenu onQuote={handleQuoteSelection} />
       <div
         className={`chat-main ${showEmptyHero ? 'chat-main-empty' : 'chat-main-active'}${
           !showEmptyHero && showGitEnvPanel ? ' git-env-panel-open' : ''
@@ -1724,6 +1740,7 @@ export function ChatView({
               scrollToBottomTrigger={scrollToBottomTrigger}
               teamConfig={teamConfig}
               onFilePreview={handleFilePreview}
+              onReplyTo={handleReplyTo}
               onResendMessage={handleResendMessage}
               onLoadingChange={setActiveSessionLoading}
               emptyStateVariant="loading"
@@ -1804,9 +1821,7 @@ export function ChatView({
         <UnifiedSessionSidePanel
           tabs={unifiedSideTabs}
           activeTab={
-            activeUnifiedSideTab != null
-              ? activeUnifiedSideTab
-              : unifiedSideTabs[0] ?? null
+            activeUnifiedSideTab != null ? activeUnifiedSideTab : (unifiedSideTabs[0] ?? null)
           }
           width={sideChatWidth}
           onWidthChange={setSideChatWidth}
@@ -1883,6 +1898,7 @@ export function ChatView({
                     teamConfig={teamConfig}
                     onFilePreview={handleFilePreview}
                     onLoadingChange={() => {}}
+                    onReplyTo={handleReplyTo}
                   />
                   <ComposerV2
                     session={sideChatSession}
@@ -2923,12 +2939,7 @@ function ChatTabbar({
         )}
       </div>
       <div className="row tabbar-actions">
-        {(
-          isGitRepo ||
-          taskCount > 0 ||
-          taskCompletedCount > 0 ||
-          hasGoal
-        ) ? (
+        {isGitRepo || taskCount > 0 || taskCompletedCount > 0 || hasGoal ? (
           <GitSessionTrigger
             open={showGitEnvPanel}
             isGitRepo={isGitRepo}
@@ -3033,13 +3044,9 @@ function buildAgentCommitMessage(includeUnstaged: boolean, push: boolean): strin
     '2. 生成简洁、可读的提交信息，必要时在 body 补充说明。',
   ]
   if (includeUnstaged) {
-    lines.push(
-      '3. 暂存全部相关更改（含未暂存的）后再提交，例如 `git add -A` 或按需选择文件。',
-    )
+    lines.push('3. 暂存全部相关更改（含未暂存的）后再提交，例如 `git add -A` 或按需选择文件。')
   } else {
-    lines.push(
-      '3. 仅提交当前已暂存的更改，不要对未暂存的内容执行 git add。',
-    )
+    lines.push('3. 仅提交当前已暂存的更改，不要对未暂存的内容执行 git add。')
   }
   if (push) {
     lines.push(
@@ -4140,7 +4147,7 @@ function ChatStream({
   /** 当前会话历史的加载状态变化（用于父级抑制「空会话 hero」误闪） */
   onLoadingChange?: (loading: boolean) => void
   teamConfig: TeamModeConfig
-  onReplyTo?: (msg: UIMessage, agentId?: string, agentName?: string) => void
+  onReplyTo?: (msg: UIMessage, agentId?: string, agentName?: string, selectedText?: string) => void
   onFilePreview?: (filePath: string, fileType: PreviewFileType) => void
   /** 重发：用户消息上"重发"按钮触发，把 blocks+attachments 重新塞回输入区 */
   onResendMessage?: (payload: ComposerPrefillPayload) => void
@@ -4257,7 +4264,10 @@ function ChatStream({
     // 历史加载后批量过滤 turn_file_summary 中被 .gitignore 忽略的路径（编译产物等噪音）。
     // fire-and-forget：无变化时 filter 函数返回原引用，setMessages 不会被触发。
     const wsId = workspaceIdRef.current
-    if (wsId != null && nextMessages.some((m) => m.blocks.some((b) => b.kind === 'turn_file_summary'))) {
+    if (
+      wsId != null &&
+      nextMessages.some((m) => m.blocks.some((b) => b.kind === 'turn_file_summary'))
+    ) {
       void filterTurnSummaryIgnoredPaths(nextMessages, wsId).then((filtered) => {
         if (filtered === nextMessages) return
         setMessages(filtered)
@@ -4860,7 +4870,12 @@ function ChatStream({
                     }
                   : {})}
                 onDelete={() => handleDeleteMessage(msg.id, msg.eventIds)}
-                {...(onReplyTo != null ? { onReply: () => onReplyTo(msg) } : {})}
+                {...(onReplyTo != null
+                  ? {
+                      onReply: (selectedText?: string) =>
+                        onReplyTo(msg, undefined, undefined, selectedText),
+                    }
+                  : {})}
                 {...(onResendMessage != null
                   ? {
                       onResend: () =>
@@ -4899,7 +4914,10 @@ function ChatStream({
                       ? { onDelete: () => handleDeleteMessage(msg.id, msg.eventIds) }
                       : {})}
                     {...(onReplyTo != null && msg.status !== 'streaming'
-                      ? { onReply: () => onReplyTo(msg, identity.id, identity.name) }
+                      ? {
+                          onReply: (selectedText?: string) =>
+                            onReplyTo(msg, identity.id, identity.name, selectedText),
+                        }
                       : {})}
                   />
                 )
@@ -7179,6 +7197,45 @@ function TextEditContextMenu({ menu, onClose }: { menu: TextEditMenuState; onClo
   return <InlineContextMenu x={menu.x} y={menu.y} items={items} onClose={onClose} />
 }
 
+function SelectionQuoteContextMenu({
+  onQuote,
+}: {
+  onQuote: (text: string, label?: string) => void
+}) {
+  const [menu, setMenu] = useState<{ x: number; y: number; text: string } | null>(null)
+
+  useEffect(() => {
+    const handleContextMenu = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target?.closest('.composer, .context-action-menu, .action-menu') != null) return
+      const selection = window.getSelection?.()
+      const text = selection?.toString().trim() ?? ''
+      if (text.length === 0 || selection?.isCollapsed) return
+      event.preventDefault()
+      setMenu({ x: event.clientX, y: event.clientY, text })
+    }
+    window.addEventListener('contextmenu', handleContextMenu)
+    return () => window.removeEventListener('contextmenu', handleContextMenu)
+  }, [])
+
+  if (menu == null) return null
+  return (
+    <InlineContextMenu
+      x={menu.x}
+      y={menu.y}
+      onClose={() => setMenu(null)}
+      items={[
+        {
+          key: 'quote-selection',
+          label: '引用对话',
+          icon: <Icons.CornerUpLeft size={14} />,
+          onClick: () => onQuote(menu.text, '选中内容'),
+        },
+      ]}
+    />
+  )
+}
+
 async function editTextSelection(
   target: HTMLTextAreaElement | HTMLInputElement,
   action: 'cut' | 'copy' | 'paste',
@@ -7234,7 +7291,7 @@ const UserMsg = React.memo(
     onDelete?: () => void
     /** 团队模式：用户 @ 指定的 Agent 名称（已解析）；用于显示"→ 已直接由 @X 处理"提示 */
     mentionAgentName?: string | undefined
-    onReply?: () => void
+    onReply?: (selectedText?: string) => void
     /** 重发：把这条消息的文本+附件重新塞回输入区 */
     onResend?: () => void
   }) {
@@ -7243,22 +7300,33 @@ const UserMsg = React.memo(
       x: number
       y: number
       imageSrc?: string
+      selectedText?: string
     } | null>(null)
 
     const handleContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
       event.preventDefault()
       const target = event.target as HTMLElement | null
       const image = target?.closest('img') as HTMLImageElement | null
+      const selectedText = readSelectedTextWithin(event.currentTarget)
       setContextMenu({
         x: event.clientX,
         y: event.clientY,
         ...(image != null ? { imageSrc: image.currentSrc || image.src } : {}),
+        ...(selectedText.length > 0 ? { selectedText } : {}),
       })
     }, [])
 
     const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
       if (contextMenu == null) return []
       const items: ContextMenuItem[] = []
+      if (contextMenu.selectedText != null && onReply != null) {
+        items.push({
+          key: 'quote-selection',
+          label: '引用对话',
+          icon: <Icons.CornerUpLeft size={14} />,
+          onClick: () => onReply(contextMenu.selectedText),
+        })
+      }
       if (contextMenu.imageSrc != null) {
         items.push({
           key: 'copy-image',
@@ -7284,7 +7352,7 @@ const UserMsg = React.memo(
           key: 'reply',
           label: '回复',
           icon: <Icons.CornerUpLeft size={14} />,
-          onClick: onReply,
+          onClick: () => onReply(),
         })
       }
       if (onDelete != null) {
@@ -7624,7 +7692,7 @@ const AssistantMessageRows = React.memo(function AssistantMessageRows({
   assistantName: string
   assistantAvatarSrc: string
   onDelete?: () => void
-  onReply?: () => void
+  onReply?: (selectedText?: string) => void
   onFilePreview?: (filePath: string, fileType: PreviewFileType) => void
 }) {
   const segments = splitAssistantMessageBlocks(blocks)
@@ -7817,7 +7885,7 @@ const AgentMsg = React.memo(function AgentMsg({
   assistantAvatarSrc: string
   running?: boolean
   onDelete?: () => void
-  onReply?: () => void
+  onReply?: (selectedText?: string) => void
   onFilePreview?: (filePath: string, fileType: PreviewFileType) => void
 }) {
   // 首个"内容块"出现前的连续思考 → 顶部思考模块；其后穿插的阶段性思考保留在内容流里
@@ -7831,8 +7899,8 @@ const AgentMsg = React.memo(function AgentMsg({
   )
   const isLeadingThinking = (b: UIBlock, i: number): boolean =>
     b.kind === 'thinking' && (firstContentIdx === -1 || i < firstContentIdx)
-  const leadingThinkingBlocks = blocks.filter(
-    (b, i): b is Extract<UIBlock, { kind: 'thinking' }> => isLeadingThinking(b, i),
+  const leadingThinkingBlocks = blocks.filter((b, i): b is Extract<UIBlock, { kind: 'thinking' }> =>
+    isLeadingThinking(b, i),
   )
   const contentBlocks = reorderTurnSummaryBlocks(
     blocks.filter(
@@ -7868,22 +7936,33 @@ const AgentMsg = React.memo(function AgentMsg({
     x: number
     y: number
     imageSrc?: string
+    selectedText?: string
   } | null>(null)
 
   const handleContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     event.preventDefault()
     const target = event.target as HTMLElement | null
     const image = target?.closest('img') as HTMLImageElement | null
+    const selectedText = readSelectedTextWithin(event.currentTarget)
     setContextMenu({
       x: event.clientX,
       y: event.clientY,
       ...(image != null ? { imageSrc: image.currentSrc || image.src } : {}),
+      ...(selectedText.length > 0 ? { selectedText } : {}),
     })
   }, [])
 
   const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
     if (contextMenu == null) return []
     const items: ContextMenuItem[] = []
+    if (contextMenu.selectedText != null && onReply != null) {
+      items.push({
+        key: 'quote-selection',
+        label: '引用对话',
+        icon: <Icons.CornerUpLeft size={14} />,
+        onClick: () => onReply(contextMenu.selectedText),
+      })
+    }
     if (contextMenu.imageSrc != null) {
       items.push({
         key: 'copy-image',
@@ -7909,7 +7988,7 @@ const AgentMsg = React.memo(function AgentMsg({
         key: 'reply',
         label: '回复',
         icon: <Icons.CornerUpLeft size={14} />,
-        onClick: onReply,
+        onClick: () => onReply(),
       })
     }
     if (onDelete != null) {
@@ -10163,6 +10242,14 @@ function ComposerV2({
             path: filePath,
             name: getFileNameFromPath(filePath),
           }
+          if (type === 'image') {
+            try {
+              const preview = await prepareImagePreview({ sourcePath: filePath })
+              return { ...attachment, previewPath: preview.filePath, previewUrl: preview.fileUrl }
+            } catch {
+              return attachment
+            }
+          }
           return attachment
         }),
       )
@@ -10171,7 +10258,7 @@ function ComposerV2({
       console.error('添加相关文件或目录失败', err)
       toast.error(err instanceof Error ? err.message : '添加相关文件或目录失败')
     }
-  }, [appendAttachments, openFileDialog, statFileKind, toast])
+  }, [appendAttachments, openFileDialog, prepareImagePreview, statFileKind, toast])
 
   const handlePaste = useCallback(
     async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -11170,7 +11257,11 @@ function ComposerV2({
             <div className="flex items-center gap-1.5 px-3 pt-2 pb-1 text-xs text-[var(--color-text-3)]">
               <div className="flex-1 min-w-0 flex items-center gap-1.5">
                 <span className="shrink-0 text-[var(--color-primary-6)]">
-                  {replyTo.role === 'assistant' ? (replyTo.agentName ?? 'Agent') : 'You'}
+                  {replyTo.role === 'assistant'
+                    ? (replyTo.agentName ?? 'Agent')
+                    : replyTo.role === 'selection'
+                      ? (replyTo.agentName ?? '引用')
+                      : 'You'}
                 </span>
                 <span className="truncate text-[var(--color-text-3)] opacity-80">
                   {replyTo.contentPreview}
@@ -12725,6 +12816,23 @@ async function copyImageFromSrc(src: string): Promise<void> {
   await navigator.clipboard.write([new ClipboardItemCtor({ [blob.type || 'image/png']: blob })])
 }
 
+function compactQuotePreview(text: string, max = 220): string {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  return normalized.length > max ? `${normalized.slice(0, max - 1)}…` : normalized
+}
+
+function readSelectedTextWithin(root: HTMLElement): string {
+  const selection = window.getSelection?.()
+  if (selection == null || selection.isCollapsed) return ''
+  const text = selection.toString().trim()
+  if (text.length === 0) return ''
+  const anchor = selection.anchorNode
+  const focus = selection.focusNode
+  const contains = (node: Node | null) =>
+    node != null && root.contains(node.nodeType === Node.ELEMENT_NODE ? node : node.parentNode)
+  return contains(anchor) || contains(focus) ? text : ''
+}
+
 function getFileNameFromPath(filePath: string): string {
   return filePath.split(/[\\/]/).filter(Boolean).pop() ?? filePath
 }
@@ -13134,7 +13242,9 @@ function normalizeEnvConfig(value: unknown): EnvConfigGetResponse {
   return {
     project: normalizeEnvLayer(config.project),
     session: normalizeEnvLayer(config.session),
-    effectiveEnv: isRecord(config.effectiveEnv) ? (config.effectiveEnv as Record<string, string>) : {},
+    effectiveEnv: isRecord(config.effectiveEnv)
+      ? (config.effectiveEnv as Record<string, string>)
+      : {},
   }
 }
 


### PR DESCRIPTION
### Motivation

- Enable users to quote arbitrary selected text from messages into the composer and make reply actions aware of selections. 
- Improve UX for adding image attachments by generating previews and avoid broken file/dialog behavior across platforms when selecting files vs directories. 
- Polish message attachment/file UI visuals for a more consistent, modern look.

### Description

- Add selection quoting support including a global `SelectionQuoteContextMenu` that offers `引用对话` on text selection and new helpers `compactQuotePreview` and `readSelectedTextWithin` to normalize previews and scope selections. 
- Extend reply types and handlers: `ReplyToState` adds a `selection` role, `onReplyTo` callbacks accept an optional `selectedText`, and the reply creation (`handleReplyTo`) accepts selected text and builds previews accordingly; selection quotes receive synthetic message IDs. 
- Wire selection quoting into message components: `UserMsg`, `AssistantMessageRows`, `AgentMsg`, and `ChatStream` now surface selection-aware reply menu items and pass `selectedText` to the parent handler. 
- Add image preview generation when adding context files in `ComposerV2` by calling `prepareImagePreview` for image attachments; fall back gracefully on failure. 
- Fix `dialog:open-file` behavior on macOS vs Windows/Linux by only allowing simultaneous file+directory selection on macOS (`process.platform === 'darwin'`) to avoid degraded dialog on other platforms. 
- Update CSS for user message attachments and file chips: adjust sizes, gaps, borders, background mixes, radii, shadows, and add styles for inline SVG and truncated filenames. 
- Minor formatting and small refactors across IPC and git utilities (array formatting, small parsing tweaks) with no behavioral change to git core commands.

### Testing

- Ran TypeScript typecheck and project build via `yarn build`, which completed successfully. 
- Ran unit tests with `yarn test`, and test suites passed. 
- Ran linter `yarn lint` and fixed style anomalies; lint passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b817656108325a22e42987de62ff9)