### PR TITLE
feat(canvas): add undo/redo history and remove demo task completion

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasBottomDock.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasBottomDock.tsx
@@ -26,9 +26,13 @@ export function CanvasBottomDock({
   onOpenShotDirector,
   onOpenAgent,
   onDeleteSelected,
+  onUndo,
+  onRedo,
   onToggleGrid,
   gridVisible,
   selectedCount,
+  canUndo,
+  canRedo,
 }: {
   activeTool: CanvasTool
   onToolChange: (tool: CanvasTool) => void
@@ -39,15 +43,18 @@ export function CanvasBottomDock({
   onOpenShotDirector: () => void
   onOpenAgent: () => void
   onDeleteSelected: () => void
+  onUndo: () => void
+  onRedo: () => void
   onToggleGrid: () => void
   gridVisible: boolean
   selectedCount: number
+  canUndo: boolean
+  canRedo: boolean
 }) {
   const items = useAddNodeMenuItems()
   const [addMenuOpen, setAddMenuOpen] = useState(false)
   const contentItems = items.filter((item) => item.category === 'content')
-  const deleteTooltip =
-    selectedCount > 0 ? `删除选中节点（${selectedCount}）` : '选择节点后可删除'
+  const deleteTooltip = selectedCount > 0 ? `删除选中节点（${selectedCount}）` : '选择节点后可删除'
   const openAddMenu = () => {
     onOpenAddMenu()
     setAddMenuOpen(true)
@@ -94,7 +101,12 @@ export function CanvasBottomDock({
 
         <div className="canvas-bottom-dock-group">
           {contentItems
-            .filter((item) => item.id === 'content:text' || item.id === 'content:image' || item.id === 'content:group')
+            .filter(
+              (item) =>
+                item.id === 'content:text' ||
+                item.id === 'content:image' ||
+                item.id === 'content:group',
+            )
             .map((item) => (
               <Tooltip key={item.id} title={item.label} placement="top">
                 <Button
@@ -185,8 +197,25 @@ export function CanvasBottomDock({
               onClick={onToggleGrid}
             />
           </Tooltip>
-          <Tooltip title="撤销" placement="top">
-            <Button size="small" type="text" icon={<Icons.RotateCcw size={15} />} disabled />
+          <Tooltip title={canUndo ? '撤销上一步画布操作' : '暂无可撤销操作'} placement="top">
+            <Button
+              size="small"
+              type="text"
+              icon={<Icons.RotateCcw size={15} />}
+              aria-label="撤销"
+              disabled={!canUndo}
+              onClick={() => closeAddMenuAndRun(onUndo)}
+            />
+          </Tooltip>
+          <Tooltip title={canRedo ? '重做上一步画布操作' : '暂无可重做操作'} placement="top">
+            <Button
+              size="small"
+              type="text"
+              icon={<Icons.RotateCw size={15} />}
+              aria-label="重做"
+              disabled={!canRedo}
+              onClick={() => closeAddMenuAndRun(onRedo)}
+            />
           </Tooltip>
         </div>
 

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, type ReactNode } from 'react'
 import { Button, Tag } from '@lobehub/ui'
 import { Descriptions, Empty, Modal, Progress, Space } from 'antd'
 import { Icons } from '../../Icons'
-import { isMediaOperation, operationLabel } from './canvas.api'
+import { operationLabel } from './canvas.api'
 import type { CanvasAsset, CanvasNode, CanvasTask, CanvasTaskStatus } from './canvas.types'
 
 type TaskFilter = 'all' | 'active' | 'failed' | 'completed'
@@ -11,7 +11,6 @@ export function CanvasTaskQueue({
   tasks,
   nodes,
   assets,
-  onCompleteDemoTask,
   onCancelTask,
   onRetryTask,
   onSelectNode,
@@ -19,7 +18,6 @@ export function CanvasTaskQueue({
   tasks: CanvasTask[]
   nodes: CanvasNode[]
   assets: CanvasAsset[]
-  onCompleteDemoTask: (taskId: string) => void
   onCancelTask: (taskId: string) => void
   onRetryTask: (task: CanvasTask) => void
   onSelectNode: (nodeId: string) => void
@@ -161,7 +159,6 @@ export function CanvasTaskQueue({
         assets={assets}
         onClose={() => setDetailTaskId(null)}
         onCancelTask={onCancelTask}
-        onCompleteDemoTask={onCompleteDemoTask}
         onRetryTask={onRetryTask}
         onSelectNode={onSelectNode}
       />
@@ -256,7 +253,6 @@ function TaskDetailModal({
   assets,
   onClose,
   onCancelTask,
-  onCompleteDemoTask,
   onRetryTask,
   onSelectNode,
 }: {
@@ -265,7 +261,6 @@ function TaskDetailModal({
   assets: CanvasAsset[]
   onClose: () => void
   onCancelTask: (taskId: string) => void
-  onCompleteDemoTask: (taskId: string) => void
   onRetryTask: (task: CanvasTask) => void
   onSelectNode: (nodeId: string) => void
 }) {
@@ -277,7 +272,6 @@ function TaskDetailModal({
   const outputAssets = assets.filter((asset) => task.outputAssetIds.includes(asset.id))
   const taskNode = nodes.find((node) => node.taskId === task.id)
   const canCancel = isTaskActive(task)
-  const canDemoComplete = !isMediaOperation(task.operation) && task.status !== 'completed'
   const raw = isRecord(task.rawResponse) ? task.rawResponse : null
   const systemPrompt = stringField(raw?.systemPrompt)
   const rawPrompt = stringField(raw?.prompt)
@@ -327,11 +321,6 @@ function TaskDetailModal({
           <Button size="small" onClick={() => onRetryTask(task)}>
             {task.status === 'failed' || task.status === 'cancelled' ? '重试' : '再次运行'}
           </Button>
-          {canDemoComplete && (
-            <Button size="small" type="primary" onClick={() => onCompleteDemoTask(task.id)}>
-              Demo 完成
-            </Button>
-          )}
         </Space>
 
         <Descriptions

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -986,6 +986,10 @@ export function CanvasWorkspaceView({
   const {
     snapshot,
     loading,
+    canUndo,
+    canRedo,
+    undoCanvasChange,
+    redoCanvasChange,
     updateNodes,
     connectNodes,
     deleteEdges,
@@ -1002,7 +1006,6 @@ export function CanvasWorkspaceView({
     updateNodeData,
     updateProjectSettings,
     createTask,
-    completeDemoTask,
     cancelTask,
     // board 管理
     createBoard,
@@ -1200,7 +1203,9 @@ export function CanvasWorkspaceView({
 
   // 是否有运行中/排队中的画布任务：离开画布会让后台任务进度无法回写，需让用户确认风险。
   const activeCanvasTaskCount = useMemo(
-    () => snapshot?.tasks.filter((task) => task.status === 'pending' || task.status === 'running').length ?? 0,
+    () =>
+      snapshot?.tasks.filter((task) => task.status === 'pending' || task.status === 'running')
+        .length ?? 0,
     [snapshot?.tasks],
   )
 
@@ -1402,8 +1407,8 @@ export function CanvasWorkspaceView({
       title: nodeIds.length === 1 ? '删除选中节点？' : `删除选中的 ${nodeIds.length} 个节点？`,
       content:
         nodeIds.length === 1
-          ? '删除后该节点会从当前画布移除，相关连线也会同步清理。'
-          : '删除后这些节点会从当前画布移除，相关连线也会同步清理。',
+          ? '删除后可通过底栏「撤销」恢复，相关连线会同步清理。'
+          : '删除后可通过底栏「撤销」恢复这些节点，相关连线会同步清理。',
       okText: '删除',
       okButtonProps: { danger: true },
       cancelText: '取消',
@@ -1418,7 +1423,9 @@ export function CanvasWorkspaceView({
             currentId && nodeIds.includes(currentId) ? null : currentId,
           )
           closeCanvasFloatPanels()
-          message.success(nodeIds.length === 1 ? '已删除节点' : `已删除 ${nodeIds.length} 个节点`)
+          message.success(
+            nodeIds.length === 1 ? '已删除节点，可撤销' : `已删除 ${nodeIds.length} 个节点，可撤销`,
+          )
         } catch (error) {
           message.error(error instanceof Error ? error.message : '删除节点失败')
           throw error
@@ -1541,7 +1548,7 @@ export function CanvasWorkspaceView({
             { x: 140, y: 120 },
           )
       await createTextNode({
-        text: '双击后续版本可直接编辑文本内容。',
+        text: '双击打开右侧编辑器，输入文案、剧情段落或生成提示词。',
         x: position.x,
         y: position.y,
       })
@@ -3559,8 +3566,12 @@ export function CanvasWorkspaceView({
               closeCanvasFloatPanels('agent')
               setAgentOpen(true)
             }}
+            onUndo={() => void undoCanvasChange()}
+            onRedo={() => void redoCanvasChange()}
             onToggleGrid={handleToggleGrid}
             gridVisible={snapshot.board.settings.grid === true}
+            canUndo={canUndo}
+            canRedo={canRedo}
             selectedCount={selectedNodes.length}
             onDeleteSelected={handleDeleteSelectedNodes}
           />
@@ -3942,7 +3953,6 @@ export function CanvasWorkspaceView({
                   tasks={snapshot.tasks}
                   nodes={snapshot.nodes}
                   assets={snapshot.assets}
-                  onCompleteDemoTask={(taskId) => void completeDemoTask(taskId)}
                   onCancelTask={(taskId) => void cancelTask(taskId)}
                   onRetryTask={(task) => void handleRetryTask(task)}
                   onSelectNode={(nodeId) => setSelectedNodeIds([nodeId])}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -1901,6 +1901,22 @@ export function CanvasWorkspaceView({
     [createImageNode, patchNodes, snapshot],
   )
 
+  const handleUndoCanvasChange = useCallback(async () => {
+    try {
+      await undoCanvasChange()
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '撤销失败')
+    }
+  }, [undoCanvasChange])
+
+  const handleRedoCanvasChange = useCallback(async () => {
+    try {
+      await redoCanvasChange()
+    } catch (error) {
+      message.error(error instanceof Error ? error.message : '重做失败')
+    }
+  }, [redoCanvasChange])
+
   const handleToggleGrid = useCallback(() => {
     if (!snapshot) return
     const next = snapshot.board.settings.grid === true ? false : true
@@ -3566,8 +3582,8 @@ export function CanvasWorkspaceView({
               closeCanvasFloatPanels('agent')
               setAgentOpen(true)
             }}
-            onUndo={() => void undoCanvasChange()}
-            onRedo={() => void redoCanvasChange()}
+            onUndo={() => void handleUndoCanvasChange()}
+            onRedo={() => void handleRedoCanvasChange()}
             onToggleGrid={handleToggleGrid}
             gridVisible={snapshot.board.settings.grid === true}
             canUndo={canUndo}

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -1630,6 +1630,40 @@ export const canvasApi = {
     return snapshotFromDb(db, projectId, resolvePreferredBoard(db))
   },
 
+  async restoreBoardSnapshot(projectId: string, snapshot: CanvasSnapshot): Promise<CanvasSnapshot> {
+    const db = readDb()
+    const boardId = snapshot.activeBoardId ?? snapshot.board.id
+    const at = now()
+    const project = db.projects.find((item) => item.id === projectId)
+    if (project) project.updatedAt = at
+    const boards = snapshot.boards ?? [snapshot.board]
+    const boardIds = new Set(boards.map((board) => board.id))
+    db.boards = db.boards.map((board) => {
+      if (board.projectId !== projectId || !boardIds.has(board.id)) return board
+      return boards.find((item) => item.id === board.id) ?? board
+    })
+    db.nodes = db.nodes.filter(
+      (node) => !(node.projectId === projectId && node.boardId === boardId),
+    )
+    db.edges = db.edges.filter(
+      (edge) => !(edge.projectId === projectId && edge.boardId === boardId),
+    )
+    db.tasks = db.tasks.filter(
+      (task) => !(task.projectId === projectId && task.boardId === boardId),
+    )
+    db.nodes.push(...snapshot.nodes.filter((node) => node.boardId === boardId))
+    db.edges.push(...snapshot.edges.filter((edge) => edge.boardId === boardId))
+    db.tasks.push(...snapshot.tasks.filter((task) => task.boardId === boardId))
+    const assetIds = new Set(snapshot.assets.map((asset) => asset.id))
+    db.assets = db.assets.filter(
+      (asset) => asset.projectId !== projectId || !assetIds.has(asset.id),
+    )
+    db.assets.push(...snapshot.assets)
+    updateProjectCounts(db, projectId)
+    writeDb(db)
+    return this.openSnapshot(projectId, boardId)
+  },
+
   async updateViewport(
     projectId: string,
     viewport: CanvasBoard['viewport'],
@@ -3451,82 +3485,6 @@ export const canvasApi = {
     db.nodes.push(taskNode)
     db.tasks.push(task)
     db.edges.push(...inputEdges)
-    updateProjectCounts(db, projectId)
-    writeDb(db)
-    return this.openSnapshot(projectId)
-  },
-
-  async completeDemoTask(projectId: string, taskId: string): Promise<CanvasSnapshot> {
-    const db = readDb()
-    const task = db.tasks.find((item) => item.id === taskId)
-    const taskNode = db.nodes.find((item) => item.taskId === taskId)
-    if (!task || !taskNode) return this.openSnapshot(projectId)
-    const asset: CanvasAsset = {
-      id: uid('canvas_asset'),
-      projectId,
-      userId: USER_ID,
-      type:
-        task.operation === 'text_generate' || task.operation === 'prompt_optimize'
-          ? 'text'
-          : 'image',
-      source: 'ai_generated',
-      title: `${task.title ?? operationLabel(task.operation)} result`,
-      contentText:
-        task.operation === 'text_generate' || task.operation === 'prompt_optimize'
-          ? `优化结果：${task.prompt ?? '基于当前选区生成一段可继续编辑的文本。'}`
-          : null,
-      url: task.operation === 'text_generate' || task.operation === 'prompt_optimize' ? null : '',
-      metadata: { taskId, demo: true },
-      createdAt: now(),
-      updatedAt: now(),
-    }
-    const resultNode = createNodeBase({
-      projectId,
-      boardId: task.boardId,
-      type: asset.type === 'image' ? 'image' : 'text',
-      title: asset.title ?? null,
-      assetId: asset.id,
-      x: taskNode.x + 380,
-      y: taskNode.y,
-      width: asset.type === 'image' ? 280 : 300,
-      height: asset.type === 'image' ? 210 : 164,
-      data:
-        asset.type === 'image'
-          ? {
-              message:
-                task.prompt != null
-                  ? `AI 图片结果占位，后续由 agent/provider 回填 URL。Prompt: ${task.prompt}`
-                  : 'AI 图片结果占位，后续由 agent/provider 回填 URL',
-            }
-          : { text: asset.contentText ?? '', format: 'plain' },
-    })
-    task.status = 'completed'
-    task.progress = 100
-    task.completedAt = now()
-    task.updatedAt = now()
-    task.outputAssetIds.push(asset.id)
-    task.outputNodeIds.push(resultNode.id)
-    taskNode.data = {
-      ...taskNode.data,
-      status: 'completed',
-      progress: 100,
-      message: 'Demo 结果已写回画布',
-    }
-    taskNode.updatedAt = now()
-    db.assets.push(asset)
-    db.nodes.push(resultNode)
-    db.edges.push({
-      id: uid('canvas_edge'),
-      projectId,
-      boardId: task.boardId,
-      userId: USER_ID,
-      sourceNodeId: taskNode.id,
-      targetNodeId: resultNode.id,
-      type: 'generated',
-      taskId,
-      metadata: {},
-      createdAt: now(),
-    })
     updateProjectCounts(db, projectId)
     writeDb(db)
     return this.openSnapshot(projectId)

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.store.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.store.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { boardHistorySignature, createHistoryEntry } from './canvas.store'
+import type { CanvasSnapshot } from './canvas.types'
+
+function makeSnapshot(overrides: Partial<CanvasSnapshot> = {}): CanvasSnapshot {
+  return {
+    project: {
+      id: 'project-1',
+      userId: 0,
+      title: 'Project',
+      status: 'active',
+      nodeCount: 1,
+      assetCount: 1,
+      taskCount: 1,
+      createdAt: '2026-06-01T00:00:00.000Z',
+      updatedAt: '2026-06-01T00:00:00.000Z',
+      lastOpenedAt: '2026-06-01T00:00:00.000Z',
+    },
+    board: {
+      id: 'board-1',
+      projectId: 'project-1',
+      userId: 0,
+      name: 'Board 1',
+      viewport: { x: 0, y: 0, zoom: 1 },
+      settings: { grid: true },
+      createdAt: '2026-06-01T00:00:00.000Z',
+      updatedAt: '2026-06-01T00:00:00.000Z',
+    },
+    boards: [],
+    activeBoardId: 'board-1',
+    nodes: [
+      {
+        id: 'node-1',
+        projectId: 'project-1',
+        boardId: 'board-1',
+        userId: 0,
+        type: 'text',
+        title: 'Node 1',
+        x: 10,
+        y: 20,
+        width: 200,
+        height: 120,
+        rotation: 0,
+        zIndex: 1,
+        locked: false,
+        hidden: false,
+        data: { text: 'hello' },
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      },
+      {
+        id: 'node-other-board',
+        projectId: 'project-1',
+        boardId: 'board-2',
+        userId: 0,
+        type: 'text',
+        title: 'Other board',
+        x: 0,
+        y: 0,
+        width: 200,
+        height: 120,
+        rotation: 0,
+        zIndex: 1,
+        locked: false,
+        hidden: false,
+        data: { text: 'ignored' },
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      },
+    ],
+    edges: [],
+    assets: [
+      {
+        id: 'asset-1',
+        projectId: 'project-1',
+        userId: 0,
+        type: 'text',
+        source: 'upload',
+        title: 'Asset',
+        contentText: 'asset text',
+        url: null,
+        metadata: {},
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      },
+    ],
+    tasks: [
+      {
+        id: 'task-1',
+        projectId: 'project-1',
+        boardId: 'board-1',
+        userId: 0,
+        operation: 'text_generate',
+        status: 'pending',
+        progress: 10,
+        title: 'Task',
+        prompt: 'prompt',
+        negativePrompt: null,
+        inputNodeIds: ['node-1'],
+        inputAssetIds: [],
+        outputNodeIds: [],
+        outputAssetIds: [],
+        modelParams: {},
+        createdAt: '2026-06-01T00:00:00.000Z',
+        updatedAt: '2026-06-01T00:00:00.000Z',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('boardHistorySignature', () => {
+  it('ignores volatile project timestamps and nodes from other boards', () => {
+    const first = makeSnapshot()
+    const second = makeSnapshot({
+      project: { ...first.project, lastOpenedAt: '2026-06-02T00:00:00.000Z' },
+      nodes: first.nodes.map((node) =>
+        node.boardId === 'board-2' ? { ...node, x: node.x + 100, data: { text: 'changed' } } : node,
+      ),
+    })
+
+    expect(boardHistorySignature(second)).toEqual(boardHistorySignature(first))
+  })
+
+  it('detects active-board node edits', () => {
+    const first = makeSnapshot()
+    const second = makeSnapshot({
+      nodes: first.nodes.map((node) => (node.id === 'node-1' ? { ...node, x: 42 } : node)),
+    })
+
+    expect(boardHistorySignature(second)).not.toEqual(boardHistorySignature(first))
+  })
+})
+
+describe('createHistoryEntry', () => {
+  it('deep-clones the snapshot so later mutations cannot corrupt undo entries', () => {
+    const snapshot = makeSnapshot()
+    const entry = createHistoryEntry(snapshot)
+    snapshot.nodes[0]!.x = 999
+    snapshot.assets[0]!.contentText = 'mutated'
+
+    expect(entry.snapshot.nodes[0]?.x).toBe(10)
+    expect(entry.snapshot.assets[0]?.contentText).toBe('asset text')
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
@@ -53,9 +53,30 @@ export function useCanvasWorkspace(projectId: string) {
   const [loading, setLoading] = useState(true)
   // 记录当前激活 board，refresh 时保留（不跳回默认 board）
   const activeBoardIdRef = useRef<string | null>(null)
+  const undoStackRef = useRef<CanvasSnapshot[]>([])
+  const redoStackRef = useRef<CanvasSnapshot[]>([])
+  const lastRecordedSnapshotRef = useRef<CanvasSnapshot | null>(null)
+  const restoringHistoryRef = useRef(false)
+  const [historyVersion, setHistoryVersion] = useState(0)
   useEffect(() => {
     activeBoardIdRef.current = snapshot?.activeBoardId ?? snapshot?.board.id ?? null
   }, [snapshot?.activeBoardId, snapshot?.board.id])
+
+  useEffect(() => {
+    if (!snapshot) return
+    if (restoringHistoryRef.current) {
+      restoringHistoryRef.current = false
+      lastRecordedSnapshotRef.current = snapshot
+      return
+    }
+    const previous = lastRecordedSnapshotRef.current
+    if (previous && JSON.stringify(previous) !== JSON.stringify(snapshot)) {
+      undoStackRef.current = [...undoStackRef.current.slice(-49), previous]
+      redoStackRef.current = []
+      setHistoryVersion((version) => version + 1)
+    }
+    lastRecordedSnapshotRef.current = snapshot
+  }, [snapshot])
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -277,7 +298,7 @@ export function useCanvasWorkspace(projectId: string) {
     ) => {
       const current = snapshot
       if (!current) return
-      // 多媒体 operation 走真实平台 adapter；文本 operation 走真实文本模型；其余走 demo 占位
+      // 多媒体 operation 走真实平台 adapter；文本 operation 走真实文本模型；其余记录为待接入执行器的任务。
       if (isMediaOperation(request.operation)) {
         setSnapshot(await canvasApi.createMediaTask(projectId, request))
       } else if (isTextModelOperation(request.operation)) {
@@ -289,13 +310,6 @@ export function useCanvasWorkspace(projectId: string) {
       }
     },
     [projectId, snapshot],
-  )
-
-  const completeDemoTask = useCallback(
-    async (taskId: string) => {
-      setSnapshot(await canvasApi.completeDemoTask(projectId, taskId))
-    },
-    [projectId],
   )
 
   const cancelTask = useCallback(
@@ -584,9 +598,36 @@ export function useCanvasWorkspace(projectId: string) {
     [projectId],
   )
 
+  const undoCanvasChange = useCallback(async () => {
+    const previous = undoStackRef.current.pop()
+    const current = lastRecordedSnapshotRef.current
+    if (!previous || !current) return
+    redoStackRef.current.push(current)
+    restoringHistoryRef.current = true
+    setSnapshot(await canvasApi.restoreBoardSnapshot(projectId, previous))
+    setHistoryVersion((version) => version + 1)
+  }, [projectId])
+
+  const redoCanvasChange = useCallback(async () => {
+    const next = redoStackRef.current.pop()
+    const current = lastRecordedSnapshotRef.current
+    if (!next || !current) return
+    undoStackRef.current.push(current)
+    restoringHistoryRef.current = true
+    setSnapshot(await canvasApi.restoreBoardSnapshot(projectId, next))
+    setHistoryVersion((version) => version + 1)
+  }, [projectId])
+
+  const canUndo = useMemo(() => undoStackRef.current.length > 0, [historyVersion])
+  const canRedo = useMemo(() => redoStackRef.current.length > 0, [historyVersion])
+
   return {
     snapshot,
     loading,
+    canUndo,
+    canRedo,
+    undoCanvasChange,
+    redoCanvasChange,
     refresh,
     updateNodes,
     connectNodes,
@@ -604,7 +645,6 @@ export function useCanvasWorkspace(projectId: string) {
     updateNodeData,
     updateProjectSettings,
     createTask,
-    completeDemoTask,
     cancelTask,
     // board 管理
     createBoard,

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
@@ -17,6 +17,34 @@ import type {
 
 export type CanvasViewMode = { mode: 'projects' } | { mode: 'workspace'; projectId: string }
 
+const CANVAS_HISTORY_LIMIT = 50
+
+export function cloneCanvasSnapshot(snapshot: CanvasSnapshot): CanvasSnapshot {
+  if (typeof structuredClone === 'function') return structuredClone(snapshot)
+  return JSON.parse(JSON.stringify(snapshot)) as CanvasSnapshot
+}
+
+export function boardHistorySignature(snapshot: CanvasSnapshot): string {
+  const boardId = snapshot.activeBoardId ?? snapshot.board.id
+  return JSON.stringify({
+    board: snapshot.board,
+    nodes: snapshot.nodes.filter((node) => node.boardId === boardId),
+    edges: snapshot.edges.filter((edge) => edge.boardId === boardId),
+    tasks: snapshot.tasks.filter((task) => task.boardId === boardId),
+    assets: snapshot.assets,
+  })
+}
+
+type CanvasHistoryEntry = {
+  snapshot: CanvasSnapshot
+  signature: string
+}
+
+export function createHistoryEntry(snapshot: CanvasSnapshot): CanvasHistoryEntry {
+  const cloned = cloneCanvasSnapshot(snapshot)
+  return { snapshot: cloned, signature: boardHistorySignature(cloned) }
+}
+
 export function useCanvasProjects() {
   const [projects, setProjects] = useState<CanvasProject[]>([])
   const [loading, setLoading] = useState(true)
@@ -53,29 +81,31 @@ export function useCanvasWorkspace(projectId: string) {
   const [loading, setLoading] = useState(true)
   // 记录当前激活 board，refresh 时保留（不跳回默认 board）
   const activeBoardIdRef = useRef<string | null>(null)
-  const undoStackRef = useRef<CanvasSnapshot[]>([])
-  const redoStackRef = useRef<CanvasSnapshot[]>([])
-  const lastRecordedSnapshotRef = useRef<CanvasSnapshot | null>(null)
+  const undoStackRef = useRef<CanvasHistoryEntry[]>([])
+  const redoStackRef = useRef<CanvasHistoryEntry[]>([])
+  const lastRecordedSnapshotRef = useRef<CanvasHistoryEntry | null>(null)
   const restoringHistoryRef = useRef(false)
   const [historyVersion, setHistoryVersion] = useState(0)
+  const [historyBusy, setHistoryBusy] = useState(false)
   useEffect(() => {
     activeBoardIdRef.current = snapshot?.activeBoardId ?? snapshot?.board.id ?? null
   }, [snapshot?.activeBoardId, snapshot?.board.id])
 
   useEffect(() => {
     if (!snapshot) return
+    const current = createHistoryEntry(snapshot)
     if (restoringHistoryRef.current) {
       restoringHistoryRef.current = false
-      lastRecordedSnapshotRef.current = snapshot
+      lastRecordedSnapshotRef.current = current
       return
     }
     const previous = lastRecordedSnapshotRef.current
-    if (previous && JSON.stringify(previous) !== JSON.stringify(snapshot)) {
-      undoStackRef.current = [...undoStackRef.current.slice(-49), previous]
+    if (previous && previous.signature !== current.signature) {
+      undoStackRef.current = [...undoStackRef.current.slice(-(CANVAS_HISTORY_LIMIT - 1)), previous]
       redoStackRef.current = []
       setHistoryVersion((version) => version + 1)
     }
-    lastRecordedSnapshotRef.current = snapshot
+    lastRecordedSnapshotRef.current = current
   }, [snapshot])
 
   const refresh = useCallback(async () => {
@@ -599,27 +629,55 @@ export function useCanvasWorkspace(projectId: string) {
   )
 
   const undoCanvasChange = useCallback(async () => {
+    if (historyBusy) return
     const previous = undoStackRef.current.pop()
     const current = lastRecordedSnapshotRef.current
     if (!previous || !current) return
-    redoStackRef.current.push(current)
-    restoringHistoryRef.current = true
-    setSnapshot(await canvasApi.restoreBoardSnapshot(projectId, previous))
-    setHistoryVersion((version) => version + 1)
-  }, [projectId])
+    setHistoryBusy(true)
+    try {
+      redoStackRef.current.push(current)
+      restoringHistoryRef.current = true
+      setSnapshot(await canvasApi.restoreBoardSnapshot(projectId, previous.snapshot))
+      setHistoryVersion((version) => version + 1)
+    } catch (error) {
+      undoStackRef.current.push(previous)
+      redoStackRef.current = redoStackRef.current.filter((entry) => entry !== current)
+      restoringHistoryRef.current = false
+      throw error
+    } finally {
+      setHistoryBusy(false)
+    }
+  }, [historyBusy, projectId])
 
   const redoCanvasChange = useCallback(async () => {
+    if (historyBusy) return
     const next = redoStackRef.current.pop()
     const current = lastRecordedSnapshotRef.current
     if (!next || !current) return
-    undoStackRef.current.push(current)
-    restoringHistoryRef.current = true
-    setSnapshot(await canvasApi.restoreBoardSnapshot(projectId, next))
-    setHistoryVersion((version) => version + 1)
-  }, [projectId])
+    setHistoryBusy(true)
+    try {
+      undoStackRef.current.push(current)
+      restoringHistoryRef.current = true
+      setSnapshot(await canvasApi.restoreBoardSnapshot(projectId, next.snapshot))
+      setHistoryVersion((version) => version + 1)
+    } catch (error) {
+      redoStackRef.current.push(next)
+      undoStackRef.current = undoStackRef.current.filter((entry) => entry !== current)
+      restoringHistoryRef.current = false
+      throw error
+    } finally {
+      setHistoryBusy(false)
+    }
+  }, [historyBusy, projectId])
 
-  const canUndo = useMemo(() => undoStackRef.current.length > 0, [historyVersion])
-  const canRedo = useMemo(() => redoStackRef.current.length > 0, [historyVersion])
+  const canUndo = useMemo(
+    () => !historyBusy && undoStackRef.current.length > 0,
+    [historyBusy, historyVersion],
+  )
+  const canRedo = useMemo(
+    () => !historyBusy && redoStackRef.current.length > 0,
+    [historyBusy, historyVersion],
+  )
 
   return {
     snapshot,


### PR DESCRIPTION
### Motivation

- Provide basic undo/redo for the infinite canvas so users can recover recent board edits from the bottom dock buttons.  
- Ensure restores only affect the current board (avoid clobbering other boards) by persisting/restoring board-scoped snapshots.  
- Remove legacy demo-complete paths and update outdated wording to align UI text with current workflows.

### Description

- Added per-board history state and APIs in the workspace store: `undoStackRef`/`redoStackRef`, `canUndo`/`canRedo`, and `undoCanvasChange`/`redoCanvasChange` in `apps/desktop/src/renderer/design/views/canvas/canvas.store.ts`.  
- Implemented `canvasApi.restoreBoardSnapshot(projectId, snapshot)` to restore only nodes/edges/tasks/assets for the active board and wired undo/redo to call it in `apps/desktop/src/renderer/design/views/canvas/canvas.api.ts`.  
- Wired bottom dock undo/redo buttons to workspace handlers and enabled/disabled them based on `canUndo`/`canRedo` in `CanvasBottomDock.tsx` and `CanvasWorkspaceView.tsx`.  
- Cleaned up demo task code paths by removing the `completeDemoTask` API and the manual "Demo 完成" UI entry, and updated default new-text content and delete confirmation/toast copy to mention undo recovery (`CanvasTaskQueue.tsx`, `CanvasWorkspaceView.tsx`).

### Testing

- Ran the renderer TypeScript check with `pnpm --filter @spark/desktop exec tsc --noEmit -p tsconfig.json` which completed successfully.  
- Ran `pnpm --filter @spark/desktop typecheck` which failed due to an unrelated main-process type error (`ProviderService.revealApiKey`) outside these changes.  
- Performed `git diff --check` and local formatting; no diff-check issues were found.  
- Attempted `npx gitnexus impact` / `npx gitnexus detect_changes` as required by repository policy but the GitNexus CLI install was blocked by an npm registry 403 so the automated impact/detect checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bddf1ecb4832e997faa02ec2ba541)