### PR TITLE
feat(composer): visually distinguish team @mentions and skill tokens in composer input

### DIFF
--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -3291,8 +3291,55 @@ body.sidebar-resizing {
   transition: height 0.12s ease;
   overflow-y: auto;
 }
+.composer-input-shell {
+  position: relative;
+}
+.composer-v2 .composer-input-shell textarea.composer-input {
+  position: relative;
+  z-index: 1;
+  color: transparent;
+  caret-color: var(--text);
+  -webkit-text-fill-color: transparent;
+}
+.composer-v2 .composer-input-shell textarea.composer-input::placeholder {
+  color: var(--text-faint);
+  -webkit-text-fill-color: var(--text-faint);
+}
+.composer-input-highlights {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  padding: 14px 70px 48px 16px;
+  min-height: 92px;
+  max-height: 320px;
+  font-family: inherit;
+  font-size: var(--font-base);
+  line-height: 1.55;
+  color: var(--text);
+}
+.composer-input-token {
+  border-radius: 7px;
+  font-weight: 650;
+}
+.composer-input-token-agent {
+  color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+}
+.composer-input-token-skill {
+  color: var(--warning);
+  background: color-mix(in srgb, var(--warning) 12%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--warning) 20%, transparent);
+}
 /* 展开态：放宽 max-height，让 JS 里的 520px 能真正生效（默认 320px 会反向 cap 住） */
 .composer.composer-v2.expanded textarea {
+  max-height: 520px;
+}
+.composer.composer-v2.expanded .composer-input-highlights {
   max-height: 520px;
 }
 .composer-expand-btn {

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -10577,6 +10577,33 @@ function ComposerV2({
     return list
   }, [teamConfig.enabled, teamConfig.hostAgentId, teamConfig.memberAgentIds, agents])
 
+  const composerHighlightParts = useMemo(() => {
+    const agentNames = teamConfig.enabled
+      ? new Set(mentionCandidates.map((candidate) => candidate.name))
+      : new Set<string>()
+    const parts: Array<{ text: string; kind?: 'agent' | 'skill' }> = []
+    const tokenPattern = /(^|\s)([@/])([^\s@/]+)/g
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+
+    while ((match = tokenPattern.exec(value)) != null) {
+      const prefix = match[1] ?? ''
+      const marker = match[2] ?? ''
+      const name = match[3] ?? ''
+      const tokenStart = match.index + prefix.length
+      const tokenEnd = tokenStart + marker.length + name.length
+      const kind = marker === '@' && agentNames.has(name) ? 'agent' : 'skill'
+
+      if (tokenStart > lastIndex) parts.push({ text: value.slice(lastIndex, tokenStart) })
+      parts.push({ text: value.slice(tokenStart, tokenEnd), kind })
+      lastIndex = tokenEnd
+    }
+
+    if (lastIndex < value.length) parts.push({ text: value.slice(lastIndex) })
+    if (parts.length === 0) parts.push({ text: value.length > 0 ? value : ' ' })
+    return parts
+  }, [mentionCandidates, teamConfig.enabled, value])
+
   // 过滤后的候选列表（用于键盘导航边界）
   const filteredMentionCandidates = useMemo(() => {
     const q = mentionQuery.trim().toLowerCase()
@@ -11449,29 +11476,57 @@ function ComposerV2({
               </button>
             </div>
           )}
-          <textarea
-            className="composer-input"
-            ref={textareaRef}
-            rows={1}
-            placeholder={composerPlaceholder}
-            value={value}
-            onChange={(event) => handleValueChange(event.target.value)}
-            onCompositionStart={() => {
-              composingRef.current = true
-            }}
-            onCompositionEnd={() => {
-              composingRef.current = false
-            }}
-            onPaste={(event) => {
-              void handlePaste(event)
-            }}
-            onKeyDown={handleKeyDown}
-            onContextMenu={handleTextContextMenu}
-            onBlur={() => {
-              // 失焦时延迟关闭 mention 弹窗，让 onClick 先执行
-              setTimeout(() => closeMentionPopup(), 150)
-            }}
-          />
+          <div className="composer-input-shell">
+            {value.length > 0 && (
+              <div className="composer-input-highlights" aria-hidden="true">
+                {composerHighlightParts.map((part, index) => (
+                  <span
+                    // eslint-disable-next-line react/no-array-index-key
+                    key={`${index}-${part.kind ?? 'text'}`}
+                    className={
+                      part.kind === 'agent'
+                        ? 'composer-input-token composer-input-token-agent'
+                        : part.kind === 'skill'
+                          ? 'composer-input-token composer-input-token-skill'
+                          : undefined
+                    }
+                  >
+                    {part.text}
+                  </span>
+                ))}
+              </div>
+            )}
+            <textarea
+              className="composer-input"
+              ref={textareaRef}
+              rows={1}
+              placeholder={composerPlaceholder}
+              value={value}
+              onChange={(event) => handleValueChange(event.target.value)}
+              onScroll={(event) => {
+                const layer = event.currentTarget
+                  .previousElementSibling as HTMLDivElement | null
+                if (layer == null) return
+                layer.scrollTop = event.currentTarget.scrollTop
+                layer.scrollLeft = event.currentTarget.scrollLeft
+              }}
+              onCompositionStart={() => {
+                composingRef.current = true
+              }}
+              onCompositionEnd={() => {
+                composingRef.current = false
+              }}
+              onPaste={(event) => {
+                void handlePaste(event)
+              }}
+              onKeyDown={handleKeyDown}
+              onContextMenu={handleTextContextMenu}
+              onBlur={() => {
+                // 失焦时延迟关闭 mention 弹窗，让 onClick 先执行
+                setTimeout(() => closeMentionPopup(), 150)
+              }}
+            />
+          </div>
           {textEditMenu != null && (
             <TextEditContextMenu menu={textEditMenu} onClose={() => setTextEditMenu(null)} />
           )}


### PR DESCRIPTION
### Motivation
- Make composer input clearer by visually distinguishing team-mode `@助手` mentions from skill-like tokens (`/...` or `@...`) so users can identify when they target an agent vs. inserting a skill reference. 
- Preserve native textarea behavior while providing a styled highlight layer to match existing UI patterns in other apps.

### Description
- Parse composer text and construct `composerHighlightParts` to detect tokens and classify them as `agent` (team-mode matches) or `skill` (fallback). (apps/desktop/src/renderer/design/views/ChatView.tsx)
- Render a synchronized highlight layer behind the native textarea (`.composer-input-shell` + `.composer-input-highlights`) and keep the textarea interactive; scroll is synchronized so highlights align with the typed text. (apps/desktop/src/renderer/design/views/ChatView.tsx)
- Add CSS rules to theme agent mentions (`composer-input-token-agent`) with the primary color and bold styling and skill tokens (`composer-input-token-skill`) with a warning-colored badge treatment, while keeping placeholder/caret behavior intact. (apps/desktop/src/renderer/design/styles/views.css)
- Token recognition handles leading whitespace and markers `@` and `/`, and the classification checks current mention candidates when team mode is enabled.

### Testing
- Ran `pnpm --filter @spark/desktop exec tsc --noEmit -p tsconfig.json`; the renderer/typecheck step for the modified code completed (renderer compilation invoked successfully). (succeeded)
- Ran full workspace typecheck via `pnpm --filter @spark/desktop typecheck`; full desktop typecheck failed due to an unrelated main-process typing error (`ProviderService.revealApiKey` missing) that exists outside these changes. (renderer pass / full desktop typecheck failed)
- Ran ESLint on the modified file; lint reported many pre-existing issues in this large file and flagged rule errors unrelated to the highlight layer. (ESLint reported failures from pre-existing rules)
- Attempted GitNexus impact/detect checks (`npx gitnexus impact` / `npx gitnexus detect_changes`) but the GitNexus CLI could not be executed in this environment due to registry 403 preventing installation; local code inspection indicates the change is UI-only and risk is assessed as Medium (affects composer rendering and mention/skill visuals but not send/IPC protocols). (blocked)

If you want, I can follow up with: run focused unit/visual tests for the composer input, add a small integration test to assert highlight rendering, or adjust token styling/thresholds after a quick UX pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b877bc578832ebefcb8008dc8ed9c)