### PR TITLE
fix: avoid window auto-fit during panel drag resize

### DIFF
--- a/apps/desktop/src/renderer/design/views/BrowserPanelView.tsx
+++ b/apps/desktop/src/renderer/design/views/BrowserPanelView.tsx
@@ -40,6 +40,12 @@ export function BrowserPanelView(): ReactElement | null {
   const panelOpenTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const open = t.browserPanelOpen
 
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove('browser-panel-resizing')
+    }
+  }, [])
+
   // Load initial status + subscribe to status updates
   useEffect(() => {
     const loadStatus = async (): Promise<void> => {
@@ -143,6 +149,7 @@ export function BrowserPanelView(): ReactElement | null {
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault()
+      e.stopPropagation()
       // Capture parent container width to clamp panel so it never overflows
       const containerWidth = (panelRef.current?.parentElement?.clientWidth ?? window.innerWidth)
       dragState.current = {
@@ -153,6 +160,7 @@ export function BrowserPanelView(): ReactElement | null {
         containerWidth,
       }
       setDragging(true)
+      document.body.classList.add('browser-panel-resizing')
       const onMove = (ev: MouseEvent): void => {
         const s = dragState.current
         if (s == null) return
@@ -178,6 +186,7 @@ export function BrowserPanelView(): ReactElement | null {
         if (s != null) setTweak('browserPanelWidth', s.latestWidth)
         dragState.current = null
         setDragging(false)
+        document.body.classList.remove('browser-panel-resizing')
         window.removeEventListener('mousemove', onMove)
         window.removeEventListener('mouseup', onUp)
       }

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -1100,9 +1100,19 @@ export function ChatView({
     const layout = chatLayoutRef.current
     if (layout == null) return
     let rafId = 0
+    const isManualPanelResizeActive = () =>
+      document.body.classList.contains('inspector-resizing') ||
+      document.body.classList.contains('side-chat-resizing') ||
+      document.body.classList.contains('browser-panel-resizing')
     const scheduleEnsure = () => {
       window.cancelAnimationFrame(rafId)
-      rafId = window.requestAnimationFrame(() => ensureChatLayoutFitsWindow(true))
+      rafId = window.requestAnimationFrame(() => {
+        // Width auto-fit is reserved for structural panel open/close and window
+        // changes. User drag-resizes intentionally override the current layout,
+        // so do not grow/shrink the app while a panel resize gesture is active.
+        if (isManualPanelResizeActive()) return
+        ensureChatLayoutFitsWindow(true)
+      })
     }
 
     scheduleEnsure()


### PR DESCRIPTION
### Motivation
- Manual drag-resizing of side panels (browser/inspector/side-chat) was triggering the app's automatic width-fitting logic and causing the whole UI to jump/auto-expand during user gestures instead of honoring the manual resize intent.
- The expected behavior is that only explicit structural actions (open/close panels) or window resizes trigger auto-fit, while manual pointer drags should temporarily suspend auto-expansion.

### Description
- Mark browser panel drag gestures by adding/removing a `browser-panel-resizing` class on `document.body` during the drag lifecycle and ensure cleanup on unmount in `BrowserPanelView` (`apps/desktop/src/renderer/design/views/BrowserPanelView.tsx`).
- Prevent the browser panel mousedown from bubbling by calling `e.stopPropagation()` so the gesture is treated as an explicit manual resize.
- In `ChatView` (`apps/desktop/src/renderer/design/views/ChatView.tsx`) add `isManualPanelResizeActive()` which checks `inspector-resizing`, `side-chat-resizing`, and `browser-panel-resizing`, and guard the auto-fit scheduler to skip calling `ensureChatLayoutFitsWindow` while any manual panel resize gesture is active.
- Preserve existing auto-fit behavior for structural changes and window resizes; the change only suppresses auto-fit while a user is actively dragging panel edges.

### Testing
- Ran TypeScript check with `pnpm --filter @spark/desktop typecheck`, which failed due to an existing unrelated type error in the main process (`ProviderService.revealApiKey`) and not because of the resize changes. (failed)
- Ran lint on the two modified files with `pnpm --filter @spark/desktop exec eslint src/renderer/design/views/BrowserPanelView.tsx src/renderer/design/views/ChatView.tsx`, which surfaced pre-existing lint debt in the large `ChatView` file and a small warning in `BrowserPanelView`; no new lint rules were introduced by this change. (failed)
- Attempted repository impact/diff check with `npx gitnexus detect_changes --scope all` per repo guidance, but the CLI run did not produce a useful diagnostic and exited with an error during the attempt. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b8aac497c8323bdfd8b176fc77d53)