### PR TITLE
Track usage_update deltas in UsageLedger, prevent double-counting, and add purge UI

### DIFF
--- a/apps/desktop/src/renderer/design/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/design/views/SettingsView.tsx
@@ -3883,6 +3883,7 @@ function UsageSection() {
   } | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [purging, setPurging] = useState(false)
 
   const loadDashboard = useCallback(async () => {
     setLoading(true)
@@ -3921,6 +3922,19 @@ function UsageSection() {
       return ts
     }
   }
+
+  const purgeOldRecords = useCallback(async () => {
+    setPurging(true)
+    setError(null)
+    try {
+      await window.spark.invoke('usage:purge', { olderThanDays: 90 })
+      await loadDashboard()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPurging(false)
+    }
+  }, [loadDashboard])
 
   const month = dashboard?.currentMonth
   const total = dashboard?.total
@@ -4050,6 +4064,15 @@ function UsageSection() {
           right={
             <Button size="small" type="text" loading={loading} icon={<Icons.Refresh size={11} />} onClick={loadDashboard} disabled={loading}>
               刷新
+            </Button>
+          }
+        />
+        <SettingsRow
+          title="清理旧记录"
+          desc="删除 90 天以前的本地用量明细，保留近期统计"
+          right={
+            <Button size="small" type="text" danger loading={purging} onClick={purgeOldRecords} disabled={loading || purging}>
+              清理
             </Button>
           }
         />

--- a/docs/desktop-agent-development-guide.md
+++ b/docs/desktop-agent-development-guide.md
@@ -4039,11 +4039,11 @@ PRD 设计的完整路径:
     → CodexSDKAdapter (Codex SDK)                       ← 缺失: 未实现
     → GenericLLMAdapter (HTTP 直接调用)                  ← 已实现: AnthropicAdapter + OpenAIAdapter
   → 工具调用 → ToolRegistry.execute() / MCP Gateway     ← 部分: 4 工具有, MCP Gateway 缺失
-  → UsageLedger.record() → 记录用量                     ← 缺失: 无用量统计
+  → UsageLedger.record() → 记录用量                     ← 已实现: usage_update 自动入账 + Settings 用量统计
   → emit AgentEvent → 前端渲染                          ← 已实现
 ```
 
-**需要补充的中间件**: RuleEngine → ContextGovernor → UsageLedger (PermissionEngine 已部分实现)
+**需要补充的中间件**: RuleEngine → ContextGovernor (PermissionEngine 已部分实现；UsageLedger 已接入会话事件入账)
 
 ### 24.2 Provider 适配器真实实现状态
 

--- a/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
@@ -57,6 +57,7 @@ const mockState = vi.hoisted(() => ({
   sdkConfigs: [] as Array<Record<string, unknown>>,
   sdkTurns: [] as Array<{ sessionId: string; turnId: string; message: string }>,
   workspaces: new Map<string, { id: string; root_path: string }>(),
+  usageRecords: [] as Array<{ sessionId: string; providerId: string; modelId: string; inputTokens: number; outputTokens: number; cacheReadTokens?: number; costUsd?: number; requestTimestamp?: string }>,
 }))
 
 vi.mock('@spark/shared/keystore', () => ({
@@ -169,6 +170,11 @@ vi.mock('@spark/storage', () => {
   }
 
   class UsageLedgerRepository {
+    record(params: { sessionId: string; providerId: string; modelId: string; inputTokens: number; outputTokens: number; cacheReadTokens?: number; costUsd?: number; requestTimestamp?: string }): string {
+      mockState.usageRecords.push(params)
+      return `usage-${mockState.usageRecords.length}`
+    }
+
     getSessionUsage(_sessionId: string): {
       totalInputTokens: number
       totalOutputTokens: number
@@ -308,6 +314,7 @@ describe('SessionService runtime provider/model resolution', () => {
     mockState.sdkConfigs.length = 0
     mockState.sdkTurns.length = 0
     mockState.workspaces.clear()
+    mockState.usageRecords.length = 0
     events = []
 
     seedProvider({
@@ -335,6 +342,87 @@ describe('SessionService runtime provider/model resolution', () => {
       is_default: 0,
     })
   })
+
+  it('records usage_update deltas to the usage ledger without double-counting cumulative updates', async () => {
+    const service = new SessionService({} as never, (event) => events.push(event))
+    const { sessionId } = await service.createSession({
+      providerProfileId: 'tencent-provider',
+      modelId: 'glm-5',
+      agentAdapter: 'claude-sdk',
+      permissionMode: 'claude-plan',
+      title: 'Usage ledger session',
+    })
+    const eventRepo = { insert: vi.fn() }
+    const persist = (service as unknown as {
+      emitAndPersist: (
+        sessionId: string,
+        turnId: string,
+        event: AgentEvent,
+        eventRepo: { insert: ReturnType<typeof vi.fn> },
+      ) => void
+    }).emitAndPersist.bind(service)
+
+    persist(
+      sessionId,
+      'turn-usage',
+      {
+        id: 'usage-1',
+        sessionId,
+        turnId: 'turn-usage',
+        timestamp: '2026-05-28T00:00:01.000Z',
+        seq: 0,
+        type: 'usage_update',
+        provider: 'claude',
+        model: '',
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheHitTokens: 5,
+        estimatedCostUsd: 0.01,
+      },
+      eventRepo,
+    )
+    persist(
+      sessionId,
+      'turn-usage',
+      {
+        id: 'usage-2',
+        sessionId,
+        turnId: 'turn-usage',
+        timestamp: '2026-05-28T00:00:02.000Z',
+        seq: 0,
+        type: 'usage_update',
+        provider: 'claude',
+        model: '',
+        inputTokens: 140,
+        outputTokens: 35,
+        cacheHitTokens: 7,
+        estimatedCostUsd: 0.015,
+      },
+      eventRepo,
+    )
+
+    expect(mockState.usageRecords).toEqual([
+      expect.objectContaining({
+        sessionId,
+        providerId: 'tencent-provider',
+        modelId: 'glm-5',
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadTokens: 5,
+        costUsd: 0.01,
+      }),
+      expect.objectContaining({
+        sessionId,
+        providerId: 'tencent-provider',
+        modelId: 'glm-5',
+        inputTokens: 40,
+        outputTokens: 15,
+        cacheReadTokens: 2,
+        costUsd: expect.closeTo(0.005),
+      }),
+    ])
+  })
+
 
   it('uses the session provider default model when an old session has no model id', async () => {
     const service = new SessionService({} as never, (event) => events.push(event))

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -325,6 +325,7 @@ export class SessionService {
   /** 等待用户对计划进行审批的 session 集合：处于此状态时 startNextQueuedTurn 不自动起跑队列。 */
   private pendingPlanApprovals = new Set<string>()
   private seqCounters = new Map<string, number>()
+  private usageLedgerLastByTurn = new Map<string, { inputTokens: number; outputTokens: number; cacheHitTokens: number; estimatedCostUsd: number }>()
   private iterationOverrides = new Map<string, number>() // sessionId → per-session max turn iterations override
   private readonly commandRegistry = createBuiltinRegistry()
   private readonly mcpService: McpService
@@ -523,6 +524,7 @@ export class SessionService {
       clearSessionEvents: async (id) => {
         eventRepo.deleteBySession(id)
         this.seqCounters.delete(id)
+        this.clearUsageLedgerTurnState(id)
       },
       getProviderName: (id) => {
         return providerRepo.get(id)?.name ?? null
@@ -679,6 +681,7 @@ export class SessionService {
       clearSessionEvents: async (id) => {
         eventRepo.deleteBySession(id)
         this.seqCounters.delete(id)
+        this.clearUsageLedgerTurnState(id)
       },
       getProviderName: (id) => providerRepo.get(id)?.name ?? null,
       getProviderModelIds: (id) => getProviderModelIds(providerRepo.get(id)?.config_json),
@@ -3230,6 +3233,57 @@ export class SessionService {
     }
   }
 
+  private usageLedgerKey(sessionId: string, turnId: string): string {
+    return `${sessionId}:${turnId}`
+  }
+
+  private clearUsageLedgerTurnState(sessionId: string, turnId?: string): void {
+    if (turnId != null) {
+      this.usageLedgerLastByTurn.delete(this.usageLedgerKey(sessionId, turnId))
+      return
+    }
+    const prefix = `${sessionId}:`
+    for (const key of this.usageLedgerLastByTurn.keys()) {
+      if (key.startsWith(prefix)) this.usageLedgerLastByTurn.delete(key)
+    }
+  }
+
+  private recordUsageUpdate(sessionId: string, turnId: string, event: Extract<AgentEvent, { type: 'usage_update' }>): void {
+    const key = this.usageLedgerKey(sessionId, turnId)
+    const prev = this.usageLedgerLastByTurn.get(key) ?? { inputTokens: 0, outputTokens: 0, cacheHitTokens: 0, estimatedCostUsd: 0 }
+    const current = {
+      inputTokens: Math.max(0, event.inputTokens),
+      outputTokens: Math.max(0, event.outputTokens),
+      cacheHitTokens: Math.max(0, event.cacheHitTokens ?? 0),
+      estimatedCostUsd: Math.max(0, event.estimatedCostUsd ?? 0),
+    }
+    this.usageLedgerLastByTurn.set(key, current)
+
+    const inputTokens = Math.max(0, current.inputTokens - prev.inputTokens)
+    const outputTokens = Math.max(0, current.outputTokens - prev.outputTokens)
+    const cacheReadTokens = Math.max(0, current.cacheHitTokens - prev.cacheHitTokens)
+    const costUsd = Math.max(0, current.estimatedCostUsd - prev.estimatedCostUsd)
+    if (inputTokens === 0 && outputTokens === 0 && cacheReadTokens === 0 && costUsd === 0) return
+
+    try {
+      const session = new SessionRepository(this.db).get(sessionId)
+      const providerId = session?.provider_profile_id ?? event.provider
+      const modelId = event.model || session?.model_id || 'unknown'
+      new UsageLedgerRepository(this.db).record({
+        sessionId,
+        providerId,
+        modelId,
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        costUsd,
+        requestTimestamp: event.timestamp,
+      })
+    } catch {
+      // Non-fatal: usage dashboard data must not interrupt chat event streaming.
+    }
+  }
+
   private emitAndPersist(
     sessionId: string,
     turnId: string,
@@ -3240,6 +3294,9 @@ export class SessionService {
     this.seqCounters.set(sessionId, seq + 1)
     const sequenced = { ...event, seq }
     this.onEvent(sequenced)
+    if (event.type === 'usage_update') {
+      this.recordUsageUpdate(sessionId, turnId, event)
+    }
     try {
       eventRepo.insert({
         id: sequenced.id,
@@ -3270,6 +3327,9 @@ export class SessionService {
           title: 'Spark Agent - 需要您的输入',
           body: event.message ?? 'Agent 需要您提供更多信息',
         })
+      }
+      if (TERMINAL_AGENT_STATUSES.has(status)) {
+        this.clearUsageLedgerTurnState(sessionId, turnId)
       }
     }
   }


### PR DESCRIPTION
### Motivation

- Ensure `usage_update` events are recorded to the `UsageLedger` as incremental deltas rather than re-recording cumulative totals, preventing double-counting for long-lived turns.
- Provide a UI action to purge old local usage records to reclaim space and keep recent stats concise.
- Update docs to reflect that usage ledger recording has been integrated into session events.

### Description

- Add per-turn state `usageLedgerLastByTurn` and helper methods `usageLedgerKey`, `clearUsageLedgerTurnState`, and `recordUsageUpdate` in `SessionService` to compute deltas and write incremental records via `UsageLedgerRepository.record`.
- Call `recordUsageUpdate` from `emitAndPersist` when handling `usage_update` events and clear turn state on `clearSessionEvents` and when agent status becomes terminal to avoid stale state accumulation.
- Add a Settings UI action in `SettingsView` (`purgeOldRecords`) with a `清理` button that invokes `window.spark.invoke('usage:purge', { olderThanDays: 90 })` and reloads the dashboard, plus `purging` state and button disabling while running.
- Update test mocks and add a unit test in `packages/agent-runtime` to assert that cumulative `usage_update` events are converted into incremental `UsageLedger` records.
- Tweak documentation in `docs/desktop-agent-development-guide.md` to mark `UsageLedger` integration and adjust phrasing.

### Testing

- Ran unit tests for `packages/agent-runtime` including the new `session-runtime-config.test.ts` test that verifies `usage_update` delta recording; the test suite passed.
- Existing mocked repository behavior was updated to capture `usageRecords` and the new test asserted the expected delta writes; those assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c9aaa6cd4832889d192af5d283e61)