### PR TITLE
Apply runtime telemetry settings, simplify telemetry UI, and add logger test

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -18,7 +18,7 @@ import crypto from 'node:crypto'
 import * as fs from 'node:fs/promises'
 import path from 'node:path'
 import { promisify } from 'node:util'
-import { createLogger, deriveTeamAvatar, normalizeEduAssetUrl } from '@spark/shared'
+import { createLogger, deriveTeamAvatar, normalizeEduAssetUrl, setLogLevel } from '@spark/shared'
 import { getAppSkillsManager } from '../services/AppSkillsManager.js'
 import { HistoryImportService } from '../services/HistoryImport/HistoryImportService.js'
 import type { ImportProviderResolution } from '../services/HistoryImport/HistoryImportService.js'
@@ -1729,6 +1729,14 @@ function readAgentHookConfig(sessionId: string): HookConfigInternal {
   return parseHookConfig(agent.hookConfig, { ...DEFAULT_HOOK_CONFIG_INTERNAL, enabled: false })
 }
 
+function applyTelemetrySettings(value: unknown): void {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return
+  const logLevel = (value as { logLevel?: unknown }).logLevel
+  if (logLevel === 'debug' || logLevel === 'info' || logLevel === 'warn' || logLevel === 'error') {
+    setLogLevel(logLevel)
+  }
+}
+
 function getStartupSettings(): { supported: boolean; openAtLogin: boolean; openAsHidden: boolean } {
   try {
     const settings = app.getLoginItemSettings()
@@ -2351,6 +2359,7 @@ async function handleRemoteInboundMessage(
 
 export function registerAllIpcHandlers(): void {
   log.info('Registering IPC handlers...')
+  applyTelemetrySettings(getSettingsService().get('telemetry', 'data'))
   void getRemoteConnectionService()
     .startRuntime(handleRemoteInboundMessage)
     .catch((err) => {
@@ -4765,6 +4774,9 @@ export function registerAllIpcHandlers(): void {
 
   typedIpcHandle('settings:set', async (req) => {
     getSettingsService().set(req.category, req.key, req.value)
+    if (req.category === 'telemetry' && req.key === 'data') {
+      applyTelemetrySettings(req.value)
+    }
     return { ok: true }
   })
 

--- a/apps/desktop/src/renderer/design/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/design/views/SettingsView.tsx
@@ -121,8 +121,6 @@ type GeneralSettings = {
   notifyWorkflowFail: boolean
   notifyMcpOffline: boolean
   notifyNewVersion: boolean
-  anonymousTelemetry: boolean
-  autoDiagPackage: boolean
 }
 
 type AppearanceSettings = {
@@ -138,10 +136,7 @@ type AppearanceSettings = {
 }
 
 type TelemetrySettings = {
-  logLevel: string
-  otlpEndpoint: string
-  traceSamplingRate: number
-  traceRetentionDays: number
+  logLevel: 'debug' | 'info' | 'warn' | 'error'
 }
 
 type UpdatesSettings = {
@@ -183,8 +178,6 @@ const DEFAULT_GENERAL: GeneralSettings = {
   notifyWorkflowFail: true,
   notifyMcpOffline: false,
   notifyNewVersion: true,
-  anonymousTelemetry: true,
-  autoDiagPackage: true,
 }
 
 const DEFAULT_APPEARANCE: AppearanceSettings = {
@@ -201,9 +194,6 @@ const DEFAULT_APPEARANCE: AppearanceSettings = {
 
 const DEFAULT_TELEMETRY: TelemetrySettings = {
   logLevel: 'info',
-  otlpEndpoint: '',
-  traceSamplingRate: 100,
-  traceRetentionDays: 14,
 }
 
 const DEFAULT_UPDATES: UpdatesSettings = {
@@ -642,32 +632,6 @@ function GeneralSection() {
               size="small"
               checked={s.notifyNewVersion}
               onChange={(v) => set({ notifyNewVersion: v })}
-            />
-          }
-        />
-      </div>
-
-      <div className="subsec-h">隐私</div>
-      <div className="settings-card">
-        <SettingsRow
-          title="匿名遥测"
-          desc="发送匿名使用与崩溃数据，帮助改进 Spark Agent"
-          right={
-            <Switch
-              size="small"
-              checked={s.anonymousTelemetry}
-              onChange={(v) => set({ anonymousTelemetry: v })}
-            />
-          }
-        />
-        <SettingsRow
-          title="自动诊断包"
-          desc="崩溃时自动收集脱敏诊断包（不含密钥与代码）"
-          right={
-            <Switch
-              size="small"
-              checked={s.autoDiagPackage}
-              onChange={(v) => set({ autoDiagPackage: v })}
             />
           }
         />
@@ -3737,103 +3701,21 @@ function TelemetrySection() {
   return (
     <div className="settings-section">
       <h2>遥测与日志</h2>
-      <div className="lede">观察会话、工作流与 Agent 内部行为；导出诊断包帮助调试。</div>
+      <div className="lede">
+        当前仅提供已接入运行时的本地日志级别设置；OpenTelemetry、trace 查看和诊断包导出仍在待开发阶段。
+      </div>
 
       <div className="form-grid">
         <label>本地日志级别</label>
         <Select
           value={s.logLevel}
-          onChange={(v) => set({ logLevel: v })}
+          onChange={(v) => set({ logLevel: v as TelemetrySettings['logLevel'] })}
           options={[
             { label: 'error', value: 'error' },
             { label: 'warn', value: 'warn' },
             { label: 'info', value: 'info' },
             { label: 'debug', value: 'debug' },
-            { label: 'trace', value: 'trace' },
           ]}
-        />
-
-        <label>
-          OpenTelemetry endpoint<span className="sub">可选 — 把 trace 转发到 collector</span>
-        </label>
-        <Input
-          value={s.otlpEndpoint}
-          onChange={(e) => set({ otlpEndpoint: e.target.value })}
-          placeholder="https://otlp.example.com:4318 (可选)"
-        />
-
-        <label>Trace 采样率</label>
-        <div className="control">
-          <Input
-            type="range"
-            min="0"
-            max="100"
-            value={s.traceSamplingRate}
-            onChange={(e) => set({ traceSamplingRate: Number(e.target.value) })}
-            className="flex1"
-          />
-          <span className="mono-sm muted range-value">{s.traceSamplingRate}%</span>
-        </div>
-
-        <label>本地保留 trace 天数</label>
-        <Input
-          type="number"
-          value={s.traceRetentionDays}
-          onChange={(e) => set({ traceRetentionDays: Number(e.target.value) || 14 })}
-          className="input-max-sm"
-        />
-      </div>
-
-      <div className="subsec-h">最近运行</div>
-      <div className="card">
-        <SettingsRow
-          title="代码功能开发：搜索优化"
-          desc="Run #4f3a · 5 agent · 4m 38s · $0.92"
-          right={
-            <Button size="small" type="text" icon={<Icons.Eye size={11} />}>
-              查看 trace
-            </Button>
-          }
-        />
-        <SettingsRow
-          title="重构 auth 模块为 OAuth 2.1"
-          desc="Run #41b8 · 1 agent · 6m 12s · $1.34"
-          right={
-            <Button size="small" type="text" icon={<Icons.Eye size={11} />}>
-              查看 trace
-            </Button>
-          }
-        />
-        <SettingsRow
-          title="MCP gateway 性能调优"
-          desc="Run #38c0 · 1 agent · 失败"
-          right={
-            <Button size="small" type="text" danger icon={<Icons.Eye size={11} />}>
-              查看错误
-            </Button>
-          }
-        />
-      </div>
-
-      <div className="subsec-h">诊断包</div>
-      <div className="card">
-        <SettingsRow
-          title="生成诊断包"
-          desc="包含 app/OS 版本、provider 健康、近期错误日志，自动脱敏"
-          right={
-            <Button size="small" type="default" icon={<Icons.Download size={11} />}>
-              生成
-            </Button>
-          }
-        />
-        <SettingsRow
-          title="复制最近一次错误"
-          desc="便于发到 GitHub Issue"
-          right={
-            <Button size="small" type="text" icon={<Icons.Copy size={11} />}>
-              复制
-            </Button>
-          }
         />
       </div>
     </div>

--- a/docs/desktop-agent-development-guide.md
+++ b/docs/desktop-agent-development-guide.md
@@ -1,5 +1,7 @@
 # Spark Agent Desktop Development Guide
 
+> 状态: 实施中 | 最后核对: 2026-06-25
+
 版本: 0.2  
 日期: 2026-05-27  
 目标: 设计并逐步实现一个综合性的桌面端 agent 程序，融合 Claude Agent SDK 与 Codex SDK 的能力，支持 ACP、MCP、Skills、多层规则、工作流、可视化多 agent、团队协作与高性能本地执行。
@@ -138,7 +140,8 @@ Spark 的创新方向:
 - Child process / PTY: Claude/Codex CLI、MCP stdio server、用户命令。
 - SQLite + WAL: 本地元数据、事件日志、会话、配置、规则、审计。
 - LanceDB 或 SQLite FTS5: 初期用于本地检索；后续可接入向量库。
-- OpenTelemetry: trace、span、usage、tool call、错误链路。
+- 本地日志级别：设置页已支持调整 Spark 共享 logger 的 `debug` / `info` / `warn` / `error` 级别。
+- OpenTelemetry: trace、span、usage、tool call、错误链路（待开发；设置页暂不展示未接入的 endpoint、采样率、trace 查看入口）。
 
 ### 3.4 包管理与工程
 
@@ -2820,7 +2823,7 @@ pnpm e2e
 
 ### 16.4 诊断包
 
-诊断包包含:
+诊断包包含（待开发；设置页暂不展示导出入口）:
 
 - app version。
 - OS 信息。
@@ -3822,8 +3825,8 @@ PRD §5.0.3。
 | # | 任务 | 优先级 | 状态 | 说明 |
 |---|------|--------|------|------|
 | P6-01 | 自动更新 (electron-updater) | P1 | ✅ 已完成 | 小米 commit `26913d7`，10 files +618/-31 |
-| P6-02 | 崩溃收集 | P2 | ❌ 待开发 | 错误上报和诊断包生成 |
-| P6-03 | 日志导出 | P2 | ❌ 待开发 | 导出脱敏后的运行日志 |
+| P6-02 | 崩溃收集 | P2 | ❌ 待开发 | 错误上报和诊断包生成；设置页暂不展示诊断包入口 |
+| P6-03 | 日志导出 | P2 | ❌ 待开发 | 导出脱敏后的运行日志；设置页暂不展示日志导出入口 |
 | P6-04 | 安装包签名 | P1 | ❌ 待开发 | macOS notarization + Windows 签名 |
 | P6-05 | ACP Server/Client | P2 | ❌ 待开发 | 外部编辑器和 agent 连接 |
 | P6-06 | Plugin/Skill Registry | P3 | ❌ 待开发 | 远程 Skill 市场 |

--- a/packages/shared/src/logger/index.test.ts
+++ b/packages/shared/src/logger/index.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createLogger, setLogLevel } from './index.js'
+
+describe('shared logger', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    setLogLevel('debug')
+  })
+
+  it('filters messages below the configured log level', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const log = createLogger('test')
+
+    setLogLevel('warn')
+
+    log.debug('debug message')
+    log.info('info message')
+    log.warn('warn message')
+    log.error('error message')
+
+    expect(debug).not.toHaveBeenCalled()
+    expect(info).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(error).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
### Motivation
- Ensure telemetry-related runtime logging level is applied at startup and when telemetry settings change so the shared logger respects user preferences.
- Simplify the renderer telemetry settings to only expose local log level while deferring OpenTelemetry and diagnostic features that are not yet implemented.
- Document current status and add a unit test to verify runtime logger level behavior.

### Description
- Added `applyTelemetrySettings()` and integrated it into `registerAllIpcHandlers()` in `apps/desktop/src/main/ipc/index.ts` to apply saved telemetry `logLevel` on startup and when `settings:set` for `telemetry.data` is called, and imported `setLogLevel` from `@spark/shared`.
- Simplified the telemetry UI in `apps/desktop/src/renderer/design/views/SettingsView.tsx` by removing OpenTelemetry endpoint, sampling, retention controls and diagnostic/export UI, narrowing `TelemetrySettings.logLevel` type to `'debug'|'info'|'warn'|'error'`, and updating explanatory copy.
- Updated documentation in `docs/desktop-agent-development-guide.md` to reflect the current telemetry/diagnostics status and local log-level support.
- Added a unit test `packages/shared/src/logger/index.test.ts` that verifies `setLogLevel()` filters console output appropriately.

### Testing
- Added unit test `packages/shared/src/logger/index.test.ts` covering `createLogger` and `setLogLevel` behavior and ran the test suite with `pnpm test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c9ad6fb40832ea34b1f8bd7ad2880)