### PR TITLE
fix(ui): 恢复官网标题文案并修正 CanvasNode 缩进

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -743,23 +743,23 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             className="canvas-node-meta-bar nodrag nopan"
           >
             <span className="canvas-node-meta-title">
-            {node.type === 'image' &&
-              (node.data.panorama360 ? <Icons.Globe size={12} /> : <Icons.Image size={12} />)}
-            {node.type === 'audio' && <Icons.Play size={12} />}
-            {(node.type === 'text' || node.type === 'prompt') && <Icons.File size={12} />}
-            {isDirectorStage ? (
-              <Icons.Play size={12} />
-            ) : isOperationNode(node) ? (
-              operationNodeIcon(nodeOperation(node))
-            ) : node.type === 'task' ? (
-              <Icons.Activity size={12} />
-            ) : null}
-            {node.type === 'video' && <Icons.Play size={12} />}
-            {node.type === 'group' && <Icons.Layers size={12} />}
-            <span title={node.data.panorama360 ? `360全景 · ${title}` : title}>
-              {node.data.panorama360 ? `360全景 · ${title}` : title}
+              {node.type === 'image' &&
+                (node.data.panorama360 ? <Icons.Globe size={12} /> : <Icons.Image size={12} />)}
+              {node.type === 'audio' && <Icons.Play size={12} />}
+              {(node.type === 'text' || node.type === 'prompt') && <Icons.File size={12} />}
+              {isDirectorStage ? (
+                <Icons.Play size={12} />
+              ) : isOperationNode(node) ? (
+                operationNodeIcon(nodeOperation(node))
+              ) : node.type === 'task' ? (
+                <Icons.Activity size={12} />
+              ) : null}
+              {node.type === 'video' && <Icons.Play size={12} />}
+              {node.type === 'group' && <Icons.Layers size={12} />}
+              <span title={node.data.panorama360 ? `360全景 · ${title}` : title}>
+                {node.data.panorama360 ? `360全景 · ${title}` : title}
+              </span>
             </span>
-          </span>
           <span className="canvas-node-meta-tags">
             {roleMeta ? (
               <span className="canvas-node-meta-chip canvas-node-meta-chip-role">{roleMeta.label}</span>

--- a/apps/website/src/routes/HomePage.tsx
+++ b/apps/website/src/routes/HomePage.tsx
@@ -69,7 +69,7 @@ export function HomePage() {
         </div>
       </Section>
       <Section
-        title="界面展示，工作流展示"
+        title="真实界面，真实工作流"
         intro="下面展示的是桌面端实际界面：从开发任务到内容生产，你看到的就是日常使用时的工作方式。"
       >
         <div className="showcase-grid">


### PR DESCRIPTION
代码审查修复：
- HomePage: 还原 Section 标题为「真实界面，真实工作流」；上一提交误改为 「界面展示，工作流展示」，与强调「实际界面」的 intro 文案冲突且表达更弱。
- CanvasNode: 修正 canvas-node-meta-title 在条件包裹后的子节点缩进， 消除上一提交遗留的层级错位（功能不变，仅可读性）。