### PR TITLE
Add image annotation modal and integrate image annotation flow into canvas

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasImageAnnotationModal.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasImageAnnotationModal.less
@@ -1,0 +1,124 @@
+.canvas-image-annotation-modal .ant-modal-content {
+  padding: 0;
+  overflow: hidden;
+  background: var(--color-bg-container, #f3f4f6);
+}
+
+.canvas-image-annotation-modal .ant-modal-close {
+  top: 12px;
+}
+
+.canvas-annotate-shell {
+  height: min(92vh, 980px);
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-layout, #eef0f3);
+}
+
+.canvas-annotate-toolbar {
+  height: 54px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 18px;
+  background: color-mix(in srgb, var(--color-bg-container, #f8fafc) 96%, transparent);
+  border-bottom: 1px solid var(--color-border-secondary, rgba(15, 23, 42, 0.1));
+}
+
+.canvas-annotate-toolbar button {
+  height: 34px;
+  min-width: 34px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-text, #111827);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.canvas-annotate-toolbar button:hover,
+.canvas-annotate-toolbar button.active {
+  background: var(--color-fill-secondary, rgba(15, 23, 42, 0.08));
+  border-color: var(--color-border, rgba(15, 23, 42, 0.12));
+}
+
+.canvas-annotate-text-input {
+  width: 180px;
+}
+
+.canvas-annotate-toolbar .color {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  border-radius: 6px;
+  border-color: var(--color-border, rgba(15, 23, 42, 0.18));
+}
+
+.canvas-annotate-toolbar .color.active {
+  outline: 3px solid color-mix(in srgb, var(--color-primary, #1677ff) 25%, transparent);
+}
+
+.canvas-annotate-divider {
+  width: 1px;
+  height: 26px;
+  background: var(--color-border-secondary, rgba(15, 23, 42, 0.12));
+  margin: 0 4px;
+}
+
+.canvas-annotate-spacer {
+  flex: 1;
+}
+
+.canvas-annotate-stage {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: 28px;
+}
+
+.canvas-annotate-stage canvas {
+  max-width: 100%;
+  max-height: 100%;
+  background: var(--color-bg-container, #fff);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.canvas-annotate-tool-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  font-weight: 700;
+}
+
+.canvas-annotate-tool-glyph.square {
+  border: 2px solid currentColor;
+}
+.canvas-annotate-tool-glyph.circle {
+  border: 2px solid currentColor;
+  border-radius: 999px;
+}
+.canvas-annotate-tool-glyph.mosaic {
+  border: 1px solid currentColor;
+  background-image:
+    linear-gradient(45deg, currentColor 25%, transparent 25%),
+    linear-gradient(-45deg, currentColor 25%, transparent 25%);
+  background-size: 6px 6px;
+  opacity: 0.75;
+}
+.canvas-annotate-tool-glyph.text {
+  border: 2px solid currentColor;
+  font-size: 13px;
+}
+.canvas-annotate-tool-glyph.crop {
+  font-size: 20px;
+  line-height: 1;
+}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasImageAnnotationModal.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasImageAnnotationModal.tsx
@@ -1,0 +1,373 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { Button, Input, Modal, Tooltip, message } from 'antd'
+import { normalizeEduAssetUrl } from '@spark/shared'
+import { Icons } from '../../Icons'
+import type { CanvasNode } from './canvas.types'
+import './CanvasImageAnnotationModal.less'
+
+type Tool = 'rect' | 'ellipse' | 'arrow' | 'pen' | 'mosaic' | 'text' | 'crop'
+type Point = { x: number; y: number }
+
+const DEFAULT_ANNOTATION_COLOR = '#ff4d4f'
+const COLORS = [
+  DEFAULT_ANNOTATION_COLOR,
+  '#faad14',
+  '#52c41a',
+  '#1677ff',
+  '#722ed1',
+  '#111827',
+  '#ffffff',
+]
+const TOOL_ITEMS: Array<{ key: Tool; label: string; icon: ReactNode }> = [
+  { key: 'rect', label: '方框标注', icon: <span className="canvas-annotate-tool-glyph square" /> },
+  {
+    key: 'ellipse',
+    label: '圆形标注',
+    icon: <span className="canvas-annotate-tool-glyph circle" />,
+  },
+  {
+    key: 'arrow',
+    label: '箭头标注',
+    icon: <span className="canvas-annotate-tool-glyph arrow">↗</span>,
+  },
+  { key: 'pen', label: '画笔自由标注', icon: <Icons.Edit size={16} /> },
+  {
+    key: 'mosaic',
+    label: '马赛克笔',
+    icon: <span className="canvas-annotate-tool-glyph mosaic" />,
+  },
+  {
+    key: 'text',
+    label: '文字标注',
+    icon: <span className="canvas-annotate-tool-glyph text">T</span>,
+  },
+  { key: 'crop', label: '裁切', icon: <span className="canvas-annotate-tool-glyph crop">⌗</span> },
+]
+
+function canvasPoint(
+  event: React.PointerEvent<HTMLCanvasElement>,
+  canvas: HTMLCanvasElement,
+): Point {
+  const rect = canvas.getBoundingClientRect()
+  return {
+    x: ((event.clientX - rect.left) / rect.width) * canvas.width,
+    y: ((event.clientY - rect.top) / rect.height) * canvas.height,
+  }
+}
+
+function drawArrow(ctx: CanvasRenderingContext2D, from: Point, to: Point) {
+  const angle = Math.atan2(to.y - from.y, to.x - from.x)
+  const headLength = 18
+  ctx.beginPath()
+  ctx.moveTo(from.x, from.y)
+  ctx.lineTo(to.x, to.y)
+  ctx.stroke()
+  ctx.beginPath()
+  ctx.moveTo(to.x, to.y)
+  ctx.lineTo(
+    to.x - headLength * Math.cos(angle - Math.PI / 6),
+    to.y - headLength * Math.sin(angle - Math.PI / 6),
+  )
+  ctx.moveTo(to.x, to.y)
+  ctx.lineTo(
+    to.x - headLength * Math.cos(angle + Math.PI / 6),
+    to.y - headLength * Math.sin(angle + Math.PI / 6),
+  )
+  ctx.stroke()
+}
+
+function applyMosaic(ctx: CanvasRenderingContext2D, point: Point, size = 24) {
+  const x = Math.max(0, Math.round(point.x - size / 2))
+  const y = Math.max(0, Math.round(point.y - size / 2))
+  const width = Math.min(size, ctx.canvas.width - x)
+  const height = Math.min(size, ctx.canvas.height - y)
+  if (width <= 0 || height <= 0) return
+  const image = ctx.getImageData(x, y, width, height)
+  let r = 0
+  let g = 0
+  let b = 0
+  const pixels = image.data.length / 4
+  for (let i = 0; i < image.data.length; i += 4) {
+    r += image.data[i] ?? 0
+    g += image.data[i + 1] ?? 0
+    b += image.data[i + 2] ?? 0
+  }
+  ctx.fillStyle = `rgb(${Math.round(r / pixels)}, ${Math.round(g / pixels)}, ${Math.round(b / pixels)})`
+  ctx.fillRect(x, y, width, height)
+}
+
+function restoreImage(canvas: HTMLCanvasElement, dataUrl: string): Promise<void> {
+  return new Promise((resolve) => {
+    const image = new Image()
+    image.onload = () => {
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return resolve()
+      canvas.width = image.naturalWidth || image.width
+      canvas.height = image.naturalHeight || image.height
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.drawImage(image, 0, 0)
+      resolve()
+    }
+    image.src = dataUrl
+  })
+}
+
+export function CanvasImageAnnotationModal({
+  open,
+  node,
+  onCancel,
+  onComplete,
+}: {
+  open: boolean
+  node: CanvasNode | null
+  onCancel: () => void
+  onComplete: (input: {
+    dataUrl: string
+    width: number
+    height: number
+    sourceNode: CanvasNode
+  }) => void
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const draftRef = useRef<string | null>(null)
+  const drawingRef = useRef(false)
+  const startRef = useRef<Point | null>(null)
+  const [tool, setTool] = useState<Tool>('rect')
+  const [color, setColor] = useState<string>(DEFAULT_ANNOTATION_COLOR)
+  const [history, setHistory] = useState<string[]>([])
+  const [readySrc, setReadySrc] = useState<string | null>(null)
+  const [textDraft, setTextDraft] = useState('标注')
+  const src = useMemo(
+    () => normalizeEduAssetUrl(node?.data.thumbnailUrl ?? node?.data.url ?? ''),
+    [node],
+  )
+
+  const pushHistory = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    setHistory((items) => [...items.slice(-19), canvas.toDataURL('image/png')])
+  }, [])
+
+  useEffect(() => {
+    if (!open || !src) return
+    const image = new Image()
+    image.crossOrigin = 'anonymous'
+    image.onload = () => {
+      const canvas = canvasRef.current
+      const ctx = canvas?.getContext('2d')
+      if (!canvas || !ctx) return
+      canvas.width = image.naturalWidth || image.width
+      canvas.height = image.naturalHeight || image.height
+      ctx.drawImage(image, 0, 0)
+      setHistory([canvas.toDataURL('image/png')])
+      setReadySrc(src)
+    }
+    image.onerror = () => message.error('图片加载失败，无法标注')
+    image.src = src
+  }, [open, src])
+
+  const drawPreview = useCallback(
+    (current: Point) => {
+      const canvas = canvasRef.current
+      const start = startRef.current
+      if (!canvas || !start || !draftRef.current) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      void restoreImage(canvas, draftRef.current).then(() => {
+        ctx.strokeStyle = color
+        ctx.fillStyle = color
+        ctx.lineWidth = 4
+        const x = Math.min(start.x, current.x)
+        const y = Math.min(start.y, current.y)
+        const width = Math.abs(current.x - start.x)
+        const height = Math.abs(current.y - start.y)
+        if (tool === 'rect' || tool === 'crop') ctx.strokeRect(x, y, width, height)
+        if (tool === 'ellipse') {
+          ctx.beginPath()
+          ctx.ellipse(x + width / 2, y + height / 2, width / 2, height / 2, 0, 0, Math.PI * 2)
+          ctx.stroke()
+        }
+        if (tool === 'arrow') drawArrow(ctx, start, current)
+      })
+    },
+    [color, tool],
+  )
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      if (!canvas || readySrc !== src) return
+      const point = canvasPoint(event, canvas)
+      if (tool === 'text') {
+        const text = textDraft.trim()
+        if (!text) {
+          message.warning('请先输入标注文字')
+          return
+        }
+        pushHistory()
+        const ctx = canvas.getContext('2d')
+        if (!ctx) return
+        ctx.fillStyle = color
+        ctx.font = '28px sans-serif'
+        ctx.textBaseline = 'top'
+        ctx.fillText(text, point.x, point.y)
+        return
+      }
+      drawingRef.current = true
+      startRef.current = point
+      draftRef.current = canvas.toDataURL('image/png')
+      pushHistory()
+      canvas.setPointerCapture(event.pointerId)
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.strokeStyle = color
+      ctx.fillStyle = color
+      ctx.lineWidth = tool === 'pen' ? 4 : 1
+      ctx.lineCap = 'round'
+      if (tool === 'pen') {
+        ctx.beginPath()
+        ctx.moveTo(point.x, point.y)
+      }
+      if (tool === 'mosaic') applyMosaic(ctx, point)
+    },
+    [color, pushHistory, readySrc, src, textDraft, tool],
+  )
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      if (!canvas || !drawingRef.current) return
+      const point = canvasPoint(event, canvas)
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      if (tool === 'pen') {
+        ctx.lineTo(point.x, point.y)
+        ctx.stroke()
+        return
+      }
+      if (tool === 'mosaic') {
+        applyMosaic(ctx, point)
+        return
+      }
+      drawPreview(point)
+    },
+    [drawPreview, tool],
+  )
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current
+      const start = startRef.current
+      if (!canvas || !drawingRef.current || !start) return
+      drawingRef.current = false
+      const end = canvasPoint(event, canvas)
+      if (tool === 'crop') {
+        const x = Math.round(Math.min(start.x, end.x))
+        const y = Math.round(Math.min(start.y, end.y))
+        const width = Math.round(Math.abs(end.x - start.x))
+        const height = Math.round(Math.abs(end.y - start.y))
+        if (width > 8 && height > 8) {
+          const ctx = canvas.getContext('2d')
+          if (ctx && draftRef.current) {
+            void restoreImage(canvas, draftRef.current).then(() => {
+              const cropCtx = canvas.getContext('2d')
+              const image = cropCtx?.getImageData(x, y, width, height)
+              if (!cropCtx || !image) return
+              canvas.width = width
+              canvas.height = height
+              cropCtx.putImageData(image, 0, 0)
+            })
+          }
+        }
+      }
+      draftRef.current = null
+      startRef.current = null
+    },
+    [tool],
+  )
+
+  const undo = useCallback(() => {
+    const previous = history[history.length - 1]
+    const canvas = canvasRef.current
+    if (!previous || !canvas) return
+    setHistory((items) => items.slice(0, -1))
+    void restoreImage(canvas, previous)
+  }, [history])
+
+  const complete = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !node) return
+    onComplete({
+      dataUrl: canvas.toDataURL('image/png'),
+      width: canvas.width,
+      height: canvas.height,
+      sourceNode: node,
+    })
+  }, [node, onComplete])
+
+  return (
+    <Modal
+      open={open}
+      footer={null}
+      onCancel={onCancel}
+      width="96vw"
+      centered
+      className="canvas-image-annotation-modal"
+      destroyOnClose
+    >
+      <div className="canvas-annotate-shell">
+        <div className="canvas-annotate-toolbar">
+          {TOOL_ITEMS.map((item) => (
+            <Tooltip title={item.label} key={item.key}>
+              <button
+                type="button"
+                className={tool === item.key ? 'active' : ''}
+                onClick={() => setTool(item.key)}
+              >
+                {item.icon}
+              </button>
+            </Tooltip>
+          ))}
+          <span className="canvas-annotate-divider" />
+          {tool === 'text' && (
+            <Input
+              className="canvas-annotate-text-input"
+              value={textDraft}
+              onChange={(event) => setTextDraft(event.target.value)}
+              placeholder="输入标注文字"
+              size="small"
+            />
+          )}
+          {COLORS.map((item) => (
+            <button
+              key={item}
+              type="button"
+              className={`color${color === item ? ' active' : ''}`}
+              style={{ background: item }}
+              onClick={() => setColor(item)}
+            />
+          ))}
+          <span className="canvas-annotate-spacer" />
+          <Button
+            onClick={undo}
+            disabled={history.length <= 1}
+            icon={<Icons.RotateCcw size={15} />}
+          >
+            撤回
+          </Button>
+          <Button type="primary" onClick={complete} disabled={readySrc !== src}>
+            完成
+          </Button>
+        </div>
+        <div className="canvas-annotate-stage">
+          <canvas
+            ref={canvasRef}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+          />
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -177,6 +177,7 @@ export type CanvasFlowNodeData = {
     dissolveGroup: (groupId: string) => void
     openAiComposer: (nodeId: string) => void
     saveToLibrary: (nodeId: string) => void
+    annotateImage?: (nodeId: string) => void
     /** 360 全景产物节点：右键 → 全景预览（与普通图片「编辑」解耦） */
     previewPanorama: (nodeId: string) => void
     createOperationChild: (
@@ -323,6 +324,15 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
       },
       ...(node.type === 'image' && !isTask
         ? [
+            {
+              key: 'annotate-image',
+              label: (
+                <span className="canvas-menu-item">
+                  <Icons.Edit size={14} /> 图片标注
+                </span>
+              ),
+              onClick: () => actions.annotateImage?.(node.id),
+            },
             {
               key: 'extract-style',
               label: (

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
@@ -157,6 +157,7 @@ export function CanvasStage({
   onOpenAiComposer,
   onEditNode,
   onSaveNodeToLibrary,
+  onAnnotateImage,
   onPreviewPanorama,
   onCreateOperationChild,
   onPipelineAction,
@@ -192,6 +193,7 @@ export function CanvasStage({
   onOpenAiComposer: (nodeId: string) => void
   onEditNode: (nodeId: string) => void
   onSaveNodeToLibrary: (nodeId: string) => void
+  onAnnotateImage: (nodeId: string) => void
   /** 360 全景产物节点右键 → 全景预览 */
   onPreviewPanorama: (nodeId: string) => void
   onCreateOperationChild: (
@@ -237,6 +239,7 @@ export function CanvasStage({
       openAiComposer: onOpenAiComposer,
       editNode: onEditNode,
       saveToLibrary: onSaveNodeToLibrary,
+      annotateImage: onAnnotateImage,
       previewPanorama: onPreviewPanorama,
       createOperationChild: onCreateOperationChild,
       pipelineAction: onPipelineAction,
@@ -252,6 +255,7 @@ export function CanvasStage({
       onEditNode,
       onMergeGroupToImage,
       onOpenAiComposer,
+      onAnnotateImage,
       onPreviewPanorama,
       onRemoveNodeFromGroup,
       onCreateOperationChild,

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -24,6 +24,7 @@ import { CanvasFilmAssetCenter, type FilmCenterHandlers } from './CanvasFilmAsse
 import { CanvasAgentModal } from './CanvasAgentModal'
 import { CanvasOperationPanel } from './CanvasOperationPanel'
 import { CanvasPanoramaViewerModal } from './CanvasPanoramaViewerModal'
+import { CanvasImageAnnotationModal } from './CanvasImageAnnotationModal'
 import {
   CanvasShotDirectorPanel,
   type CanvasShotDirectorDraft,
@@ -1101,6 +1102,16 @@ export function CanvasWorkspaceView({
   >('details')
   const [editingNodeId, setEditingNodeId] = useState<string | null>(null)
   const [panoramaPreviewNodeId, setPanoramaPreviewNodeId] = useState<string | null>(null)
+  const [annotatingImageNodeId, setAnnotatingImageNodeId] = useState<string | null>(null)
+  const annotatingImageNode = useMemo(
+    () =>
+      annotatingImageNodeId
+        ? (snapshot?.nodes.find(
+            (node) => node.id === annotatingImageNodeId && node.type === 'image',
+          ) ?? null)
+        : null,
+    [annotatingImageNodeId, snapshot?.nodes],
+  )
   const [directorStageNodeId, setDirectorStageNodeId] = useState<string | null>(null)
   const [activeOperationPanelNodeId, setActiveOperationPanelNodeId] = useState<string | null>(null)
   const [assetDetailResetKey, setAssetDetailResetKey] = useState(0)
@@ -2182,6 +2193,46 @@ export function CanvasWorkspaceView({
     [createImageNode, patchNodes, snapshot],
   )
 
+  const handleAnnotateImageComplete = useCallback(
+    async (input: { dataUrl: string; width: number; height: number; sourceNode: CanvasNode }) => {
+      if (!snapshot) return
+      const fileName = `${
+        (input.sourceNode.title || 'image')
+          .replace(/[^\p{L}\p{N}_-]+/gu, '-')
+          .replace(/^-+|-+$/g, '')
+          .slice(0, 40) || 'image'
+      }-annotated-${Date.now()}.png`
+      const file = await dataUrlToFile(input.dataUrl, fileName)
+      const savedImage = await window.spark.invoke('file:save-pasted-image', {
+        dataUrl: input.dataUrl,
+        mimeType: file.type,
+        suggestedBaseName: fileName.replace(/\.[^.]+$/, ''),
+        storageScope: 'canvas',
+        ...(snapshot.project.rootPath ? { projectRootPath: snapshot.project.rootPath } : {}),
+      })
+      const nodeSize = fitImageNodeSize(input.width, input.height)
+      const source = input.sourceNode
+      const imageNode = await createImageNode({
+        file,
+        filePath: savedImage.filePath,
+        x: source.x + source.width + 48,
+        y: source.y,
+        width: nodeSize.width,
+        height: nodeSize.height,
+        imageWidth: input.width,
+        imageHeight: input.height,
+      })
+      if (imageNode) {
+        await patchNodes([imageNode.id], { title: `${source.title ?? '图片'} · 标注` })
+        await connectNodes({ sourceNodeId: source.id, targetNodeId: imageNode.id })
+        setSelectedNodeIds([imageNode.id])
+      }
+      setAnnotatingImageNodeId(null)
+      message.success('已生成标注图片节点')
+    },
+    [connectNodes, createImageNode, patchNodes, snapshot],
+  )
+
   const handleUndoCanvasChange = useCallback(async () => {
     try {
       await undoCanvasChange()
@@ -2222,6 +2273,8 @@ export function CanvasWorkspaceView({
         setLeaveOpen(false)
       } else if (saveToLibraryNodeId != null) {
         setSaveToLibraryNodeId(null)
+      } else if (annotatingImageNodeId != null) {
+        setAnnotatingImageNodeId(null)
       } else if (editingNodeId != null) {
         setEditingNodeId(null)
       } else if (agentOpen) {
@@ -2247,6 +2300,7 @@ export function CanvasWorkspaceView({
   }, [
     leaveOpen,
     saveToLibraryNodeId,
+    annotatingImageNodeId,
     editingNodeId,
     agentOpen,
     filmCenterOpen,
@@ -3821,6 +3875,7 @@ export function CanvasWorkspaceView({
             onEditNode={handleEditNode}
             onPreviewPanorama={handlePreviewPanorama}
             onSaveNodeToLibrary={(nodeId) => setSaveToLibraryNodeId(nodeId)}
+            onAnnotateImage={(nodeId) => setAnnotatingImageNodeId(nodeId)}
             onCreateOperationChild={(parentId, operation, options) => {
               const parent = snapshot.nodes.find((n) => n.id === parentId)
               if (!parent) return
@@ -3892,6 +3947,12 @@ export function CanvasWorkspaceView({
               void handleCreateTask(input)
               setInlineAiOpen(false)
             }}
+          />
+          <CanvasImageAnnotationModal
+            open={Boolean(annotatingImageNode)}
+            node={annotatingImageNode}
+            onCancel={() => setAnnotatingImageNodeId(null)}
+            onComplete={(input) => void handleAnnotateImageComplete(input)}
           />
           <CanvasShotDirectorPanel
             key={`${snapshot.board.id}:${shotDirectorDraft?.updatedAt ?? 'draft'}`}


### PR DESCRIPTION
### Motivation
- Provide an in-canvas image annotation feature so users can mark up images (rect, ellipse, arrow, pen, mosaic, text, crop) and generate annotated image nodes. 
- Surface the annotation action in image node context menus and wire it through the stage/workspace so annotated images can be saved back to the project and connected to the source. 

### Description
- Add `CanvasImageAnnotationModal.tsx` which implements a canvas-based annotation UI with tools (`rect`, `ellipse`, `arrow`, `pen`, `mosaic`, `text`, `crop`), undo/history, color palette, and `complete` producing a `dataUrl`; include styles in `CanvasImageAnnotationModal.less`.
- Extend `CanvasNode` context menu to include a "图片标注" item which calls a new `annotateImage` action when present.
- Thread the `annotateImage` action through `CanvasStage` and `CanvasWorkspaceView` by adding `onAnnotateImage`, state `annotatingImageNodeId`, ESC handling to close the modal, and rendering `CanvasImageAnnotationModal` when applicable.
- Implement `handleAnnotateImageComplete` in `CanvasWorkspaceView` to convert the returned `dataUrl` to a file, call `file:save-pasted-image`, create a new image node using `createImageNode`, connect it to the source node, and select the new node.

### Testing
- Ran TypeScript type-check (`yarn tsc`) and a local build (`yarn build`), and both completed successfully.
- No new automated unit tests were added for the annotation UI in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c89bf28388323b314b357fca571cc)