### PR TITLE
Canvas: add “Merge Group to Image” action and html2canvas-based snapshot export

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
     "antd": "^6.4.4",
     "better-sqlite3": "^11.10.0",
     "electron-updater": "^6.8.3",
+    "html2canvas": "^1.4.1",
     "js-yaml": "^4.1.1",
     "katex": "^0.17.0",
     "keytar": "^7.9.0",

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -81,14 +81,21 @@ function DirectorStageMini({ data }: { data: SparkCanvasNode['data'] }) {
   const stage = readDirectorStageMini(data)
   const toPlan = (x: number, z: number) => ({ px: 50 + x * 40, py: 50 + z * 40 })
   const cam = stage ? toPlan(stage.camera.x, stage.camera.z) : { px: 50, py: 90 }
-  const head = (deg: number) => ({ hx: Math.sin((deg * Math.PI) / 180), hy: -Math.cos((deg * Math.PI) / 180) })
+  const head = (deg: number) => ({
+    hx: Math.sin((deg * Math.PI) / 180),
+    hy: -Math.cos((deg * Math.PI) / 180),
+  })
   const fov = stage?.camera.fov ?? 50
   const facing = stage?.camera.facing ?? 0
   const left = head(facing - fov / 2)
   const right = head(facing + fov / 2)
   const L = 120
   return (
-    <svg className="canvas-node-director-mini" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
+    <svg
+      className="canvas-node-director-mini"
+      viewBox="0 0 100 100"
+      preserveAspectRatio="xMidYMid slice"
+    >
       <defs>
         <clipPath id="mini-stage-clip">
           <rect x="8" y="8" width="84" height="84" rx="4" />
@@ -110,7 +117,9 @@ function DirectorStageMini({ data }: { data: SparkCanvasNode['data'] }) {
       />
       {stage?.items.map((item, index) => {
         const p = toPlan(item.x, item.z)
-        return <circle key={index} cx={p.px} cy={p.py} r={3.4} fill={item.color} className="mini-dot" />
+        return (
+          <circle key={index} cx={p.px} cy={p.py} r={3.4} fill={item.color} className="mini-dot" />
+        )
       })}
       <rect x={cam.px - 3} y={cam.py - 3} width={6} height={6} rx={1.4} className="mini-cam" />
     </svg>
@@ -160,6 +169,7 @@ export type CanvasFlowNodeData = {
     deleteNode: (nodeId: string) => void
     toggleLockNode: (nodeId: string) => void
     bringNodeToFront: (nodeId: string) => void
+    mergeGroupToImage: (groupId: string) => void
     createGroupFromSelection: () => void
     addSelectionToGroup: (groupId: string) => void
     removeNodeFromGroup: (nodeId: string) => void
@@ -399,6 +409,15 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
       ...(isGroup
         ? [
             {
+              key: 'merge-group-to-image',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Image size={14} /> 多图合并
+                </span>
+              ),
+              onClick: () => actions.mergeGroupToImage(node.id),
+            },
+            {
               key: 'add-to-group',
               disabled: selectedCount < 2,
               label: (
@@ -491,6 +510,7 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
   return (
     <Dropdown trigger={['contextMenu']} menu={menu} placement="bottomLeft">
       <div
+        data-canvas-node-id={node.id}
         className={`canvas-node canvas-node-${node.type}${selected ? ' canvas-node-selected' : ''}${roleMeta ? ' canvas-node-has-role' : ''}`}
         {...(roleMeta ? { style: { ['--role-color' as string]: roleMeta.color } } : {})}
         onDoubleClick={(event) => {
@@ -657,7 +677,9 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
           ) : isDirectorStage ? (
             <div className="canvas-node-director-stage">
               <DirectorStageMini data={node.data} />
-              <div className="canvas-node-director-stage-hint">双击编排画面 · 站位 / 取景 / 提示词</div>
+              <div className="canvas-node-director-stage-hint">
+                双击编排画面 · 站位 / 取景 / 提示词
+              </div>
             </div>
           ) : isOperationNode(node) ? (
             <div className="canvas-node-task canvas-node-operation">

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
@@ -144,6 +144,7 @@ export function CanvasStage({
   onDeleteNode,
   onToggleLockNode,
   onBringNodeToFront,
+  onMergeGroupToImage,
   onCreateGroupFromSelection,
   onAddSelectionToGroup,
   onRemoveNodeFromGroup,
@@ -177,6 +178,7 @@ export function CanvasStage({
   onDeleteNode: (nodeId: string) => void
   onToggleLockNode: (nodeId: string) => void
   onBringNodeToFront: (nodeId: string) => void
+  onMergeGroupToImage: (groupId: string) => void
   onCreateGroupFromSelection: () => void
   onAddSelectionToGroup: (groupId: string) => void
   onRemoveNodeFromGroup: (nodeId: string) => void
@@ -220,6 +222,7 @@ export function CanvasStage({
       deleteNode: onDeleteNode,
       toggleLockNode: onToggleLockNode,
       bringNodeToFront: onBringNodeToFront,
+      mergeGroupToImage: onMergeGroupToImage,
       createGroupFromSelection: onCreateGroupFromSelection,
       addSelectionToGroup: onAddSelectionToGroup,
       removeNodeFromGroup: onRemoveNodeFromGroup,
@@ -239,6 +242,7 @@ export function CanvasStage({
       onDissolveGroup,
       onDuplicateNode,
       onEditNode,
+      onMergeGroupToImage,
       onOpenAiComposer,
       onRemoveNodeFromGroup,
       onCreateOperationChild,
@@ -664,9 +668,7 @@ export function CanvasStage({
     }) => {
       onSelectionChange(selected.map((node) => node.id))
       const nextEdgeIds = selectedEdges.map((edge) => edge.id)
-      setSelectedEdgeIds((previous) =>
-        sameIdList(previous, nextEdgeIds) ? previous : nextEdgeIds,
-      )
+      setSelectedEdgeIds((previous) => (sameIdList(previous, nextEdgeIds) ? previous : nextEdgeIds))
       if (selectedEdges.length === 0) setEdgeContextMenu(null)
     },
     [onSelectionChange],

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -132,6 +132,36 @@ async function dataUrlToFile(dataUrl: string, fileName: string): Promise<File> {
   return new File([blob], fileName, { type: blob.type || 'image/png' })
 }
 
+function cssEscape(value: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(value)
+  return value.replace(/["\\]/g, '\\$&')
+}
+
+function buildCanvasSnapshotFileName(title: string | undefined): string {
+  const safeTitle = (title || 'group')
+    .trim()
+    .replace(/[^\p{L}\p{N}_-]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48)
+  return `${safeTitle || 'group'}-merged-${Date.now()}.png`
+}
+
+function collectGroupDescendantNodes(nodes: CanvasNode[], groupId: string): CanvasNode[] {
+  const descendants: CanvasNode[] = []
+  const queue = nodes.filter((node) => node.parentNodeId === groupId)
+
+  while (queue.length > 0) {
+    const node = queue.shift()
+    if (!node) continue
+    descendants.push(node)
+    if (node.type === 'group') {
+      queue.push(...nodes.filter((candidate) => candidate.parentNodeId === node.id))
+    }
+  }
+
+  return descendants
+}
+
 const CANVAS_SIDE_PANEL_WIDTH_KEY = 'spark-canvas:side-panel-width'
 const CANVAS_SIDE_PANEL_DEFAULT_WIDTH = 360
 const CANVAS_SIDE_PANEL_MIN_WIDTH = 300
@@ -1063,6 +1093,7 @@ export function CanvasWorkspaceView({
   const [activeOperationPanelNodeId, setActiveOperationPanelNodeId] = useState<string | null>(null)
   const [assetDetailResetKey, setAssetDetailResetKey] = useState(0)
   const canvasViewportRef = useRef<CanvasStageViewport | null>(null)
+  const mergingGroupImageIdsRef = useRef(new Set<string>())
   const [sidePanelWidth, setSidePanelWidth] = useState(readSidePanelWidth)
   const [sidePanelCollapsed, setSidePanelCollapsed] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -1200,7 +1231,9 @@ export function CanvasWorkspaceView({
 
   // 是否有运行中/排队中的画布任务：离开画布会让后台任务进度无法回写，需让用户确认风险。
   const activeCanvasTaskCount = useMemo(
-    () => snapshot?.tasks.filter((task) => task.status === 'pending' || task.status === 'running').length ?? 0,
+    () =>
+      snapshot?.tasks.filter((task) => task.status === 'pending' || task.status === 'running')
+        .length ?? 0,
     [snapshot?.tasks],
   )
 
@@ -1450,6 +1483,152 @@ export function CanvasWorkspaceView({
       void patchNodes([nodeId], { zIndex: maxZ + 1 })
     },
     [patchNodes, snapshot?.nodes],
+  )
+
+  const handleMergeGroupToImage = useCallback(
+    async (groupId: string) => {
+      if (mergingGroupImageIdsRef.current.has(groupId)) {
+        message.info('正在合成该组，请稍候')
+        return
+      }
+
+      const currentSnapshot = snapshot
+      const groupNode = currentSnapshot?.nodes.find(
+        (node) => node.id === groupId && node.type === 'group',
+      )
+      if (!currentSnapshot || !groupNode) return
+      const childNodes = collectGroupDescendantNodes(currentSnapshot.nodes, groupId)
+      if (childNodes.length === 0) {
+        message.warning('组内没有可合成的节点')
+        return
+      }
+
+      const stageElement = document.querySelector<HTMLElement>('.canvas-stage-area')
+      const nodeElements = [groupNode, ...childNodes]
+        .map((node) =>
+          document.querySelector<HTMLElement>(`[data-canvas-node-id="${cssEscape(node.id)}"]`),
+        )
+        .filter((element): element is HTMLElement => Boolean(element))
+
+      if (!stageElement || nodeElements.length === 0) {
+        message.error('无法定位组节点画面，请稍后重试')
+        return
+      }
+
+      const stageRect = stageElement.getBoundingClientRect()
+      const unionRect = nodeElements.reduce(
+        (rect, element) => {
+          const current = element.getBoundingClientRect()
+          return {
+            left: Math.min(rect.left, current.left),
+            top: Math.min(rect.top, current.top),
+            right: Math.max(rect.right, current.right),
+            bottom: Math.max(rect.bottom, current.bottom),
+          }
+        },
+        { left: Number.POSITIVE_INFINITY, top: Number.POSITIVE_INFINITY, right: 0, bottom: 0 },
+      )
+
+      const padding = 12
+      const cropX = Math.max(0, Math.floor(unionRect.left - stageRect.left - padding))
+      const cropY = Math.max(0, Math.floor(unionRect.top - stageRect.top - padding))
+      const cropWidth = Math.min(
+        Math.ceil(unionRect.right - unionRect.left + padding * 2),
+        Math.floor(stageRect.width - cropX),
+      )
+      const cropHeight = Math.min(
+        Math.ceil(unionRect.bottom - unionRect.top + padding * 2),
+        Math.floor(stageRect.height - cropY),
+      )
+
+      if (cropWidth <= 0 || cropHeight <= 0) {
+        message.error('组节点当前不在可截图区域内，请先移动视图后再合成')
+        return
+      }
+
+      mergingGroupImageIdsRef.current.add(groupId)
+
+      const hideElements = Array.from(
+        stageElement.querySelectorAll<HTMLElement>(
+          '.react-flow__controls, .canvas-minimap, .canvas-alignment-guides, .canvas-edge-delete-button',
+        ),
+      )
+      const previousVisibility = hideElements.map((element) => element.style.visibility)
+      hideElements.forEach((element) => {
+        element.style.visibility = 'hidden'
+      })
+
+      try {
+        const { default: html2canvas } = await import('html2canvas')
+        const renderedCanvas = await html2canvas(stageElement, {
+          backgroundColor: null,
+          useCORS: true,
+          allowTaint: false,
+          logging: false,
+          scale: Math.min(2, window.devicePixelRatio || 1),
+        })
+        const scaleX = renderedCanvas.width / stageRect.width
+        const scaleY = renderedCanvas.height / stageRect.height
+        const outputCanvas = document.createElement('canvas')
+        outputCanvas.width = Math.max(1, Math.round(cropWidth * scaleX))
+        outputCanvas.height = Math.max(1, Math.round(cropHeight * scaleY))
+        const context = outputCanvas.getContext('2d')
+        if (!context) throw new Error('无法创建合成画布')
+        context.drawImage(
+          renderedCanvas,
+          Math.round(cropX * scaleX),
+          Math.round(cropY * scaleY),
+          outputCanvas.width,
+          outputCanvas.height,
+          0,
+          0,
+          outputCanvas.width,
+          outputCanvas.height,
+        )
+
+        const dataUrl = outputCanvas.toDataURL('image/png')
+        const file = await dataUrlToFile(
+          dataUrl,
+          buildCanvasSnapshotFileName(groupNode.title ?? undefined),
+        )
+        const savedImage = await window.spark.invoke('file:save-pasted-image', {
+          dataUrl,
+          mimeType: 'image/png',
+          suggestedBaseName: file.name.replace(/\.[^.]+$/, ''),
+          storageScope: 'canvas',
+          ...(currentSnapshot.project.rootPath
+            ? { projectRootPath: currentSnapshot.project.rootPath }
+            : {}),
+        })
+        const imageNode = await createImageNode({
+          file,
+          filePath: savedImage.filePath,
+          x: Math.round(groupNode.x + groupNode.width + 80),
+          y: Math.round(groupNode.y),
+          ...fitImageNodeSize(outputCanvas.width, outputCanvas.height),
+          imageWidth: outputCanvas.width,
+          imageHeight: outputCanvas.height,
+        })
+        if (imageNode) {
+          await patchNodes([imageNode.id], { title: `${groupNode.title ?? '组'} 合成图` })
+          setSelectedNodeIds([imageNode.id])
+        }
+        message.success('已在组右侧生成合成图节点')
+      } catch (error) {
+        console.error('[canvas] merge group to image failed', error)
+        message.error(
+          error instanceof Error
+            ? `合成图失败：${error.message}`
+            : '合成图失败，请检查组内图片是否可访问',
+        )
+      } finally {
+        hideElements.forEach((element, index) => {
+          element.style.visibility = previousVisibility[index] ?? ''
+        })
+        mergingGroupImageIdsRef.current.delete(groupId)
+      }
+    },
+    [createImageNode, patchNodes, snapshot],
   )
 
   const handleCreateGroup = useCallback(() => {
@@ -3504,6 +3683,7 @@ export function CanvasWorkspaceView({
             onDeleteNode={handleDeleteNode}
             onToggleLockNode={handleToggleLockNode}
             onBringNodeToFront={handleBringNodeToFront}
+            onMergeGroupToImage={handleMergeGroupToImage}
             onCreateGroupFromSelection={handleCreateGroup}
             onAddSelectionToGroup={handleAddSelectionToGroup}
             onRemoveNodeFromGroup={(nodeId) => handleRemoveFromGroup([nodeId])}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasAlignmentGuides.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasAlignmentGuides.test.ts
@@ -56,6 +56,7 @@ function createFlowNode(
         deleteNode: () => undefined,
         toggleLockNode: () => undefined,
         bringNodeToFront: () => undefined,
+        mergeGroupToImage: () => undefined,
         createGroupFromSelection: () => undefined,
         addSelectionToGroup: () => undefined,
         removeNodeFromGroup: () => undefined,

--- a/apps/desktop/src/renderer/design/views/canvas/canvasStageLayout.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasStageLayout.test.ts
@@ -46,6 +46,7 @@ function createFlowNode(
         deleteNode: () => undefined,
         toggleLockNode: () => undefined,
         bringNodeToFront: () => undefined,
+        mergeGroupToImage: () => undefined,
         createGroupFromSelection: () => undefined,
         addSelectionToGroup: () => undefined,
         removeNodeFromGroup: () => undefined,
@@ -64,9 +65,9 @@ function createFlowNode(
 describe('persistCanvasNodeLayoutChanges', () => {
   it('ignores non-layout ReactFlow changes', () => {
     const node = createCanvasNode()
-    const changes = [
-      { id: node.id, type: 'select', selected: true },
-    ] as NodeChange<Node<CanvasFlowNodeData>>[]
+    const changes = [{ id: node.id, type: 'select', selected: true }] as NodeChange<
+      Node<CanvasFlowNodeData>
+    >[]
 
     expect(persistCanvasNodeLayoutChanges([node], [createFlowNode(node)], changes)).toBeNull()
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       electron-updater:
         specifier: ^6.8.3
         version: 6.8.3
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -3031,6 +3034,10 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3425,6 +3432,9 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
@@ -4401,6 +4411,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -6535,6 +6549,9 @@ packages:
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   three@0.184.0:
     resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
 
@@ -6777,6 +6794,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
@@ -10076,6 +10096,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.32: {}
@@ -10499,6 +10521,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -11767,6 +11793,11 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   htmlparser2@10.1.0:
     dependencies:
@@ -14291,6 +14322,10 @@ snapshots:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   three@0.184.0: {}
 
   throttle-debounce@5.0.2: {}
@@ -14517,6 +14552,10 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@13.0.2: {}
 


### PR DESCRIPTION
### Motivation
- Add a UI action to export/merge a group (and its descendant nodes) into a single image so users can quickly generate a combined image from grouped canvas nodes.
- Introduce a client-side snapshotting flow that captures the rendered canvas area, crops to the group bounds and saves the merged image into project storage.

### Description
- Added `html2canvas` dependency and lockfile entries and dynamically import it in runtime to render the canvas for merging.
- Implemented `handleMergeGroupToImage` in `CanvasWorkspaceView.tsx` which collects group descendants, computes a union bounding box, renders the stage, crops and composes an output canvas, saves the image via `window.spark.invoke('file:save-pasted-image')` and creates a new image node via `createImageNode`.
- Added helpers `cssEscape`, `buildCanvasSnapshotFileName`, and `collectGroupDescendantNodes`, a re-entrancy guard `mergingGroupImageIdsRef`, and temporarily hides UI controls during rendering; also added `data-canvas-node-id` on nodes to locate DOM elements for screenshotting.
- Wired the new action through `CanvasNode` menu and `CanvasStage` props (`mergeGroupToImage`) and updated test mocks to include the new `mergeGroupToImage` action key.

### Testing
- Updated unit tests `canvasAlignmentGuides.test.ts` and `canvasStageLayout.test.ts` to include the new `mergeGroupToImage` stub in flow node action mocks and ran the test suite; the affected tests passed.
- Manual runtime safeguards were added (existence checks, error handling and user messages) and the merge flow logs and error messages on failure to aid diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3be19b26b08328af34dcdce006aba8)