### PR TITLE
Add panorama_360 operation with WebGL 360° viewer and pipeline support

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasInlineAiComposer.tsx
@@ -11,7 +11,11 @@ import { Button, Checkbox as LobeCheckbox, Input, Tag, Tooltip } from '@lobehub/
 import { Icons } from '../../Icons'
 import { Select as LobeSelect } from '@lobehub/ui'
 import { capabilityForOperation } from '@spark/protocol'
-import type { CanvasMediaModelSummary, CanvasMediaTaskInputFile, ManagedAgent } from '@spark/protocol'
+import type {
+  CanvasMediaModelSummary,
+  CanvasMediaTaskInputFile,
+  ManagedAgent,
+} from '@spark/protocol'
 import {
   CANVAS_AGENT_PRESETS,
   buildAgentPresetPrompt,
@@ -209,9 +213,7 @@ export function CanvasInlineAiComposer({
   const mediaCapabilityIds = useMemo(() => capabilityForOperation(operation), [operation])
   /** 文本类操作（剧本/分镜/导演/动作 等专属 agent 适用）：走真实文本模型，可指定 agent */
   const isTextOperation =
-    operation === 'text_generate' ||
-    operation === 'text_rewrite' ||
-    operation === 'prompt_optimize'
+    operation === 'text_generate' || operation === 'text_rewrite' || operation === 'prompt_optimize'
   const supportedMediaModels = useMemo(() => {
     if (mediaCapabilityIds.length === 0) return []
     return mediaModels.filter((model) =>
@@ -1109,6 +1111,7 @@ function canRunFromInputOnly(operation: CanvasOperationType, nodes: CanvasNode[]
       'image_to_image',
       'image_edit',
       'image_compose',
+      'panorama_360',
       'image_to_video',
       'video_edit',
       'audio_transcribe',
@@ -1123,9 +1126,14 @@ function canRunFromInputOnly(operation: CanvasOperationType, nodes: CanvasNode[]
 }
 
 function operationNeedsImageInput(operation: CanvasOperationType): boolean {
-  return ['image_to_image', 'image_edit', 'image_compose', 'image_to_video', 'video_edit'].includes(
-    operation,
-  )
+  return [
+    'image_to_image',
+    'image_edit',
+    'image_compose',
+    'panorama_360',
+    'image_to_video',
+    'video_edit',
+  ].includes(operation)
 }
 
 function operationSupportsVideoFrameRoles(operation: CanvasOperationType): boolean {
@@ -1149,6 +1157,8 @@ function fallbackPromptForOperation(operation: CanvasOperationType): string {
   if (operation === 'image_edit') return '请基于输入图片进行自然编辑，保持主体与画面质量。'
   if (operation === 'image_to_image') return '请基于输入图片生成一个高质量变体。'
   if (operation === 'image_compose') return '请将输入图片自然合成为一张高质量图片。'
+  if (operation === 'panorama_360')
+    return '请基于输入内容生成一张可用于 360° 全景预览的等距柱状投影场景图。'
   if (operation === 'image_to_video') return '请基于输入图片生成一段自然流畅的视频。'
   if (operation === 'video_edit') return '请基于输入视频和参考帧进行自然视频编辑。'
   if (operation === 'audio_transcribe') return '请转写输入音频内容。'
@@ -1299,7 +1309,11 @@ export function schemaFields(schema: Record<string, unknown>): SchemaField[] {
 }
 
 export function operationSuggestedFields(operation: CanvasOperationType): SchemaField[] {
-  if (['text_to_image', 'image_to_image', 'image_edit', 'image_compose'].includes(operation)) {
+  if (
+    ['text_to_image', 'image_to_image', 'image_edit', 'image_compose', 'panorama_360'].includes(
+      operation,
+    )
+  ) {
     return [
       {
         name: 'size',

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -81,14 +81,21 @@ function DirectorStageMini({ data }: { data: SparkCanvasNode['data'] }) {
   const stage = readDirectorStageMini(data)
   const toPlan = (x: number, z: number) => ({ px: 50 + x * 40, py: 50 + z * 40 })
   const cam = stage ? toPlan(stage.camera.x, stage.camera.z) : { px: 50, py: 90 }
-  const head = (deg: number) => ({ hx: Math.sin((deg * Math.PI) / 180), hy: -Math.cos((deg * Math.PI) / 180) })
+  const head = (deg: number) => ({
+    hx: Math.sin((deg * Math.PI) / 180),
+    hy: -Math.cos((deg * Math.PI) / 180),
+  })
   const fov = stage?.camera.fov ?? 50
   const facing = stage?.camera.facing ?? 0
   const left = head(facing - fov / 2)
   const right = head(facing + fov / 2)
   const L = 120
   return (
-    <svg className="canvas-node-director-mini" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
+    <svg
+      className="canvas-node-director-mini"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid slice"
+    >
       <defs>
         <clipPath id="mini-stage-clip">
           <rect x="8" y="8" width="84" height="84" rx="4" />
@@ -110,7 +117,9 @@ function DirectorStageMini({ data }: { data: SparkCanvasNode['data'] }) {
       />
       {stage?.items.map((item, index) => {
         const p = toPlan(item.x, item.z)
-        return <circle key={index} cx={p.px} cy={p.py} r={3.4} fill={item.color} className="mini-dot" />
+        return (
+          <circle key={index} cx={p.px} cy={p.py} r={3.4} fill={item.color} className="mini-dot" />
+        )
       })}
       <rect x={cam.px - 3} y={cam.py - 3} width={6} height={6} rx={1.4} className="mini-cam" />
     </svg>
@@ -124,7 +133,8 @@ function operationNodeIcon(operation: CanvasOperationType | null): React.ReactNo
     operation.startsWith('text_to_image') ||
     operation === 'image_to_image' ||
     operation === 'image_edit' ||
-    operation === 'image_compose'
+    operation === 'image_compose' ||
+    operation === 'panorama_360'
   ) {
     return <Icons.Image size={13} />
   }
@@ -222,6 +232,7 @@ const typeColor: Record<SparkCanvasNode['type'], string> = {
   image_to_image: 'green',
   image_edit: 'green',
   image_compose: 'green',
+  panorama_360: 'green',
   text_generate: 'green',
   text_rewrite: 'green',
   prompt_optimize: 'green',
@@ -334,6 +345,11 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
                   key: 'op-image_compose',
                   label: '多图合成',
                   onClick: () => actions.createOperationChild(node.id, 'image_compose'),
+                },
+                {
+                  key: 'op-panorama_360',
+                  label: '360 全景图',
+                  onClick: () => actions.createOperationChild(node.id, 'panorama_360'),
                 },
                 {
                   key: 'op-text_generate',
@@ -511,7 +527,8 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
         <Handle type="target" position={Position.Left} className="canvas-node-handle" />
         <div className="canvas-node-head">
           <div className="canvas-node-title">
-            {node.type === 'image' && <Icons.Image size={14} />}
+            {node.type === 'image' &&
+              (node.data.panorama360 ? <Icons.Globe size={14} /> : <Icons.Image size={14} />)}
             {node.type === 'audio' && <Icons.Play size={14} />}
             {(node.type === 'text' || node.type === 'prompt') && <Icons.File size={14} />}
             {isDirectorStage ? (
@@ -523,7 +540,10 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             ) : null}
             {node.type === 'video' && <Icons.Play size={14} />}
             {node.type === 'group' && <Icons.Layers size={14} />}
-            <span>{title}</span>
+            <span>
+              {node.data.panorama360 ? '360全景 · ' : ''}
+              {title}
+            </span>
           </div>
           <div className="canvas-node-head-actions">
             {pipelineActions.slice(0, 2).map((action) => (
@@ -657,7 +677,9 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
           ) : isDirectorStage ? (
             <div className="canvas-node-director-stage">
               <DirectorStageMini data={node.data} />
-              <div className="canvas-node-director-stage-hint">双击编排画面 · 站位 / 取景 / 提示词</div>
+              <div className="canvas-node-director-stage-hint">
+                双击编排画面 · 站位 / 取景 / 提示词
+              </div>
             </div>
           ) : isOperationNode(node) ? (
             <div className="canvas-node-task canvas-node-operation">

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasPanoramaViewerModal.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasPanoramaViewerModal.tsx
@@ -1,0 +1,533 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Button, Modal, Slider, Switch, message } from 'antd'
+import { normalizeEduAssetUrl } from '@spark/shared'
+import { Icons } from '../../Icons'
+import type { CanvasNode } from './canvas.types'
+
+type PanoramaViewerHandle = {
+  screenshot: () => string | null
+  reset: () => void
+}
+
+type PanoramaPose = {
+  yaw: number
+  pitch: number
+  fov: number
+}
+
+type PanoramaLoadState = 'idle' | 'loading' | 'ready' | 'error' | 'webgl-unavailable'
+
+const MIN_FOV = 30
+const MAX_FOV = 100
+const DEFAULT_FOV = 75
+const MAX_PITCH = 1.45
+const KEYBOARD_STEP = 0.12
+const AUTOROTATE_SPEED = 0.0016
+const VELOCITY_DECAY = 0.92
+const MIN_VELOCITY = 0.00004
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function wrapRadians(value: number): number {
+  const twoPi = Math.PI * 2
+  return ((value % twoPi) + twoPi) % twoPi
+}
+
+function radiansToDegrees(value: number): number {
+  return Math.round((value * 180) / Math.PI)
+}
+
+function formatYaw(yaw: number): string {
+  const degrees = Math.round((wrapRadians(yaw) * 180) / Math.PI)
+  if (degrees >= 315 || degrees < 45) return `${degrees}° N`
+  if (degrees < 135) return `${degrees}° E`
+  if (degrees < 225) return `${degrees}° S`
+  return `${degrees}° W`
+}
+
+function compileShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+  const shader = gl.createShader(type)
+  if (!shader) throw new Error('无法创建 WebGL shader')
+  gl.shaderSource(shader, source)
+  gl.compileShader(shader)
+  if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+    const error = gl.getShaderInfoLog(shader) || 'shader compile failed'
+    gl.deleteShader(shader)
+    throw new Error(error)
+  }
+  return shader
+}
+
+function linkProgram(
+  gl: WebGLRenderingContext,
+  vertexSource: string,
+  fragmentSource: string,
+): WebGLProgram {
+  const vertex = compileShader(gl, gl.VERTEX_SHADER, vertexSource)
+  const fragment = compileShader(gl, gl.FRAGMENT_SHADER, fragmentSource)
+  const program = gl.createProgram()
+  if (!program) throw new Error('无法创建 WebGL program')
+  gl.attachShader(program, vertex)
+  gl.attachShader(program, fragment)
+  gl.linkProgram(program)
+  gl.deleteShader(vertex)
+  gl.deleteShader(fragment)
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+    const error = gl.getProgramInfoLog(program) || 'program link failed'
+    gl.deleteProgram(program)
+    throw new Error(error)
+  }
+  return program
+}
+
+function createFullscreenQuad(): { vertices: Float32Array; indices: Uint16Array } {
+  // Full-screen render target. The fragment shader samples an equirectangular panorama as if
+  // the camera were inside a textured sphere, matching the core approach used by lightweight
+  // WebGL panorama viewers while avoiding another runtime dependency.
+  return {
+    vertices: new Float32Array([-1, -1, 0, 1, -1, 0, 1, 1, 0, -1, 1, 0]),
+    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+  }
+}
+
+function setTextureFilters(gl: WebGLRenderingContext, width: number, height: number): void {
+  const isPowerOfTwo = (value: number) => (value & (value - 1)) === 0
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+  if (isPowerOfTwo(width) && isPowerOfTwo(height)) {
+    gl.generateMipmap(gl.TEXTURE_2D)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR)
+    return
+  }
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+}
+
+function PanoramaWebglViewer({
+  src,
+  fov,
+  autorotate,
+  onFovChange,
+  onLoadState,
+  onPoseChange,
+  onReady,
+}: {
+  src: string
+  fov: number
+  autorotate: boolean
+  onFovChange: (fov: number) => void
+  onLoadState: (state: PanoramaLoadState) => void
+  onPoseChange: (pose: PanoramaPose) => void
+  onReady: (handle: PanoramaViewerHandle | null) => void
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const yawRef = useRef(0)
+  const pitchRef = useRef(0)
+  const fovRef = useRef(fov)
+  const autorotateRef = useRef(autorotate)
+  const dragRef = useRef<{ x: number; y: number; yaw: number; pitch: number; t: number } | null>(
+    null,
+  )
+  const velocityRef = useRef({ yaw: 0, pitch: 0 })
+  const lastFrameRef = useRef(0)
+
+  useEffect(() => {
+    fovRef.current = fov
+  }, [fov])
+
+  useEffect(() => {
+    autorotateRef.current = autorotate
+  }, [autorotate])
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return undefined
+    onLoadState('loading')
+    const gl = canvas.getContext('webgl', { antialias: true, preserveDrawingBuffer: true })
+    if (!gl) {
+      onLoadState('webgl-unavailable')
+      onReady(null)
+      return undefined
+    }
+
+    let program: WebGLProgram | null = null
+    let vertexBuffer: WebGLBuffer | null = null
+    let indexBuffer: WebGLBuffer | null = null
+    let texture: WebGLTexture | null = null
+    let disposed = false
+    let frame = 0
+
+    try {
+      program = linkProgram(
+        gl,
+        `attribute vec3 aPosition;
+         void main() {
+           gl_Position = vec4(aPosition.xy, 0.0, 1.0);
+         }`,
+        `precision highp float;
+         uniform sampler2D uTexture;
+         uniform float uYaw;
+         uniform float uPitch;
+         uniform float uFov;
+         uniform vec2 uResolution;
+         const float PI = 3.141592653589793;
+         mat3 rotY(float a){ float s=sin(a), c=cos(a); return mat3(c,0.0,-s, 0.0,1.0,0.0, s,0.0,c); }
+         mat3 rotX(float a){ float s=sin(a), c=cos(a); return mat3(1.0,0.0,0.0, 0.0,c,s, 0.0,-s,c); }
+         void main() {
+           vec2 uv = (gl_FragCoord.xy / uResolution) * 2.0 - 1.0;
+           uv.x *= uResolution.x / uResolution.y;
+           float z = 1.0 / tan(radians(uFov) * 0.5);
+           vec3 dir = normalize(vec3(uv.x, uv.y, -z));
+           dir = rotY(uYaw) * rotX(uPitch) * dir;
+           float lon = atan(dir.x, -dir.z);
+           float lat = asin(clamp(dir.y, -1.0, 1.0));
+           vec2 panoUv = vec2(fract(0.5 + lon / (2.0 * PI)), 0.5 + lat / PI);
+           gl_FragColor = texture2D(uTexture, panoUv);
+         }`,
+      )
+      gl.useProgram(program)
+      const mesh = createFullscreenQuad()
+      vertexBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
+      gl.bufferData(gl.ARRAY_BUFFER, mesh.vertices, gl.STATIC_DRAW)
+      indexBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer)
+      gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, mesh.indices, gl.STATIC_DRAW)
+      const positionLocation = gl.getAttribLocation(program, 'aPosition')
+      gl.enableVertexAttribArray(positionLocation)
+      gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 0, 0)
+      const yawLocation = gl.getUniformLocation(program, 'uYaw')
+      const pitchLocation = gl.getUniformLocation(program, 'uPitch')
+      const fovLocation = gl.getUniformLocation(program, 'uFov')
+      const resolutionLocation = gl.getUniformLocation(program, 'uResolution')
+      texture = gl.createTexture()
+      gl.bindTexture(gl.TEXTURE_2D, texture)
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        1,
+        1,
+        0,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        new Uint8Array([2, 6, 23, 255]),
+      )
+
+      const render = (time = performance.now(), scheduleNextFrame = true) => {
+        if (disposed) return
+        const delta = lastFrameRef.current ? Math.min(48, time - lastFrameRef.current) : 16
+        lastFrameRef.current = time
+        if (!dragRef.current) {
+          if (autorotateRef.current) yawRef.current += AUTOROTATE_SPEED * delta
+          if (
+            Math.abs(velocityRef.current.yaw) > MIN_VELOCITY ||
+            Math.abs(velocityRef.current.pitch) > MIN_VELOCITY
+          ) {
+            yawRef.current += velocityRef.current.yaw * delta
+            pitchRef.current = clamp(
+              pitchRef.current + velocityRef.current.pitch * delta,
+              -MAX_PITCH,
+              MAX_PITCH,
+            )
+            velocityRef.current.yaw *= VELOCITY_DECAY
+            velocityRef.current.pitch *= VELOCITY_DECAY
+          }
+        }
+        const rect = canvas.getBoundingClientRect()
+        const dpr = window.devicePixelRatio || 1
+        const width = Math.max(1, Math.floor(rect.width * dpr))
+        const height = Math.max(1, Math.floor(rect.height * dpr))
+        if (canvas.width !== width || canvas.height !== height) {
+          canvas.width = width
+          canvas.height = height
+        }
+        gl.viewport(0, 0, width, height)
+        gl.clearColor(0, 0, 0, 1)
+        gl.clear(gl.COLOR_BUFFER_BIT)
+        gl.uniform1f(yawLocation, yawRef.current)
+        gl.uniform1f(pitchLocation, pitchRef.current)
+        gl.uniform1f(fovLocation, fovRef.current)
+        gl.uniform2f(resolutionLocation, width, height)
+        gl.drawElements(gl.TRIANGLES, mesh.indices.length, gl.UNSIGNED_SHORT, 0)
+        onPoseChange({ yaw: yawRef.current, pitch: pitchRef.current, fov: fovRef.current })
+        if (scheduleNextFrame) frame = window.requestAnimationFrame(render)
+      }
+
+      const image = new Image()
+      image.crossOrigin = 'anonymous'
+      image.onload = () => {
+        if (disposed || !texture) return
+        gl.bindTexture(gl.TEXTURE_2D, texture)
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 1)
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image)
+        setTextureFilters(gl, image.naturalWidth, image.naturalHeight)
+        onLoadState('ready')
+        onReady({
+          screenshot: () => {
+            render(performance.now(), false)
+            return canvas.toDataURL('image/png')
+          },
+          reset: () => {
+            yawRef.current = 0
+            pitchRef.current = 0
+            velocityRef.current = { yaw: 0, pitch: 0 }
+            onFovChange(DEFAULT_FOV)
+          },
+        })
+        render()
+      }
+      image.onerror = () => {
+        onLoadState('error')
+        message.error('全景图加载失败')
+      }
+      image.src = src
+    } catch (error) {
+      onLoadState('error')
+      message.error(error instanceof Error ? error.message : '全景渲染器初始化失败')
+    }
+
+    return () => {
+      disposed = true
+      window.cancelAnimationFrame(frame)
+      onReady(null)
+      if (texture) gl.deleteTexture(texture)
+      if (vertexBuffer) gl.deleteBuffer(vertexBuffer)
+      if (indexBuffer) gl.deleteBuffer(indexBuffer)
+      if (program) gl.deleteProgram(program)
+    }
+  }, [onFovChange, onLoadState, onPoseChange, onReady, src])
+
+  const updateFov = useCallback(
+    (nextFov: number) => {
+      const clamped = clamp(nextFov, MIN_FOV, MAX_FOV)
+      fovRef.current = clamped
+      onFovChange(Math.round(clamped))
+    },
+    [onFovChange],
+  )
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLCanvasElement>) => {
+    event.currentTarget.setPointerCapture(event.pointerId)
+    dragRef.current = {
+      x: event.clientX,
+      y: event.clientY,
+      yaw: yawRef.current,
+      pitch: pitchRef.current,
+      t: performance.now(),
+    }
+    velocityRef.current = { yaw: 0, pitch: 0 }
+  }, [])
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLCanvasElement>) => {
+    const drag = dragRef.current
+    if (!drag) return
+    const now = performance.now()
+    const dx = event.clientX - drag.x
+    const dy = event.clientY - drag.y
+    yawRef.current = drag.yaw - dx * 0.006
+    pitchRef.current = clamp(drag.pitch + dy * 0.006, -MAX_PITCH, MAX_PITCH)
+    const elapsed = Math.max(1, now - drag.t)
+    velocityRef.current = { yaw: (-dx * 0.006) / elapsed, pitch: (dy * 0.006) / elapsed }
+  }, [])
+
+  const finishPointer = useCallback((event: React.PointerEvent<HTMLCanvasElement>) => {
+    dragRef.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+  }, [])
+
+  const handleWheel = useCallback(
+    (event: React.WheelEvent<HTMLCanvasElement>) => {
+      event.preventDefault()
+      updateFov(fovRef.current + event.deltaY * 0.03)
+    },
+    [updateFov],
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLCanvasElement>) => {
+      if (event.key === 'ArrowLeft') yawRef.current -= KEYBOARD_STEP
+      else if (event.key === 'ArrowRight') yawRef.current += KEYBOARD_STEP
+      else if (event.key === 'ArrowUp')
+        pitchRef.current = clamp(pitchRef.current - KEYBOARD_STEP, -MAX_PITCH, MAX_PITCH)
+      else if (event.key === 'ArrowDown')
+        pitchRef.current = clamp(pitchRef.current + KEYBOARD_STEP, -MAX_PITCH, MAX_PITCH)
+      else if (event.key === '+' || event.key === '=') updateFov(fovRef.current - 5)
+      else if (event.key === '-' || event.key === '_') updateFov(fovRef.current + 5)
+      else return
+      event.preventDefault()
+      velocityRef.current = { yaw: 0, pitch: 0 }
+    },
+    [updateFov],
+  )
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="canvas-panorama-webgl"
+      tabIndex={0}
+      role="img"
+      aria-label="360 全景预览，可拖拽、滚轮缩放或使用方向键查看"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishPointer}
+      onPointerCancel={finishPointer}
+      onWheel={handleWheel}
+      onKeyDown={handleKeyDown}
+    />
+  )
+}
+
+export function CanvasPanoramaViewerModal({
+  node,
+  open,
+  onClose,
+  onScreenshot,
+}: {
+  node: CanvasNode | null
+  open: boolean
+  onClose: () => void
+  onScreenshot: (dataUrl: string, sourceNode: CanvasNode, pose: PanoramaPose) => Promise<void>
+}) {
+  const [fov, setFov] = useState(DEFAULT_FOV)
+  const [loadState, setLoadState] = useState<PanoramaLoadState>('idle')
+  const [autorotate, setAutorotate] = useState(false)
+  const [pose, setPose] = useState<PanoramaPose>({ yaw: 0, pitch: 0, fov: DEFAULT_FOV })
+  const [fullscreen, setFullscreen] = useState(false)
+  const handleRef = useRef<PanoramaViewerHandle | null>(null)
+  const src = node?.data.url ? normalizeEduAssetUrl(node.data.url) : ''
+  const isBusy = loadState === 'loading' || loadState === 'idle'
+  const canCapture = loadState === 'ready' && Boolean(handleRef.current)
+  const aspectLabel = useMemo(() => {
+    const width = node?.width ?? 0
+    const height = node?.height ?? 0
+    if (width <= 0 || height <= 0) return 'equirectangular'
+    return Math.abs(width / height - 2) < 0.22 ? '2:1 equirectangular' : 'panorama image'
+  }, [node?.height, node?.width])
+
+  useEffect(() => {
+    if (!open) return
+    setFov(DEFAULT_FOV)
+    setLoadState(src ? 'loading' : 'idle')
+    setAutorotate(false)
+    setPose({ yaw: 0, pitch: 0, fov: DEFAULT_FOV })
+    setFullscreen(false)
+  }, [open, src])
+
+  return (
+    <Modal
+      open={open}
+      onCancel={onClose}
+      footer={null}
+      width="100vw"
+      className={`canvas-panorama-modal${fullscreen ? ' canvas-panorama-modal-fullscreen' : ''}`}
+      title={null}
+      destroyOnHidden
+    >
+      <div className="canvas-panorama-shell">
+        <div className="canvas-panorama-topbar">
+          <div>
+            <div className="canvas-panorama-kicker">360° Panorama Preview</div>
+            <div className="canvas-panorama-title">{node?.title ?? '360 全景预览'}</div>
+          </div>
+          <div className="canvas-panorama-topbar-actions">
+            <span className="canvas-panorama-meta">{aspectLabel}</span>
+            <Button
+              icon={fullscreen ? <Icons.Minimize size={14} /> : <Icons.Maximize size={14} />}
+              onClick={() => setFullscreen((value) => !value)}
+            >
+              {fullscreen ? '退出全屏' : '沉浸全屏'}
+            </Button>
+            <Button icon={<Icons.X size={14} />} onClick={onClose} />
+          </div>
+        </div>
+
+        {src && (
+          <PanoramaWebglViewer
+            src={src}
+            fov={fov}
+            autorotate={autorotate}
+            onFovChange={setFov}
+            onLoadState={setLoadState}
+            onPoseChange={setPose}
+            onReady={(handle) => {
+              handleRef.current = handle
+            }}
+          />
+        )}
+
+        {isBusy && (
+          <div className="canvas-panorama-state">
+            <div className="canvas-panorama-spinner" />
+            <strong>正在加载全景图</strong>
+            <span>准备 WebGL 球面渲染与纹理采样…</span>
+          </div>
+        )}
+        {loadState === 'webgl-unavailable' && (
+          <div className="canvas-panorama-state canvas-panorama-state-error">
+            <strong>当前环境不支持 WebGL</strong>
+            <span>请在支持 WebGL 的浏览器 / Electron 渲染环境中打开 360 全景预览。</span>
+          </div>
+        )}
+        {loadState === 'error' && (
+          <div className="canvas-panorama-state canvas-panorama-state-error">
+            <strong>全景图加载失败</strong>
+            <span>请确认产物图片仍可访问，并且是 PNG / JPG / WebP 等浏览器可加载格式。</span>
+          </div>
+        )}
+
+        <div className="canvas-panorama-compass" aria-hidden>
+          <div
+            className="canvas-panorama-compass-needle"
+            style={{ transform: `rotate(${radiansToDegrees(pose.yaw)}deg)` }}
+          />
+          <span>N</span>
+        </div>
+
+        <div className="canvas-panorama-toolbar">
+          <Button icon={<Icons.RotateCcw size={14} />} onClick={() => handleRef.current?.reset()}>
+            重置
+          </Button>
+          <div className="canvas-panorama-switch">
+            <span>自动环视</span>
+            <Switch size="small" checked={autorotate} onChange={setAutorotate} />
+          </div>
+          <div className="canvas-panorama-telemetry">
+            <span>{formatYaw(pose.yaw)}</span>
+            <span>Pitch {radiansToDegrees(pose.pitch)}°</span>
+            <span>FOV {Math.round(fov)}°</span>
+          </div>
+          <span className="canvas-panorama-toolbar-label">远近</span>
+          <Slider
+            min={MIN_FOV}
+            max={MAX_FOV}
+            value={fov}
+            onChange={setFov}
+            className="canvas-panorama-zoom"
+            tooltip={{ formatter: (value) => `${value}°` }}
+          />
+          <Button
+            type="primary"
+            disabled={!canCapture}
+            icon={<Icons.Image size={14} />}
+            onClick={async () => {
+              if (!node) return
+              const dataUrl = handleRef.current?.screenshot()
+              if (!dataUrl) return
+              await onScreenshot(dataUrl, node, pose)
+            }}
+          >
+            截图生成场景图
+          </Button>
+        </div>
+        <div className="canvas-panorama-hint">
+          拖拽 / 触控滑动查看方向 · 滚轮 / 滑杆缩放 · 方向键环视 · +/- 缩放
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -7653,3 +7653,431 @@ body.canvas-side-panel-resizing {
 .canvas-operation-panel-text-input-content {
   white-space: pre-wrap;
 }
+
+.canvas-node-image-placeholder .canvas-panorama-badge,
+.canvas-node .canvas-panorama-badge {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+}
+
+.canvas-panorama-modal .ant-modal {
+  top: 0;
+  max-width: 100vw;
+  padding-bottom: 0;
+}
+
+.canvas-panorama-modal .ant-modal-content {
+  min-height: 100vh;
+  padding: 0;
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.canvas-panorama-modal .ant-modal-body {
+  padding: 0;
+}
+
+.canvas-panorama-modal .ant-modal-close {
+  display: none;
+}
+
+.canvas-panorama-shell {
+  position: relative;
+  display: flex;
+  height: 100vh;
+  min-height: 520px;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 50% 34%,
+      color-mix(in srgb, var(--primary) 18%, transparent),
+      transparent 42%
+    ),
+    radial-gradient(
+      circle at 12% 14%,
+      color-mix(in srgb, var(--canvas-accent-cyan) 12%, transparent),
+      transparent 28%
+    ),
+    var(--bg-sunken);
+  color: var(--text);
+}
+
+.canvas-panorama-webgl {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: block;
+  cursor: grab;
+  touch-action: none;
+}
+
+.canvas-panorama-webgl:active {
+  cursor: grabbing;
+}
+
+.canvas-panorama-topbar,
+.canvas-panorama-toolbar,
+.canvas-panorama-state,
+.canvas-panorama-compass,
+.canvas-panorama-hint {
+  box-sizing: border-box;
+  -webkit-app-region: no-drag;
+}
+
+.canvas-panorama-topbar {
+  position: absolute;
+  z-index: 4;
+  top: 14px;
+  left: 16px;
+  right: 16px;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: var(--r-xl);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #ffffff 7%, transparent), transparent),
+    color-mix(in srgb, var(--canvas-float-bg) 94%, transparent);
+  box-shadow:
+    0 18px 58px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 1px color-mix(in srgb, var(--divider) 44%, transparent);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+}
+
+.canvas-panorama-topbar > div:first-child {
+  min-width: 0;
+}
+
+.canvas-panorama-kicker {
+  overflow: hidden;
+  color: color-mix(in srgb, var(--primary) 82%, var(--canvas-accent-cyan));
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.canvas-panorama-title {
+  max-width: min(56vw, 760px);
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-panorama-topbar-actions {
+  display: flex;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.canvas-panorama-topbar-actions .ant-btn,
+.canvas-panorama-toolbar .ant-btn {
+  flex-shrink: 0;
+}
+
+.canvas-panorama-meta {
+  display: inline-flex;
+  max-width: 180px;
+  height: 28px;
+  align-items: center;
+  padding: 0 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--primary) 12%, var(--panel-elev));
+  color: color-mix(in srgb, var(--primary) 78%, var(--text));
+  font-size: 11px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.canvas-panorama-state {
+  position: absolute;
+  z-index: 3;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  width: min(360px, calc(100% - 40px));
+  transform: translate(-50%, -50%);
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 24px;
+  border-radius: var(--r-xl);
+  background: color-mix(in srgb, var(--canvas-float-bg) 92%, transparent);
+  box-shadow:
+    0 22px 68px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 1px color-mix(in srgb, var(--divider) 38%, transparent);
+  color: var(--text);
+  text-align: center;
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+}
+
+.canvas-panorama-state strong {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--text-strong);
+  font-size: 15px;
+}
+
+.canvas-panorama-state span {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.canvas-panorama-state-error {
+  background: color-mix(in srgb, var(--danger-bg) 72%, var(--canvas-float-bg));
+  box-shadow:
+    0 22px 68px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 1px color-mix(in srgb, var(--danger) 26%, transparent);
+}
+
+.canvas-panorama-spinner {
+  width: 34px;
+  height: 34px;
+  border: 3px solid color-mix(in srgb, var(--primary) 18%, transparent);
+  border-top-color: var(--primary);
+  border-radius: 999px;
+  animation: canvas-panorama-spin 0.9s linear infinite;
+}
+
+@keyframes canvas-panorama-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.canvas-panorama-compass {
+  position: absolute;
+  z-index: 4;
+  right: 24px;
+  bottom: clamp(104px, 16vh, 148px);
+  width: 58px;
+  height: 58px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--canvas-float-bg) 84%, transparent);
+  box-shadow:
+    0 14px 42px rgba(0, 0, 0, 0.2),
+    inset 0 0 0 1px color-mix(in srgb, var(--divider) 38%, transparent);
+  color: var(--text-strong);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+}
+
+.canvas-panorama-compass span {
+  position: absolute;
+  top: 5px;
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--danger);
+  font-size: 10px;
+  font-weight: 800;
+}
+
+.canvas-panorama-compass-needle {
+  position: absolute;
+  inset: 10px 27px;
+  transform-origin: 50% 50%;
+}
+
+.canvas-panorama-compass-needle::before,
+.canvas-panorama-compass-needle::after {
+  position: absolute;
+  left: -4px;
+  width: 8px;
+  height: 19px;
+  content: '';
+  clip-path: polygon(50% 0, 100% 100%, 0 100%);
+}
+
+.canvas-panorama-compass-needle::before {
+  top: 0;
+  background: var(--danger);
+}
+
+.canvas-panorama-compass-needle::after {
+  bottom: 0;
+  transform: rotate(180deg);
+  background: color-mix(in srgb, var(--primary) 70%, var(--text-muted));
+}
+
+.canvas-panorama-toolbar {
+  position: absolute;
+  z-index: 4;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  max-height: min(34vh, 190px);
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  padding: 10px 12px;
+  border-radius: var(--r-xl);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, #ffffff 5%, transparent), transparent),
+    color-mix(in srgb, var(--canvas-float-bg) 94%, transparent);
+  box-shadow:
+    0 18px 58px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 1px color-mix(in srgb, var(--divider) 42%, transparent);
+  color: var(--text);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+}
+
+.canvas-panorama-switch,
+.canvas-panorama-telemetry {
+  display: inline-flex;
+  min-height: 28px;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-elev) 74%, transparent);
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.canvas-panorama-switch span,
+.canvas-panorama-telemetry span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.canvas-panorama-telemetry {
+  flex: 0 1 auto;
+  gap: 10px;
+  color: color-mix(in srgb, var(--primary) 76%, var(--text));
+  font-variant-numeric: tabular-nums;
+}
+
+.canvas-panorama-toolbar-label {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.canvas-panorama-zoom {
+  width: clamp(140px, 18vw, 220px);
+  min-width: 120px;
+  margin: 0 6px;
+}
+
+.canvas-panorama-hint {
+  position: absolute;
+  z-index: 3;
+  top: 82px;
+  left: 50%;
+  max-width: min(720px, calc(100% - 40px));
+  transform: translateX(-50%);
+  padding: 7px 10px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--canvas-float-bg) 78%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--divider) 32%, transparent);
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.35;
+  pointer-events: none;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+}
+
+@media (max-width: 900px) {
+  .canvas-panorama-topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .canvas-panorama-title {
+    max-width: calc(100vw - 56px);
+  }
+
+  .canvas-panorama-topbar-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .canvas-panorama-hint {
+    display: none;
+  }
+
+  .canvas-panorama-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .canvas-panorama-telemetry {
+    max-width: 100%;
+    flex-wrap: wrap;
+    border-radius: var(--r-lg);
+    padding: 6px 10px;
+  }
+}
+
+@media (max-width: 620px), (max-height: 640px) {
+  .canvas-panorama-topbar {
+    top: 10px;
+    left: 10px;
+    right: 10px;
+    padding: 9px 10px;
+  }
+
+  .canvas-panorama-toolbar {
+    left: 10px;
+    right: 10px;
+    bottom: 10px;
+    max-height: 42vh;
+    padding: 9px 10px;
+  }
+
+  .canvas-panorama-meta {
+    max-width: 100%;
+  }
+
+  .canvas-panorama-compass {
+    right: 14px;
+    bottom: calc(42vh + 20px);
+    width: 48px;
+    height: 48px;
+  }
+
+  .canvas-panorama-compass-needle {
+    inset: 8px 22px;
+  }
+
+  .canvas-panorama-zoom {
+    width: min(100%, 220px);
+    flex: 1 1 160px;
+  }
+}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -19,6 +19,7 @@ import { CanvasTemplatePanel } from './CanvasTemplatePanel'
 import { CanvasFilmAssetCenter, type FilmCenterHandlers } from './CanvasFilmAssetCenter'
 import { CanvasAgentModal } from './CanvasAgentModal'
 import { CanvasOperationPanel } from './CanvasOperationPanel'
+import { CanvasPanoramaViewerModal } from './CanvasPanoramaViewerModal'
 import {
   CanvasShotDirectorPanel,
   type CanvasShotDirectorDraft,
@@ -478,6 +479,8 @@ function fallbackPromptForOperation(operation: CanvasOperationType): string {
   if (operation === 'image_edit') return '请基于输入图片进行自然编辑，保持主体与画面质量。'
   if (operation === 'image_to_image') return '请基于输入图片生成一个高质量变体。'
   if (operation === 'image_compose') return '请将输入图片自然合成为一张高质量图片。'
+  if (operation === 'panorama_360')
+    return '请基于输入内容生成一张可用于 360° 全景预览的等距柱状投影场景图。'
   if (operation === 'image_to_video') return '请基于输入图片生成一段自然流畅的视频。'
   if (operation === 'video_edit') return '请基于输入视频和参考帧进行自然视频编辑。'
   if (operation === 'audio_transcribe') return '请转写输入音频内容。'
@@ -1059,6 +1062,7 @@ export function CanvasWorkspaceView({
     'production' | 'boards' | 'assets' | 'details' | 'project'
   >('details')
   const [editingNodeId, setEditingNodeId] = useState<string | null>(null)
+  const [panoramaPreviewNodeId, setPanoramaPreviewNodeId] = useState<string | null>(null)
   const [directorStageNodeId, setDirectorStageNodeId] = useState<string | null>(null)
   const [activeOperationPanelNodeId, setActiveOperationPanelNodeId] = useState<string | null>(null)
   const [assetDetailResetKey, setAssetDetailResetKey] = useState(0)
@@ -1200,7 +1204,9 @@ export function CanvasWorkspaceView({
 
   // 是否有运行中/排队中的画布任务：离开画布会让后台任务进度无法回写，需让用户确认风险。
   const activeCanvasTaskCount = useMemo(
-    () => snapshot?.tasks.filter((task) => task.status === 'pending' || task.status === 'running').length ?? 0,
+    () =>
+      snapshot?.tasks.filter((task) => task.status === 'pending' || task.status === 'running')
+        .length ?? 0,
     [snapshot?.tasks],
   )
 
@@ -1271,6 +1277,10 @@ export function CanvasWorkspaceView({
   const editingNode = useMemo(
     () => snapshot?.nodes.find((node) => node.id === editingNodeId) ?? null,
     [editingNodeId, snapshot?.nodes],
+  )
+  const panoramaPreviewNode = useMemo(
+    () => snapshot?.nodes.find((node) => node.id === panoramaPreviewNodeId) ?? null,
+    [panoramaPreviewNodeId, snapshot?.nodes],
   )
   const selectedGroups = useMemo(
     () => selectedNodes.filter((node) => node.type === 'group'),
@@ -1507,6 +1517,12 @@ export function CanvasWorkspaceView({
         setActiveOperationPanelNodeId(nodeId)
         return
       }
+      if (node?.data.panorama360) {
+        closeCanvasFloatPanels('node-edit')
+        setSelectedNodeIds([nodeId])
+        setPanoramaPreviewNodeId(nodeId)
+        return
+      }
       if (node?.data.subtype === 'director_stage') {
         closeCanvasFloatPanels('node-edit')
         setSelectedNodeIds([nodeId])
@@ -1527,6 +1543,58 @@ export function CanvasWorkspaceView({
       setEditingNodeId(null)
     },
     [patchNodes, updateNodeData],
+  )
+
+  const handlePanoramaScreenshot = useCallback(
+    async (
+      dataUrl: string,
+      sourceNode: CanvasNode,
+      pose: { yaw: number; pitch: number; fov: number },
+    ) => {
+      if (!snapshot) return
+      const { readImageDimensions } = await import('./canvas-safe-file')
+      const dimensions = await readImageDimensions(dataUrl)
+      const blob = await (await fetch(dataUrl)).blob()
+      const file = new File([blob], `panorama-viewport-${Date.now()}.png`, { type: 'image/png' })
+      const savedImage = await window.spark.invoke('file:save-pasted-image', {
+        dataUrl,
+        mimeType: 'image/png',
+        suggestedBaseName: 'panorama-viewport',
+        storageScope: 'canvas',
+        ...(snapshot.project.rootPath ? { projectRootPath: snapshot.project.rootPath } : {}),
+      })
+      const node = await createImageNode({
+        file,
+        filePath: savedImage.filePath,
+        x: sourceNode.x + sourceNode.width + 60,
+        y: sourceNode.y,
+        width: 320,
+        height: 180,
+        imageWidth: dimensions.width,
+        imageHeight: dimensions.height,
+      })
+      if (node) {
+        await patchNodes([node.id], { title: '全景视口截图' })
+        await updateNodeData(node.id, {
+          ...node.data,
+          message: '从 360 全景预览当前视口截图生成',
+          modelParams: {
+            ...(node.data.modelParams ?? {}),
+            panoramaViewport: {
+              sourceNodeId: sourceNode.id,
+              yaw: pose.yaw,
+              pitch: pose.pitch,
+              fov: pose.fov,
+              capturedAt: new Date().toISOString(),
+            },
+          },
+        })
+        await connectNodes({ sourceNodeId: sourceNode.id, targetNodeId: node.id })
+        setSelectedNodeIds([node.id])
+        message.success('已从当前全景视口生成场景图片节点')
+      }
+    },
+    [connectNodes, createImageNode, patchNodes, snapshot, updateNodeData],
   )
 
   // ─── 节点创建动作（useCallback，必须在 early return 之前）────────────────
@@ -2135,6 +2203,7 @@ export function CanvasWorkspaceView({
         'image_to_image',
         'image_edit',
         'image_compose',
+        'panorama_360',
         'text_to_video',
         'image_to_video',
         'video_edit',
@@ -3747,6 +3816,12 @@ export function CanvasWorkspaceView({
             onClose={() => setEditingNodeId(null)}
             onSave={handleSaveNodeEdit}
             onCreatePromptTask={(input) => void handleCreateTask({ ...input, inputNodeIds: [] })}
+          />
+          <CanvasPanoramaViewerModal
+            node={panoramaPreviewNode}
+            open={Boolean(panoramaPreviewNode)}
+            onClose={() => setPanoramaPreviewNodeId(null)}
+            onScreenshot={handlePanoramaScreenshot}
           />
           <CanvasDirectorStageModal
             key={directorStageNode?.id}

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -55,6 +55,18 @@ const STORAGE_KEY = 'spark-canvas:v1'
 const USER_ID = 0
 const PROVIDER_NOT_CONFIGURED_MESSAGE = '请先在『模型 / Agent 配置』中添加可用模型'
 
+const PANORAMA_360_PROMPT_PREFIX = `请基于入参生成一张可用于 360° 全景查看器的完整场景全景图。必须输出单张 2:1 等距柱状投影（equirectangular panorama）图片，覆盖水平 360° 与垂直 180° 视野；左右边缘必须无缝衔接，地平线保持水平，避免黑边、拼接缝、文字、水印、边框、鱼眼圆图、六面体展开图或多宫格。画面应适合映射到球体内部进行沉浸式 3D 预览。`
+
+function buildPanorama360Prompt(prompt: string | undefined): string {
+  const body = (prompt ?? '').trim()
+  return body
+    ? `${PANORAMA_360_PROMPT_PREFIX}
+
+入参/场景要求：
+${body}`
+    : PANORAMA_360_PROMPT_PREFIX
+}
+
 const MANUSCRIPT_SPLIT_MODE_LABELS: Record<ChapterSplitMode, string> = {
   heading: '按标题',
   length: '按长度分片',
@@ -246,6 +258,7 @@ const MEDIA_OPERATIONS = new Set<CanvasOperationType>([
   'image_to_image',
   'image_edit',
   'image_compose',
+  'panorama_360',
   'text_to_audio',
   'audio_transcribe',
   'text_to_video',
@@ -3395,7 +3408,9 @@ export const canvasApi = {
       progress: 12,
       message: '任务已创建，等待 agent/provider 接入',
     }
-    if (request.prompt != null) taskNodeData.prompt = request.prompt
+    const requestPrompt =
+      request.operation === 'panorama_360' ? buildPanorama360Prompt(request.prompt) : request.prompt
+    if (requestPrompt != null) taskNodeData.prompt = requestPrompt
 
     const taskNode = createNodeBase({
       projectId,
@@ -3420,7 +3435,7 @@ export const canvasApi = {
       status: 'pending',
       progress: 12,
       title: operationLabel(request.operation),
-      prompt: request.prompt ?? null,
+      prompt: requestPrompt ?? null,
       negativePrompt: request.negativePrompt ?? null,
       inputNodeIds: request.inputNodeIds ?? [],
       inputAssetIds: request.inputAssetIds ?? [],
@@ -3556,7 +3571,9 @@ export const canvasApi = {
       progress,
       message: messageText,
     }
-    if (request.prompt != null) taskNodeData.prompt = request.prompt
+    const requestPrompt =
+      request.operation === 'panorama_360' ? buildPanorama360Prompt(request.prompt) : request.prompt
+    if (requestPrompt != null) taskNodeData.prompt = requestPrompt
 
     let taskNode: CanvasNode
     const bindNode = request.bindToNodeId
@@ -3775,7 +3792,9 @@ export const canvasApi = {
         .find((value): value is string => value != null) ||
       nonEmptyString(project?.settings?.prompt) ||
       ''
-    const prompt = nonEmptyString(input.prompt) ?? inheritedPrompt
+    const basePrompt = nonEmptyString(input.prompt) ?? inheritedPrompt
+    const prompt =
+      input.operation === 'panorama_360' ? buildPanorama360Prompt(basePrompt) : basePrompt
     const inheritedNegativePrompt =
       inputTasks
         .map((task) => nonEmptyString(task.negativePrompt))
@@ -4081,7 +4100,9 @@ export const canvasApi = {
       progress: 24,
       message: '调用平台 adapter 中…',
     }
-    if (request.prompt != null) taskNodeData.prompt = request.prompt
+    const requestPrompt =
+      request.operation === 'panorama_360' ? buildPanorama360Prompt(request.prompt) : request.prompt
+    if (requestPrompt != null) taskNodeData.prompt = requestPrompt
     // 专用流水线节点：任务节点角色 + 暂存产物节点角色（供完成回写读取）
     if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
     if (request.outputPipelineRole != null)
@@ -4120,7 +4141,7 @@ export const canvasApi = {
       status: 'running',
       progress: 24,
       title: operationLabel(request.operation),
-      prompt: request.prompt ?? null,
+      prompt: requestPrompt ?? null,
       negativePrompt: request.negativePrompt ?? null,
       inputNodeIds: request.inputNodeIds ?? [],
       inputAssetIds: request.inputAssetIds ?? [],
@@ -4158,7 +4179,7 @@ export const canvasApi = {
       projectId,
       clientTaskId: taskId,
       operation: request.operation,
-      ...(request.prompt != null ? { prompt: request.prompt } : {}),
+      ...(requestPrompt != null ? { prompt: requestPrompt } : {}),
       ...(request.negativePrompt != null ? { negativePrompt: request.negativePrompt } : {}),
       ...(request.inputFiles != null ? { inputFiles: request.inputFiles } : {}),
       ...(request.providerProfileId != null
@@ -4217,7 +4238,9 @@ export const canvasApi = {
       progress: 30,
       message: '调用文本模型中…',
     }
-    if (request.prompt != null) taskNodeData.prompt = request.prompt
+    const requestPrompt =
+      request.operation === 'panorama_360' ? buildPanorama360Prompt(request.prompt) : request.prompt
+    if (requestPrompt != null) taskNodeData.prompt = requestPrompt
     // 专用流水线节点：任务节点角色 + 暂存产物节点角色（供完成回写读取）
     if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
     if (request.outputPipelineRole != null)
@@ -4534,6 +4557,7 @@ export const canvasApi = {
           : null
       const assetWidth = assetOut.width ?? detectedImageSize?.width ?? null
       const assetHeight = assetOut.height ?? detectedImageSize?.height ?? null
+      const isPanorama360 = task.operation === 'panorama_360' && assetType === 'image'
       const asset: CanvasAsset = {
         id: uid('canvas_asset'),
         projectId,
@@ -4554,6 +4578,9 @@ export const canvasApi = {
         ...(assetOut.durationMs != null ? { durationMs: assetOut.durationMs } : {}),
         metadata: {
           taskId,
+          ...(isPanorama360
+            ? { panorama360: { projection: 'equirectangular', sourceOperation: 'panorama_360' } }
+            : {}),
           provider: response.provider,
           model: response.model,
           requestId: responseRequestId,
@@ -4582,6 +4609,8 @@ export const canvasApi = {
         if (displayUrl) nodeData.url = displayUrl
         if (asset.mimeType) nodeData.mimeType = asset.mimeType
         if (assetType === 'image' && asset.thumbnailUrl) nodeData.thumbnailUrl = asset.thumbnailUrl
+        if (isPanorama360)
+          nodeData.panorama360 = { projection: 'equirectangular', sourceOperation: 'panorama_360' }
       }
       const resultNodeSize = fitMediaNodeSize(assetType, assetWidth, assetHeight)
       const resultNode = createNodeBase({

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.capabilities.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.capabilities.ts
@@ -1,4 +1,9 @@
-import type { CanvasCapability, CanvasNode, CanvasNodeType, CanvasOperationType } from './canvas.types'
+import type {
+  CanvasCapability,
+  CanvasNode,
+  CanvasNodeType,
+  CanvasOperationType,
+} from './canvas.types'
 
 export const CANVAS_CAPABILITIES: CanvasCapability[] = [
   {
@@ -24,6 +29,15 @@ export const CANVAS_CAPABILITIES: CanvasCapability[] = [
     label: '多图合成',
     operation: 'image_compose',
     inputTypes: ['image', 'text', 'prompt'],
+    outputTypes: ['image'],
+    enabled: true,
+    paramsSchema: {},
+  },
+  {
+    id: 'canvas.panorama-360',
+    label: '360 全景图',
+    operation: 'panorama_360',
+    inputTypes: ['text', 'prompt', 'image'],
     outputTypes: ['image'],
     enabled: true,
     paramsSchema: {},
@@ -116,6 +130,7 @@ export const OPERATION_NODE_TYPES: ReadonlySet<string> = new Set<CanvasNodeType>
   'image_to_image',
   'image_edit',
   'image_compose',
+  'panorama_360',
   'text_generate',
   'text_rewrite',
   'prompt_optimize',
@@ -153,6 +168,8 @@ export function operationNodeIcon(op: CanvasOperationType | null): string {
       return '🎨'
     case 'image_compose':
       return '🧩'
+    case 'panorama_360':
+      return '🌐'
     case 'text_generate':
       return '📝'
     case 'text_rewrite':

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
@@ -17,6 +17,7 @@ export type CanvasNodeType =
   | 'image_to_image'
   | 'image_edit'
   | 'image_compose'
+  | 'panorama_360'
   | 'text_generate'
   | 'text_rewrite'
   | 'prompt_optimize'
@@ -35,6 +36,7 @@ export type CanvasOperationType =
   | 'image_to_image'
   | 'image_edit'
   | 'image_compose'
+  | 'panorama_360'
   | 'text_generate'
   | 'text_rewrite'
   | 'prompt_optimize'
@@ -186,6 +188,12 @@ export type CanvasNodeData = {
   outputPipelineRole?: CanvasPipelineRole
   /** 3D 导演台节点数据：三维对象、摄像机、网格与导出提示词。 */
   directorStage?: Record<string, unknown>
+  /** 360 全景图产物标记：基于 equirectangular panorama 渲染全屏 3D 预览。 */
+  panorama360?: {
+    projection: 'equirectangular'
+    sourceOperation?: 'panorama_360'
+    capturedFromNodeId?: string
+  }
 }
 
 export type CanvasNode = {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationIcons.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationIcons.tsx
@@ -23,28 +23,82 @@ const ICON_SIZE = 15
 export function getOperationVisual(operation: CanvasOperationType): OperationVisual {
   switch (operation) {
     case 'text_to_image':
-      return { icon: <Icons.ImagePlus size={ICON_SIZE} />, category: 'image', colorClass: 'canvas-op-color-image' }
+      return {
+        icon: <Icons.ImagePlus size={ICON_SIZE} />,
+        category: 'image',
+        colorClass: 'canvas-op-color-image',
+      }
     case 'image_to_image':
-      return { icon: <Icons.Refresh size={ICON_SIZE} />, category: 'image', colorClass: 'canvas-op-color-image' }
+      return {
+        icon: <Icons.Refresh size={ICON_SIZE} />,
+        category: 'image',
+        colorClass: 'canvas-op-color-image',
+      }
     case 'image_edit':
-      return { icon: <Icons.Brush size={ICON_SIZE} />, category: 'image', colorClass: 'canvas-op-color-image' }
+      return {
+        icon: <Icons.Brush size={ICON_SIZE} />,
+        category: 'image',
+        colorClass: 'canvas-op-color-image',
+      }
     case 'image_compose':
-      return { icon: <Icons.Combine size={ICON_SIZE} />, category: 'image', colorClass: 'canvas-op-color-image' }
+      return {
+        icon: <Icons.Combine size={ICON_SIZE} />,
+        category: 'image',
+        colorClass: 'canvas-op-color-image',
+      }
+    case 'panorama_360':
+      return {
+        icon: <Icons.Globe size={ICON_SIZE} />,
+        category: 'image',
+        colorClass: 'canvas-op-color-image',
+      }
     case 'text_generate':
-      return { icon: <Icons.FileText size={ICON_SIZE} />, category: 'text', colorClass: 'canvas-op-color-text' }
+      return {
+        icon: <Icons.FileText size={ICON_SIZE} />,
+        category: 'text',
+        colorClass: 'canvas-op-color-text',
+      }
     case 'text_rewrite':
-      return { icon: <Icons.RotateCw size={ICON_SIZE} />, category: 'text', colorClass: 'canvas-op-color-text' }
+      return {
+        icon: <Icons.RotateCw size={ICON_SIZE} />,
+        category: 'text',
+        colorClass: 'canvas-op-color-text',
+      }
     case 'prompt_optimize':
-      return { icon: <Icons.Wand size={ICON_SIZE} />, category: 'text', colorClass: 'canvas-op-color-text' }
+      return {
+        icon: <Icons.Wand size={ICON_SIZE} />,
+        category: 'text',
+        colorClass: 'canvas-op-color-text',
+      }
     case 'text_to_audio':
-      return { icon: <Icons.Mic size={ICON_SIZE} />, category: 'audio', colorClass: 'canvas-op-color-audio' }
+      return {
+        icon: <Icons.Mic size={ICON_SIZE} />,
+        category: 'audio',
+        colorClass: 'canvas-op-color-audio',
+      }
     case 'audio_transcribe':
-      return { icon: <Icons.AudioLines size={ICON_SIZE} />, category: 'audio', colorClass: 'canvas-op-color-audio' }
+      return {
+        icon: <Icons.AudioLines size={ICON_SIZE} />,
+        category: 'audio',
+        colorClass: 'canvas-op-color-audio',
+      }
     case 'text_to_video':
-      return { icon: <Icons.Film size={ICON_SIZE} />, category: 'video', colorClass: 'canvas-op-color-video' }
+      return {
+        icon: <Icons.Film size={ICON_SIZE} />,
+        category: 'video',
+        colorClass: 'canvas-op-color-video',
+      }
     case 'image_to_video':
-      return { icon: <Icons.Play size={ICON_SIZE} />, category: 'video', colorClass: 'canvas-op-color-video' }
+      return {
+        icon: <Icons.Play size={ICON_SIZE} />,
+        category: 'video',
+        colorClass: 'canvas-op-color-video',
+      }
     case 'video_edit':
-      return { icon: <Icons.Scissors size={ICON_SIZE} />, category: 'video', colorClass: 'canvas-op-color-video' }
+      return {
+        icon: <Icons.Scissors size={ICON_SIZE} />,
+        category: 'video',
+        colorClass: 'canvas-op-color-video',
+      }
   }
 }

--- a/packages/protocol/src/media-config.ts
+++ b/packages/protocol/src/media-config.ts
@@ -220,6 +220,7 @@ export type CanvasOperationType =
   | 'image_to_image'
   | 'image_edit'
   | 'image_compose'
+  | 'panorama_360'
   | 'text_generate'
   | 'text_rewrite'
   | 'prompt_optimize'
@@ -240,6 +241,8 @@ export function capabilityForOperation(operation: CanvasOperationType): MediaCap
       return ['image.edit']
     case 'image_compose':
       return ['image.edit']
+    case 'panorama_360':
+      return ['image.generate']
     case 'text_to_audio':
       return ['audio.speech']
     case 'audio_transcribe':

--- a/packages/protocol/src/schemas/index.ts
+++ b/packages/protocol/src/schemas/index.ts
@@ -832,6 +832,7 @@ export const IpcSchemaRegistry = {
       'image_to_image',
       'image_edit',
       'image_compose',
+      'panorama_360',
       'text_generate',
       'text_rewrite',
       'prompt_optimize',


### PR DESCRIPTION
### Motivation
- Add first-class support for 360° equirectangular panorama generation and preview in the Canvas feature set.
- Provide a dedicated WebGL viewer for interactive panorama inspection and a screenshot-to-node workflow for generating scene images from a viewport.
- Ensure backend/task plumbing treats `panorama_360` consistently (capabilities, prompts, asset metadata) across the stack.

### Description
- Introduce `panorama_360` operation and node type across types and protocol schemas by updating `canvas.types.ts`, `packages/protocol` schemas, and capability mappings (including `capabilityForOperation`).
- Add a `PANORAMA_360` prompt prefix builder (`buildPanorama360Prompt`) and apply it when creating or starting `panorama_360` tasks in `canvas.api.ts` so generated tasks include required equirectangular instructions.
- Implement `CanvasPanoramaViewerModal` (WebGL viewer) with interactive controls, autorotate, screenshot API, and integrate it into `CanvasWorkspaceView` with `handlePanoramaScreenshot` to save screenshots as image nodes and attach viewport metadata.
- Mark panorama assets/nodes with panorama metadata on task completion and expose UI affordances: node icon/label changes in `CanvasNode.tsx`, operation icon in `canvasOperationIcons.tsx`, capability entry in `canvas.capabilities.ts`, new CSS rules in `CanvasWorkspaceView.less`, and fallback prompt additions where relevant.
- Miscellaneous: small formatting/JSX tidies and list/array formatting adjustments to align with the new operation.

### Testing
- Ran TypeScript build (`yarn build` / `tsc`) and type checks: succeeded.
- Ran unit tests via the repository test suite (`yarn test`): all tests passed.
- Ran linting (`yarn lint` / ESLint): no new lint errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd42beff4832590d869bfcb26499c)