### PR TITLE
Add custom slash commands (settings UI, registry, execution, and tests)

### DIFF
--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -14947,3 +14947,87 @@ body.inspector-resizing {
 .agent-config-section.is-interactive:hover .agent-config-advanced {
   color: var(--primary);
 }
+
+/* ─── Custom commands settings ───────────────────────────────────────────── */
+.custom-command-toolbar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  margin: 12px 0;
+}
+.custom-command-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+.custom-command-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--bg-soft) 90%, var(--primary) 4%), var(--bg));
+  box-shadow: var(--shadow-sm);
+}
+.custom-command-card.disabled { opacity: 0.62; }
+.custom-command-card-h {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.custom-command-name {
+  color: var(--text-strong);
+  font-family: var(--font-mono);
+  font-size: var(--font-base);
+  font-weight: 700;
+}
+.custom-command-desc {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+  line-height: 1.4;
+}
+.custom-command-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.custom-command-meta span {
+  padding: 3px 8px;
+  border-radius: 999px;
+  color: var(--text-muted);
+  background: var(--hover);
+  font-size: var(--font-xs);
+}
+.custom-command-preview {
+  min-height: 58px;
+  max-height: 112px;
+  overflow: hidden;
+  padding: 10px;
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: var(--r-md);
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--bg) 84%, transparent);
+  font-size: var(--font-xs);
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+.custom-command-preview-strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--bg-soft);
+  color: var(--text-muted);
+  font-size: var(--font-xs);
+}
+.custom-command-preview-strip code {
+  color: var(--primary);
+  font-family: var(--font-mono);
+}
+.custom-command-textarea { min-height: 120px; }

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -10647,17 +10647,15 @@ function ComposerV2({
   const flatSlashList = groupedSlashCmds.flatMap((g) => g.cmds)
 
   const openSlashPopup = useCallback(async () => {
-    if (slashCmds.length === 0) {
-      try {
-        const res = await window.spark.invoke('command:list', {})
-        setSlashCmds(res.commands ?? [])
-      } catch {
-        // ignore
-      }
+    try {
+      const res = await window.spark.invoke('command:list', {})
+      setSlashCmds(res.commands ?? [])
+    } catch {
+      // keep the previous command cache if refresh fails
     }
     setSlashOpen(true)
     setSlashIndex(0)
-  }, [slashCmds.length])
+  }, [])
 
   const closeSlashPopup = useCallback(() => {
     setSlashOpen(false)
@@ -11411,7 +11409,7 @@ function ComposerV2({
                         }}
                       >
                         <span className={`slash-cmd-layer layer-${cmd.layer}`}>
-                          {cmd.layer === 'sdk' ? 'SDK' : cmd.layer === 'skill' ? '技能' : '内置'}
+                          {cmd.layer === 'sdk' ? 'SDK' : cmd.layer === 'skill' ? '技能' : cmd.layer === 'custom' ? '自定义' : '内置'}
                         </span>
                         <span className="slash-cmd-name">/{cmd.name}</span>
                         {cmd.aliases.length > 0 && (

--- a/apps/desktop/src/renderer/design/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/design/views/SettingsView.tsx
@@ -65,6 +65,8 @@ const WORKFLOW_TEMPLATES_KEY = 'spark-workflow-templates'
 const COMPOSER_PREFS_KEY = 'spark-agent:composer-prefs'
 const RUNTIME_PERMISSION_SETTINGS_CATEGORY = 'runtime-permissions'
 const RUNTIME_PERMISSION_SETTINGS_KEY = 'defaults'
+const CUSTOM_COMMANDS_CATEGORY = 'custom-commands'
+const CUSTOM_COMMANDS_KEY = 'items'
 
 // 远程连接：记住用户上次新建/切换的渠道，方便"新建连接"卡片一键复用
 const REMOTE_LAST_CHANNEL_CATEGORY = 'remote-connections'
@@ -163,6 +165,19 @@ type RuntimePermissionModeOption = {
   label: string
   desc: string
   tone?: 'auto' | 'danger'
+}
+
+type CustomCommandScriptLanguage = 'javascript' | 'python'
+
+type CustomCommandItem = {
+  id: string
+  name: string
+  description: string
+  prompt: string
+  script: string
+  scriptLanguage: CustomCommandScriptLanguage
+  enabled: boolean
+  updatedAt: string
 }
 
 const DEFAULT_GENERAL: GeneralSettings = {
@@ -307,6 +322,7 @@ export function SettingsView() {
       group: 'Agent',
       items: [
         { id: 'rules', icon: <Icons.Beaker />, label: '规则' },
+        { id: 'custom-commands', icon: <Icons.Command />, label: '自定义命令' },
         { id: 'permissions', icon: <Icons.Shield />, label: '权限策略' },
       ],
     },
@@ -342,6 +358,7 @@ export function SettingsView() {
     appearance: AppearanceSection,
     shortcuts: ShortcutsSection,
     rules: RulesSection,
+    'custom-commands': CustomCommandsSection,
     permissions: PermissionsSection,
     // MCP 设置暂未完全实现，隐藏
     // 'mcp-settings': McpSection,
@@ -2431,6 +2448,187 @@ function RuleEditPanel({
       </div>
     </div>
   )
+}
+
+function CustomCommandsSection() {
+  const [commands, setCommands] = useState<CustomCommandItem[]>([])
+  const [query, setQuery] = useState('')
+  const [editing, setEditing] = useState<CustomCommandItem | null>(null)
+  const [loading, setLoading] = useState(true)
+  const { requestConfirm } = useApp()
+  const { toast } = useToast()
+
+  const loadCommands = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await window.spark.invoke('settings:get', { category: CUSTOM_COMMANDS_CATEGORY, key: CUSTOM_COMMANDS_KEY })
+      setCommands(parseCustomCommandItems(typeof res.value === 'string' ? res.value : null))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => deferEffect(loadCommands), [loadCommands])
+
+  const persistCommands = useCallback(async (next: CustomCommandItem[]) => {
+    setCommands(next)
+    await window.spark.invoke('settings:set', { category: CUSTOM_COMMANDS_CATEGORY, key: CUSTOM_COMMANDS_KEY, value: JSON.stringify(next) })
+  }, [])
+
+  const normalizedQuery = query.trim().toLowerCase()
+  const visibleCommands = commands.filter((command) => {
+    if (!normalizedQuery) return true
+    return [command.name, command.description, command.prompt, command.script].join(' ').toLowerCase().includes(normalizedQuery)
+  })
+  const enabledCount = commands.filter((command) => command.enabled).length
+
+  const handleSave = async (draft: CustomCommandItem) => {
+    const normalizedName = normalizeCustomCommandInput(draft.name)
+    if (normalizedName == null) {
+      toast.error('命令名需形如 /custom-plan，并以字母开头，仅支持字母、数字和短横线。')
+      return
+    }
+    if (!draft.prompt.trim() && !draft.script.trim()) {
+      toast.error('请至少填写提示词或脚本。')
+      return
+    }
+    if (commands.some((command) => command.id !== draft.id && normalizeCustomCommandInput(command.name) === normalizedName)) {
+      toast.error(`命令 ${normalizedName} 已存在。`)
+      return
+    }
+    const nextCommand: CustomCommandItem = {
+      ...draft,
+      name: normalizedName,
+      description: draft.description.trim(),
+      prompt: draft.prompt.trim(),
+      script: draft.script.trimEnd(),
+      updatedAt: new Date().toISOString(),
+    }
+    const next = commands.some((command) => command.id === draft.id)
+      ? commands.map((command) => (command.id === draft.id ? nextCommand : command))
+      : [nextCommand, ...commands]
+    await persistCommands(next)
+    setEditing(null)
+    toast.success('自定义命令已保存，重新打开 / 命令列表即可使用。')
+  }
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    await persistCommands(commands.map((command) => command.id === id ? { ...command, enabled, updatedAt: new Date().toISOString() } : command))
+  }
+
+  const handleDelete = async (id: string) => {
+    const confirmed = await requestConfirm({ title: '删除自定义命令？', description: '删除后会立即从会话斜杠命令列表中移除。', confirmText: '删除', danger: true })
+    if (!confirmed) return
+    await persistCommands(commands.filter((command) => command.id !== id))
+  }
+
+  return (
+    <>
+      <div className="settings-section section-wider">
+        <h2>自定义命令</h2>
+        <div className="lede">将常用流程沉淀为 / 命令。可先运行 JavaScript / Python 脚本，再把配置好的提示词交给 Agent 继续处理。</div>
+        <div className="row info-banner">
+          <Icons.Command size={14} className="color-primary flex-shrink-0" />
+          <div className="flex1 info-banner-text"><strong>{enabledCount} 个启用</strong> · {commands.length} 个自定义命令 · 会显示在会话输入框的「工具」分组。</div>
+          <Button size="small" type="primary" icon={<Icons.Plus size={11} />} onClick={() => setEditing(createCustomCommandDraft())}>新增命令</Button>
+        </div>
+        <div className="custom-command-toolbar">
+          <Input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="搜索命令名、描述、提示词或脚本…" />
+          <Button size="small" onClick={() => void loadCommands()}>刷新</Button>
+        </div>
+        {loading ? (
+          <div className="card loading-card">正在加载自定义命令...</div>
+        ) : visibleCommands.length === 0 ? (
+          <div className="placeholder-section"><Icons.Command size={28} /><h3>{commands.length === 0 ? '还没有自定义命令' : '没有匹配的命令'}</h3><p>建议从 /custom-plan 开始，把固定计划、审查或总结流程变成一键入口。</p></div>
+        ) : (
+          <div className="custom-command-grid">
+            {visibleCommands.map((command) => (
+              <div key={command.id} className={`custom-command-card ${command.enabled ? '' : 'disabled'}`}>
+                <div className="custom-command-card-h">
+                  <div><div className="custom-command-name">{command.name}</div><div className="custom-command-desc">{command.description || '未填写描述'}</div></div>
+                  <Switch size="small" checked={command.enabled} onChange={(enabled) => void handleToggle(command.id, enabled)} />
+                </div>
+                <div className="custom-command-meta"><span>{command.prompt.trim() ? '提示词' : '无提示词'}</span><span>{command.script.trim() ? (command.scriptLanguage === 'python' ? 'Python' : 'JavaScript') : '无脚本'}</span><span>{formatCustomCommandDate(command.updatedAt)}</span></div>
+                <div className="custom-command-preview">{command.prompt || command.script || '未配置内容'}</div>
+                <div className="row gap-8"><Button size="small" onClick={() => setEditing(command)}>编辑</Button><Button size="small" danger onClick={() => void handleDelete(command.id)}>删除</Button></div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      {editing != null && <CustomCommandEditPanel command={editing} onClose={() => setEditing(null)} onSave={(draft) => void handleSave(draft)} />}
+    </>
+  )
+}
+
+function CustomCommandEditPanel({ command, onClose, onSave }: { command: CustomCommandItem; onClose: () => void; onSave: (draft: CustomCommandItem) => void }) {
+  const [draft, setDraft] = useState(command)
+  const patch = (next: Partial<CustomCommandItem>) => setDraft((current) => ({ ...current, ...next }))
+  const normalizedName = normalizeCustomCommandInput(draft.name)
+  const canSave = normalizedName != null && (!!draft.prompt.trim() || !!draft.script.trim())
+
+  return (
+    <div className="slide-panel-backdrop" onClick={onClose}>
+      <div className="slide-panel custom-command-panel" onClick={(event) => event.stopPropagation()}>
+        <div className="slide-panel-h"><div className="h-icon">/</div><div className="flex1"><div className="h-title">编辑自定义命令</div><div className="h-sub">保存后可在会话输入框输入 / 搜索触发</div></div><button className="icon-btn" onClick={onClose}><Icons.X /></button></div>
+        <div className="slide-panel-body">
+          <div className="custom-command-preview-strip"><span>预览</span><code>{normalizedName ?? '/custom-plan'} 用户输入的参数</code></div>
+          <div className="form-grid">
+            <label>命令名<span className="sub">例如 /custom-plan</span></label>
+            <Input value={draft.name} onChange={(event) => patch({ name: event.target.value })} placeholder="/custom-plan" />
+            <label>描述<span className="sub">显示在斜杠命令列表</span></label>
+            <Input value={draft.description} onChange={(event) => patch({ description: event.target.value })} placeholder="生成一份可执行计划" />
+            <label>启用</label>
+            <Switch size="small" checked={draft.enabled} onChange={(enabled) => patch({ enabled })} />
+            <label>脚本语言</label>
+            <Segmented value={draft.scriptLanguage} onChange={(value) => patch({ scriptLanguage: value as CustomCommandScriptLanguage })} options={[{ label: 'JavaScript', value: 'javascript' }, { label: 'Python', value: 'python' }]} />
+            <label>提示词<span className="sub">脚本成功后继续交给 Agent</span></label>
+            <TextArea value={draft.prompt} onChange={(event) => patch({ prompt: event.target.value })} placeholder="请基于用户输入输出分阶段计划，并列出风险和验证步骤。" className="rule-textarea custom-command-textarea" />
+            <label>脚本<span className="sub">命令后的文本会作为第一个参数传入</span></label>
+            <TextArea value={draft.script} onChange={(event) => patch({ script: event.target.value })} placeholder={draft.scriptLanguage === 'python' ? 'import sys\nprint(sys.argv[1] if len(sys.argv) > 1 else "")' : 'const arg = process.argv[2] || ""\\nconsole.log(arg)'} className="rule-textarea custom-command-textarea" />
+          </div>
+        </div>
+        <div className="slide-panel-foot"><span className="muted text-xs-12">{!canSave ? '需要有效命令名，并至少填写提示词或脚本。' : '脚本失败时不会继续执行提示词。'}</span><span className="flex1" /><Button size="small" type="default" onClick={onClose}>取消</Button><Button size="small" type="primary" disabled={!canSave} onClick={() => onSave(draft)}>保存</Button></div>
+      </div>
+    </div>
+  )
+}
+
+function createCustomCommandDraft(): CustomCommandItem {
+  const now = new Date().toISOString()
+  return { id: `custom-${Date.now()}`, name: '/custom-plan', description: '生成一份可执行计划', prompt: '请基于用户输入生成一份简洁、可执行、包含验证步骤的计划。', script: '', scriptLanguage: 'javascript', enabled: true, updatedAt: now }
+}
+
+function parseCustomCommandItems(raw: string | null): CustomCommandItem[] {
+  if (raw == null || raw.trim().length === 0) return []
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((item): item is Record<string, unknown> => item != null && typeof item === 'object').map((item) => ({
+      id: typeof item.id === 'string' ? item.id : `custom-${Date.now()}`,
+      name: typeof item.name === 'string' ? item.name : '/custom-command',
+      description: typeof item.description === 'string' ? item.description : '',
+      prompt: typeof item.prompt === 'string' ? item.prompt : '',
+      script: typeof item.script === 'string' ? item.script : '',
+      scriptLanguage: item.scriptLanguage === 'python' ? 'python' : 'javascript',
+      enabled: item.enabled !== false,
+      updatedAt: typeof item.updatedAt === 'string' ? item.updatedAt : new Date().toISOString(),
+    }))
+  } catch {
+    return []
+  }
+}
+
+function normalizeCustomCommandInput(value: string): string | null {
+  const name = value.trim().replace(/^\//, '').toLowerCase()
+  if (!/^[a-z][a-z0-9-]{1,62}$/.test(name)) return null
+  return `/${name}`
+}
+
+function formatCustomCommandDate(value: string): string {
+  const time = Date.parse(value)
+  if (!Number.isFinite(time)) return '未更新'
+  return new Date(time).toLocaleDateString()
 }
 
 /* ───────── MCP ───────── */

--- a/apps/desktop/src/renderer/design/views/overlays.tsx
+++ b/apps/desktop/src/renderer/design/views/overlays.tsx
@@ -251,6 +251,7 @@ function getLayerBadgeColor(layer: CommandLayer | 'ui'): string {
     case 'sdk': return 'var(--color-accent, #6366f1)'
     case 'builtin': return 'var(--color-success, #22c55e)'
     case 'skill': return 'var(--color-warning, #f59e0b)'
+    case 'custom': return 'var(--primary, #165dff)'
     case 'ui': return 'var(--color-muted, #94a3b8)'
   }
 }
@@ -464,7 +465,7 @@ export function CommandPalette({
 
     // Group by layer → group
     const sectionMap = new Map<string, PaletteSection>()
-    const layerOrder: Array<CommandLayer | 'ui'> = ['sdk', 'builtin', 'skill', 'ui']
+    const layerOrder: Array<CommandLayer | 'ui'> = ['sdk', 'builtin', 'skill', 'custom', 'ui']
 
     for (const cmd of filtered) {
       const layer = cmd.layer
@@ -691,7 +692,7 @@ function PaletteCommandItem({
           opacity: 0.7,
           whiteSpace: 'nowrap',
         }}>
-          {command.layer === 'sdk' ? 'SDK' : command.layer === 'builtin' ? '内置' : command.layer === 'skill' ? '技能' : ''}
+          {command.layer === 'sdk' ? 'SDK' : command.layer === 'builtin' ? '内置' : command.layer === 'skill' ? '技能' : command.layer === 'custom' ? '自定义' : ''}
         </span>
         {shortcutLabel && <span className="kbd" style={{ fontSize: 10 }}>{shortcutLabel}</span>}
         {!shortcutLabel && command.usage && (

--- a/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
+++ b/packages/agent-runtime/src/__tests__/core/command-registry.test.ts
@@ -167,6 +167,45 @@ describe('CommandRegistry', () => {
     expect(result.followUpPrompt).toBe('check the auth module for security issues')
     expect(result.followUpSkillId).toBe('builtin:code-review')
   })
+
+  it('registerCustomCommands adds valid enabled commands and skips invalid entries', () => {
+    const registry = createBuiltinRegistry()
+    registry.registerCustomCommands([
+      { id: 'plan', name: '/custom-plan', description: 'Plan work', prompt: 'Create a plan', script: '', scriptLanguage: 'javascript', enabled: true },
+      { id: 'bad', name: '/1-invalid', description: 'Invalid', prompt: 'No-op', script: '', scriptLanguage: 'python', enabled: true },
+      { id: 'disabled', name: '/disabled-command', description: 'Disabled', prompt: 'No-op', script: '', scriptLanguage: 'python', enabled: false },
+    ])
+
+    expect(registry.get('custom-plan')?.layer).toBe('custom')
+    expect(registry.get('custom-plan')?.description).toBe('Plan work')
+    expect(registry.get('1-invalid')).toBeUndefined()
+    expect(registry.get('disabled-command')).toBeUndefined()
+  })
+
+  it('custom prompt command returns followUpPrompt with arguments', async () => {
+    const registry = createBuiltinRegistry()
+    registry.registerCustomCommands([
+      { id: 'plan', name: '/custom-plan', description: 'Plan work', prompt: 'Create a plan', script: '', scriptLanguage: 'javascript', enabled: true },
+    ])
+
+    const result = await registry.execute(parse('/custom-plan auth refactor'), ctx, makeDeps())
+    expect(result.success).toBe(true)
+    expect(result.followUpPrompt).toContain('Create a plan')
+    expect(result.followUpPrompt).toContain('auth refactor')
+  })
+
+  it('custom script command executes through injected shell dependency', async () => {
+    const execShell = vi.fn(async () => ({ stdout: 'ok', stderr: '', exitCode: 0 }))
+    const registry = createBuiltinRegistry()
+    registry.registerCustomCommands([
+      { id: 'script', name: '/custom-script', description: 'Run script', prompt: '', script: 'console.log(process.argv[2])', scriptLanguage: 'javascript', enabled: true },
+    ])
+
+    const result = await registry.execute(parse('/custom-script hello'), ctx, makeDeps({ execShell }))
+    expect(result.success).toBe(true)
+    expect(result.message).toContain('stdout')
+    expect(execShell).toHaveBeenCalledWith(expect.stringContaining('node'), undefined)
+  })
 })
 
 describe('Built-in commands', () => {

--- a/packages/agent-runtime/src/core/command-registry.ts
+++ b/packages/agent-runtime/src/core/command-registry.ts
@@ -11,7 +11,10 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs'
+import { rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import path from 'node:path'
+import crypto from 'node:crypto'
 import type { ParsedCommand } from './command-parser.js'
 
 /* ============================================================
@@ -19,7 +22,7 @@ import type { ParsedCommand } from './command-parser.js'
    ============================================================ */
 
 /** 命令来源层 */
-export type CommandLayer = 'sdk' | 'builtin' | 'skill'
+export type CommandLayer = 'sdk' | 'builtin' | 'skill' | 'custom'
 
 /** 命令分组 */
 export type CommandGroup =
@@ -157,6 +160,18 @@ export interface CommandListItem {
   hasSubcommands?: boolean
 }
 
+export type CustomCommandScriptLanguage = 'javascript' | 'python'
+
+export interface CustomCommandConfig {
+  id: string
+  name: string
+  description: string
+  prompt: string
+  script: string
+  scriptLanguage: CustomCommandScriptLanguage
+  enabled: boolean
+}
+
 /* ============================================================
    Helpers
    ============================================================ */
@@ -182,6 +197,14 @@ function slugify(name: string): string {
     .replace(/[\s_]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '')
+}
+
+export function normalizeCustomCommandName(name: string): string {
+  return name.trim().replace(/^\//, '').toLowerCase()
+}
+
+export function isValidCustomCommandName(name: string): boolean {
+  return /^[a-z][a-z0-9-]{1,62}$/.test(normalizeCustomCommandName(name))
 }
 
 function clipCommandSectionOutput(output: string, maxLength = 4000): string {
@@ -241,6 +264,37 @@ export class CommandRegistry {
           this.aliasIndex.delete(alias)
         }
       }
+    }
+  }
+
+  clearCustomCommands(): void {
+    for (const [name, def] of this.commands) {
+      if (def.layer !== 'custom') continue
+      this.commands.delete(name)
+      for (const alias of def.aliases) {
+        this.aliasIndex.delete(alias)
+      }
+    }
+  }
+
+  registerCustomCommands(customCommands: CustomCommandConfig[]): void {
+    this.clearCustomCommands()
+    for (const custom of customCommands) {
+      if (!custom.enabled || !isValidCustomCommandName(custom.name)) continue
+      const name = normalizeCustomCommandName(custom.name)
+      if (this.commands.has(name) && this.commands.get(name)!.layer !== 'custom') continue
+      this.register({
+        id: `custom:${custom.id}`,
+        name,
+        aliases: [],
+        layer: 'custom',
+        group: 'utility',
+        description: custom.description.trim() || `自定义命令 /${name}`,
+        scope: 'session',
+        risk: custom.script.trim().length > 0 ? 'medium' : 'low',
+        usage: `/${name} [参数]`,
+        handler: async (cmd, _ctx, deps) => runCustomCommand(custom, cmd, deps),
+      })
     }
   }
 
@@ -347,6 +401,66 @@ export class CommandRegistry {
       }
     }
   }
+}
+
+async function runCustomCommand(
+  custom: CustomCommandConfig,
+  cmd: ParsedCommand,
+  deps: CommandDeps,
+): Promise<CommandResult> {
+  const argsText = cmd.freeText || cmd.args.join(' ').trim()
+  const outputSections: string[] = []
+
+  if (custom.script.trim().length > 0) {
+    if (deps.execShell == null) {
+      return { success: false, message: '当前运行时不支持执行自定义脚本。' }
+    }
+    const ext = custom.scriptLanguage === 'python' ? 'py' : 'js'
+    const runner = custom.scriptLanguage === 'python' ? 'python3' : 'node'
+    const safeId = custom.id.replace(/[^a-zA-Z0-9_-]/g, '-').slice(0, 64) || 'command'
+    const filePath = path.join(tmpdir(), `spark-custom-command-${safeId}-${crypto.randomUUID()}.${ext}`)
+    await writeFile(filePath, custom.script, 'utf8')
+    try {
+      const result = await deps.execShell(
+        `${runner} ${JSON.stringify(filePath)} ${JSON.stringify(argsText)}`,
+        deps.getWorkspacePath?.() ?? undefined,
+      )
+      outputSections.push(formatCustomScriptOutput(custom.scriptLanguage, result))
+      if (result.exitCode !== 0) return { success: false, message: outputSections.join('\n\n') }
+    } finally {
+      await rm(filePath, { force: true }).catch(() => undefined)
+    }
+  }
+
+  const prompt = custom.prompt.trim()
+  if (prompt.length > 0) {
+    return {
+      success: true,
+      message: [...outputSections, '已按自定义命令提示词继续交给 Agent 处理。']
+        .filter(Boolean)
+        .join('\n\n'),
+      followUpPrompt: `${prompt}${argsText ? `\n\n用户提供的命令参数：\n${argsText}` : ''}`,
+    }
+  }
+
+  return {
+    success: true,
+    message: outputSections.length > 0 ? outputSections.join('\n\n') : '自定义命令已执行。',
+  }
+}
+
+function formatCustomScriptOutput(
+  language: CustomCommandScriptLanguage,
+  result: { stdout: string; stderr: string; exitCode: number },
+): string {
+  const sections = [`脚本执行完成（${language}，exit ${result.exitCode}）。`]
+  if (result.stdout.trim()) {
+    sections.push(`**stdout**\n\n\`\`\`\n${clipCommandSectionOutput(result.stdout, 6000)}\n\`\`\``)
+  }
+  if (result.stderr.trim()) {
+    sections.push(`**stderr**\n\n\`\`\`\n${clipCommandSectionOutput(result.stderr, 3000)}\n\`\`\``)
+  }
+  return sections.join('\n\n')
 }
 
 /* ============================================================

--- a/packages/agent-runtime/src/core/index.ts
+++ b/packages/agent-runtime/src/core/index.ts
@@ -13,6 +13,8 @@ export type {
   CommandScope,
   CommandRisk,
   CommandListItem,
+  CustomCommandConfig,
+  CustomCommandScriptLanguage,
   CheckpointSnapshot,
   CheckpointRestoreResult,
 } from './command-registry.js'

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -65,6 +65,7 @@ import type {
   CheckpointSnapshot,
   CommandDeps,
   CommandListItem,
+  CustomCommandConfig,
 } from '../core/index.js'
 import * as keystore from '@spark/shared/keystore'
 import { McpService } from './mcp-server.service.js'
@@ -634,6 +635,7 @@ export class SessionService {
       ...(session?.model_id != null ? { model: session.model_id } : {}),
     }
 
+    this.registerConfiguredCommands()
     const result = await this.commandRegistry.execute(parsed, ctx, deps)
     if (result.forwardToAgent) return { isCommand: false }
     return { isCommand: true, result }
@@ -783,6 +785,7 @@ export class SessionService {
       ...(session?.model_id != null ? { model: session.model_id } : {}),
     }
 
+    this.registerConfiguredCommands()
     const result = await this.commandRegistry.execute(parsed, ctx, deps)
 
     if (result.forwardToAgent) return { isCommand: true, forwardToAgent: true }
@@ -895,10 +898,28 @@ export class SessionService {
   }
 
   listCommands(): CommandListItem[] {
-    // Dynamically register enabled skills as Layer 3 commands
+    this.registerConfiguredCommands()
+    return this.commandRegistry.listItems()
+  }
+
+  private registerConfiguredCommands(): void {
     const skills = listSkillSummaries(new SkillRepository(this.db))
     this.commandRegistry.registerSkillCommands(skills)
-    return this.commandRegistry.listItems()
+    this.commandRegistry.registerCustomCommands(this.listCustomCommands())
+  }
+
+  private listCustomCommands(): CustomCommandConfig[] {
+    const raw = new SettingsRepository(this.db).get('custom-commands', 'items')
+    if (typeof raw !== 'string' || raw.trim().length === 0) return []
+    try {
+      const parsed = JSON.parse(raw) as unknown
+      if (!Array.isArray(parsed)) return []
+      return parsed
+        .map((item) => normalizeCustomCommandConfig(item))
+        .filter((item): item is CustomCommandConfig => item != null)
+    } catch {
+      return []
+    }
   }
 
   async sendTurn(params: {
@@ -5488,6 +5509,23 @@ function trimHistoryEvent(event: AgentEvent): AgentEvent {
 
 type WorkspaceFileChangeSnapshot = Set<string>
 type WorkspaceDetectedFileChange = { path: string; changeType: 'create' | 'modify' | 'delete' }
+
+function normalizeCustomCommandConfig(value: unknown): CustomCommandConfig | null {
+  if (value == null || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const id = typeof record.id === 'string' ? record.id : ''
+  const name = typeof record.name === 'string' ? record.name : ''
+  if (!id || !name) return null
+  return {
+    id,
+    name,
+    description: typeof record.description === 'string' ? record.description : '',
+    prompt: typeof record.prompt === 'string' ? record.prompt : '',
+    script: typeof record.script === 'string' ? record.script : '',
+    scriptLanguage: record.scriptLanguage === 'python' ? 'python' : 'javascript',
+    enabled: record.enabled !== false,
+  }
+}
 
 async function collectWorkspaceChangeSnapshot(workspaceRootPath: string): Promise<WorkspaceFileChangeSnapshot> {
   try {

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -2926,7 +2926,7 @@ export type TerminalStreamEvent =
 
 // ─── Command Channels ────────────────────────────────────────────────────────
 
-export type CommandLayer = 'sdk' | 'builtin' | 'skill'
+export type CommandLayer = 'sdk' | 'builtin' | 'skill' | 'custom'
 
 export type CommandGroup =
   | 'session'


### PR DESCRIPTION
### Motivation

- Provide a way for users to define reusable slash commands that can run a short script and/or continue with a prompt, and expose them in the command palette and composer slash list.  

### Description

- Add a new "Custom Commands" settings section and UI components including list, search, edit panel, toolbar and CSS styles under `apps/desktop/src/renderer/design/...` to create, edit, enable/disable and preview commands.  
- Introduce a new `custom` command layer across the codebase and wire it into the composer slash popup and command palette display badges and ordering (UI badges, colors and labels).  
- Extend the command registry with `registerCustomCommands`, `clearCustomCommands`, name validation/normalization helpers, and `runCustomCommand` which can execute JavaScript/Python scripts via an injected `execShell` dependency, stream script stdout/stderr into the command result, and then optionally produce a follow-up prompt to forward to an Agent.  
- Persist and load custom commands from settings (session service integration), parse/normalize stored configs, and add IPC type support for the `custom` layer.  
- Add unit tests for the command registry to cover registration, name validation, prompt-based follow-up, and script execution through the injected shell dependency.  

### Testing

- Ran unit tests for the agent runtime command registry (`packages/agent-runtime`), including the new `command-registry` tests; all tests succeeded.  
- Manual UI checks were exercised by loading the Settings view to ensure commands list, editor panel, search, enable/disable and refresh interactions render without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e3cd6163083239cd5406fc4516e1f)