### PR TITLE
Command palette: session-scoped insert, quick-task binding, and shortcuts UI polish

### DIFF
--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -927,6 +927,7 @@ function Shell() {
   )
 
   const [quickTaskOpen, setQuickTaskOpen] = useState(false)
+  const [paletteCommandRequest, setPaletteCommandRequest] = useState<{ id: number; commandText: string } | null>(null)
 
   // Toggle left sidebar visibility. Kept for non-shortcut UI entry points; Ctrl/Cmd+B
   // is now reserved for global quick task capture.
@@ -1055,6 +1056,7 @@ function Shell() {
             userQuestion={activeUserQuestion}
             onUserQuestionClose={dismissUserQuestion}
             onExpandSidebar={handleExpandSidebar}
+            paletteCommandRequest={paletteCommandRequest}
           />
         )
       case 'workflows':
@@ -1091,6 +1093,7 @@ function Shell() {
             userQuestion={activeUserQuestion}
             onUserQuestionClose={dismissUserQuestion}
             onExpandSidebar={handleExpandSidebar}
+            paletteCommandRequest={paletteCommandRequest}
           />
         )
     }
@@ -1194,7 +1197,11 @@ function Shell() {
             onClose={() => setTweak('showPalette', false)}
             onNavigate={handleNavigate}
             onNewSession={handleNewBlankSession}
-            onToggleSidebar={handleToggleSidebar}
+            onQuickTask={handleQuickTask}
+            sessionContext={t.view === 'chat'}
+            onInsertCommand={(commandText) => {
+              setPaletteCommandRequest({ id: Date.now(), commandText })
+            }}
           />
         )}
         {t.showPerm && (

--- a/apps/desktop/src/renderer/design/hooks/useKeyboard.ts
+++ b/apps/desktop/src/renderer/design/hooks/useKeyboard.ts
@@ -35,9 +35,7 @@ export function formatShortcut(key: string, shift = false): string {
 export type ShortcutId =
   | 'openPalette'
   | 'newSession'
-  | 'newProject'
   | 'openSettings'
-  | 'viewHome'
   | 'viewChat'
   | 'viewWorkflows'
   | 'viewAgents'
@@ -72,15 +70,13 @@ export type ShortcutBinding = {
 export const DEFAULT_SHORTCUTS: ShortcutBinding[] = [
   { id: 'openPalette',   label: '命令面板',       key: 'k', mod: true,  shift: false, description: '打开命令面板',                   group: 'action' },
   { id: 'newSession',    label: '新建会话',       key: 'n', mod: true,  shift: false, description: '创建一个新的聊天会话',           group: 'action' },
-  { id: 'newProject',    label: '新建项目',       key: 'n', mod: true,  shift: true,  description: '创建一个新项目',                 group: 'action' },
   { id: 'openSettings',  label: '设置',           key: ',', mod: true,  shift: false, description: '打开设置页面',                   group: 'settings' },
-  { id: 'viewHome',      label: 'Home 视图',      key: '1', mod: true,  shift: false, description: '切换到 Home 视图',               group: 'navigation' },
-  { id: 'viewChat',      label: 'Chat 视图',      key: '2', mod: true,  shift: false, description: '切换到 Chat 视图',               group: 'navigation' },
-  { id: 'viewWorkflows', label: 'Workflows 视图', key: '3', mod: true,  shift: false, description: '切换到 Workflows 视图',          group: 'navigation' },
-  { id: 'viewAgents',    label: 'Agents 视图',    key: '4', mod: true,  shift: false, description: '切换到 Agents 视图',             group: 'navigation' },
-  { id: 'viewSkills',    label: 'Skills 视图',    key: '5', mod: true,  shift: false, description: '切换到 Skills 视图',             group: 'navigation' },
-  { id: 'viewMcp',       label: '连接器与 MCP 视图',       key: '6', mod: true,  shift: false, description: '切换到连接器与 MCP 视图',                group: 'navigation' },
-  { id: 'viewSettings',  label: 'Settings 快捷', key: '7', mod: true,  shift: false, description: '切换到 Settings 视图',           group: 'navigation' },
+  { id: 'viewChat',      label: 'Chat 视图',      key: '1', mod: true,  shift: false, description: '切换到 Chat 视图',               group: 'navigation' },
+  { id: 'viewWorkflows', label: 'Workflows 视图', key: '2', mod: true,  shift: false, description: '切换到 Workflows 视图',          group: 'navigation' },
+  { id: 'viewAgents',    label: 'Agents 视图',    key: '3', mod: true,  shift: false, description: '切换到 Agents 视图',             group: 'navigation' },
+  { id: 'viewSkills',    label: 'Skills 视图',    key: '4', mod: true,  shift: false, description: '切换到 Skills 视图',             group: 'navigation' },
+  { id: 'viewMcp',       label: '连接器与 MCP 视图',       key: '5', mod: true,  shift: false, description: '切换到连接器与 MCP 视图',                group: 'navigation' },
+  { id: 'viewSettings',  label: 'Settings 快捷', key: '6', mod: true,  shift: false, description: '切换到 Settings 视图',           group: 'navigation' },
   { id: 'toggleSidebar', label: '快捷录入任务',  key: 'b', mod: true,  shift: false, description: '打开全局任务快捷录入浮窗',       group: 'action' },
   { id: 'search',        label: '搜索',           key: 'f', mod: true,  shift: false, description: '聚焦搜索框（Chat 页面）',        group: 'action' },
   { id: 'escape',        label: '关闭',           key: 'Escape', mod: false, shift: false, description: '关闭当前对话框/面板/命令面板', group: 'action' },
@@ -143,8 +139,6 @@ type ShortcutActions = {
   onSearchFocus?: () => void
   /** Optional: trigger a custom new-session action */
   onNewSession?: () => void
-  /** Optional: trigger a custom new-project action */
-  onNewProject?: () => void
   /** Optional: open the global quick task modal (Ctrl/Cmd+B) */
   onQuickTask?: () => void
   /** Optional: toggle the left sidebar visibility (legacy fallback) */
@@ -155,12 +149,11 @@ type ShortcutActions = {
 
 const VIEW_INDEX_MAP: Record<string, ViewId> = {
   '1': 'chat',
-  '2': 'chat',
-  '3': 'workflows',
-  '4': 'agents',
-  '5': 'skill-store',
-  '6': 'mcp',
-  '7': 'settings',
+  '2': 'workflows',
+  '3': 'agents',
+  '4': 'skill-store',
+  '5': 'mcp',
+  '6': 'settings',
 }
 
 export function useGlobalShortcuts(actions: ShortcutActions): ShortcutBinding[] {
@@ -208,7 +201,7 @@ export function useGlobalShortcuts(actions: ShortcutActions): ShortcutBinding[] 
     }
 
     const shortcuts = shortcutsRef.current
-    const { setTweak, onSearchFocus, onNewSession, onNewProject, onQuickTask, onToggleSidebar, hasOverlayOpen } = actionsRef.current
+    const { setTweak, onSearchFocus, onNewSession, onQuickTask, onToggleSidebar, hasOverlayOpen } = actionsRef.current
 
     for (const sc of shortcuts) {
       const modPressed = isMac ? e.metaKey : e.ctrlKey
@@ -221,7 +214,7 @@ export function useGlobalShortcuts(actions: ShortcutActions): ShortcutBinding[] 
       ) {
         // For mod-required shortcuts, skip if input is focused, except app search:
         // Cmd/Ctrl+F should always open Spark's search instead of browser find.
-        if (sc.mod && sc.id !== 'search' && isEditableTarget(e.target)) continue
+        if (sc.mod && sc.id !== 'search' && sc.id !== 'openPalette' && isEditableTarget(e.target)) continue
         // For Escape, always handle (even in inputs)
         if (sc.id === 'escape' && isEditableTarget(e.target)) {
           // Let the input handle Escape naturally (blur, etc.) — only close overlays
@@ -245,17 +238,9 @@ export function useGlobalShortcuts(actions: ShortcutActions): ShortcutBinding[] 
               setTweak('view', 'chat')
             }
             break
-          case 'newProject':
-            if (onNewProject) {
-              onNewProject()
-            } else {
-              setTweak('view', 'chat')
-            }
-            break
           case 'openSettings':
             setTweak('view', 'settings')
             break
-          case 'viewHome':
           case 'viewChat':
           case 'viewWorkflows':
           case 'viewAgents':

--- a/apps/desktop/src/renderer/design/styles/views.css
+++ b/apps/desktop/src/renderer/design/styles/views.css
@@ -9481,12 +9481,28 @@ body.inspector-resizing {
 }
 .keymap .km-action,
 .keymap .km-keys {
-  padding: 8px 12px;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--divider);
   display: flex;
   align-items: center;
   font-size: var(--font-sm);
   color: var(--text);
+}
+.keymap .km-action {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 5px;
+}
+.keymap .km-action-title {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  color: var(--text);
+}
+.keymap .km-action-desc {
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--muted);
 }
 .km-row:last-child .km-action,
 .km-row:last-child .km-keys {

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -344,6 +344,7 @@ type ChatViewProps = {
   userQuestion?: UserQuestionData | null
   onUserQuestionClose?: (sessionId: string, questionId?: string) => void
   onExpandSidebar?: () => void
+  paletteCommandRequest?: { id: number; commandText: string } | null
 }
 
 const SAFE_FILE_SCHEME = 'safe-file'
@@ -500,6 +501,7 @@ export function ChatView({
   userQuestion = null,
   onUserQuestionClose,
   onExpandSidebar,
+  paletteCommandRequest = null,
 }: ChatViewProps = {}) {
   const { t, setTweak } = useApp()
   const appearance = useAppearanceSettings()
@@ -1696,6 +1698,7 @@ export function ChatView({
         onOpenSkillStore={openSkillStore}
         replyTo={null}
         onDispatchStateChange={setComposerDispatching}
+        paletteCommandRequest={paletteCommandRequest}
       />
     ) : (
       <ComposerV2
@@ -1745,6 +1748,7 @@ export function ChatView({
         replyTo={showEmptyHero ? null : replyTo}
         onClearReply={() => setReplyTo(null)}
         onDispatchStateChange={setComposerDispatching}
+        paletteCommandRequest={paletteCommandRequest}
       />
     )
 
@@ -9652,6 +9656,7 @@ function ComposerV2({
   focusTrigger = 0,
   resendRequest = null,
   onDispatchStateChange,
+  paletteCommandRequest = null,
 }: {
   session: SessionSummary | null
   workspace: WorkspaceInfo | null
@@ -9725,6 +9730,7 @@ function ComposerV2({
   // 暴露发送中状态给父组件。父组件用它在发送期间抑制 hero，
   // 覆盖 createSession→sendTurn→status=running 之间 hero 闪现的窗口。
   onDispatchStateChange?: (dispatching: boolean) => void
+  paletteCommandRequest?: { id: number; commandText: string } | null
 }) {
   const { toast } = useToast()
   const initialPrefsRef = useRef<ComposerPrefs | null>(null)
@@ -11174,6 +11180,30 @@ function ComposerV2({
       void handleSend()
     }
   }
+
+
+  // Command palette can be opened from the chat composer with Cmd/Ctrl+K; selecting
+  // a session command should fill the composer instead of executing immediately.
+  const lastPaletteCommandRequestIdRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (paletteCommandRequest == null) return
+    if (paletteCommandRequest.id === lastPaletteCommandRequestIdRef.current) return
+    lastPaletteCommandRequestIdRef.current = paletteCommandRequest.id
+
+    const { commandText } = paletteCommandRequest
+    setValue(commandText)
+    setSlashOpen(false)
+    setSlashFilter('')
+    setSlashIndex(0)
+    setTextEditMenu(null)
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (el == null) return
+      el.focus()
+      const caret = commandText.length
+      el.setSelectionRange(caret, caret)
+    })
+  }, [paletteCommandRequest, setValue])
 
   // Auto-dismiss Escape confirmation after 3 seconds
   useEffect(() => {

--- a/apps/desktop/src/renderer/design/views/SettingsView.tsx
+++ b/apps/desktop/src/renderer/design/views/SettingsView.tsx
@@ -1928,8 +1928,8 @@ function ShortcutsSection() {
               {items.map((shortcut) => (
                 <div key={shortcut.id} className="km-row">
                   <div className="km-action">
-                    <div>{shortcut.label}</div>
-                    <div className="muted small">{shortcut.description}</div>
+                    <div className="km-action-title">{shortcut.label}</div>
+                    <div className="km-action-desc">{shortcut.description}</div>
                   </div>
                   <div className="km-keys">
                     {shortcut.shift && <span className="kbd">⇧</span>}

--- a/apps/desktop/src/renderer/design/views/overlays.tsx
+++ b/apps/desktop/src/renderer/design/views/overlays.tsx
@@ -18,9 +18,9 @@ import { Icons } from '../Icons'
 import { Input } from '@lobehub/ui'
 import type { InputRef } from 'antd'
 import { useToast } from '../components/Toast'
-import { getShortcutLabel, DEFAULT_SHORTCUTS, formatShortcut } from '../hooks/useKeyboard'
+import { getShortcutLabel } from '../hooks/useKeyboard'
 import type { ShortcutId } from '../hooks/useKeyboard'
-import type { PermissionApprovalRequest, PermissionApprovalDecision, CommandListItem, CommandLayer, CommandGroup, CommandRisk } from '@spark/protocol'
+import type { PermissionApprovalRequest, PermissionApprovalDecision, CommandListItem, CommandLayer, CommandRisk, CommandScope } from '@spark/protocol'
 
 /* ============================================================
    Types
@@ -34,6 +34,7 @@ type CommandItem = {
   group: string
   description: string
   risk: CommandRisk | 'none'
+  scope: CommandScope | 'app'
   usage?: string
   hasSubcommands?: boolean
   /** Optional shortcut ID for displaying keyboard hint */
@@ -284,15 +285,21 @@ export function CommandPalette({
   onClose,
   onNavigate,
   onNewSession,
-  onToggleSidebar,
+  onQuickTask,
+  sessionContext = false,
+  onInsertCommand,
 }: {
   onClose: () => void
   /** Navigate to a view */
   onNavigate?: (view: string) => void
   /** Create a new session */
   onNewSession?: () => void
-  /** Toggle the left sidebar visibility */
-  onToggleSidebar?: () => void
+  /** Open the global quick task modal */
+  onQuickTask?: () => void
+  /** True when opened from the chat/session view. Session-scoped commands are only useful there. */
+  sessionContext?: boolean
+  /** Insert a slash command into the active conversation composer instead of executing it. */
+  onInsertCommand?: (commandText: string) => void
 }) {
   const [query, setQuery] = useState('')
   const [ipcCommands, setIpcCommands] = useState<CommandListItem[]>([])
@@ -320,14 +327,6 @@ export function CommandPalette({
 
   // Built-in UI commands (shortcuts that appear in the palette)
   const uiCommands: UICmd[] = useMemo(() => [
-    {
-      id: 'ui:nav-home',
-      name: 'Home 视图',
-      description: '切换到 Home 视图',
-      category: 'navigation',
-      shortcutId: 'viewHome',
-      execute: () => onNavigate?.('home'),
-    },
     {
       id: 'ui:nav-chat',
       name: 'Chat 视图',
@@ -392,14 +391,14 @@ export function CommandPalette({
       execute: () => onNewSession?.(),
     },
     {
-      id: 'ui:toggle-sidebar',
-      name: '切换侧边栏',
-      description: '折叠/展开侧边栏',
+      id: 'ui:quick-task',
+      name: '快捷录入任务',
+      description: '打开全局任务快捷录入浮窗',
       category: 'action',
       shortcutId: 'toggleSidebar',
-      execute: () => onToggleSidebar?.(),
+      execute: () => onQuickTask?.(),
     },
-  ], [onNavigate, onNewSession, onToggleSidebar])
+  ], [onNavigate, onNewSession, onQuickTask])
 
   // Merge all commands: IPC three-layer + UI commands
   const allCommands = useMemo(() => {
@@ -413,6 +412,7 @@ export function CommandPalette({
         group: cmd.group,
         description: cmd.description,
         risk: cmd.risk,
+        scope: cmd.scope,
       }
       if (cmd.usage !== undefined) item.usage = cmd.usage
       if (cmd.hasSubcommands !== undefined) item.hasSubcommands = cmd.hasSubcommands
@@ -427,10 +427,14 @@ export function CommandPalette({
       group: cmd.category,
       description: cmd.description,
       risk: 'none' as const,
+      scope: 'app' as const,
       shortcutId: cmd.shortcutId,
     }))
-    return [...ipcItems, ...uiItems]
-  }, [ipcCommands, uiCommands])
+    const contextAwareIpcItems = sessionContext
+      ? ipcItems
+      : ipcItems.filter((cmd) => cmd.scope === 'global' || cmd.scope === 'workspace')
+    return [...contextAwareIpcItems, ...uiItems]
+  }, [ipcCommands, uiCommands, sessionContext])
 
   // Filter, sort (recent first), and group by layer + group
   const filteredSections = useCallback((): PaletteSection[] => {
@@ -535,6 +539,13 @@ export function CommandPalette({
       return
     }
 
+    // Session commands are conversation actions: selecting them fills the chat composer.
+    if (sessionContext && cmd.scope === 'session') {
+      onInsertCommand?.(`/${cmd.name} `)
+      onClose()
+      return
+    }
+
     // IPC command
     const fullCommand = query.trim() || `/${cmd.name}`
     try {
@@ -551,7 +562,7 @@ export function CommandPalette({
       toast.error(err instanceof Error ? err.message : `执行 /${cmd.name} 失败`)
     }
     onClose()
-  }, [query, toast, onClose, uiCommands])
+  }, [query, toast, onClose, uiCommands, sessionContext, onInsertCommand])
 
   // Keyboard navigation
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -583,7 +594,7 @@ export function CommandPalette({
           <Icons.Search />
           <Input
             ref={inputRef}
-            placeholder="搜索命令..."
+            placeholder={sessionContext ? '搜索命令，选择后加入对话...' : '搜索应用级命令...'}
             autoFocus
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -658,7 +669,6 @@ function PaletteCommandItem({
   const shortcutLabel = command.shortcutId
     ? getShortcutLabel(command.shortcutId)
     : command.shortcutHint ?? ''
-  const displayCommand = command.layer === 'ui' ? command.name : `/${command.name}`
   const layerColor = getLayerBadgeColor(command.layer)
 
   return (


### PR DESCRIPTION
### Motivation
- Allow selecting slash/agent commands from the command palette to fill the chat composer instead of executing immediately when opened from a session context. 
- Repurpose the legacy Ctrl/Cmd+B toggle to open a global quick-task capture modal and ensure shortcuts reflect that change. 
- Improve the shortcuts settings UI presentation and keymap layout for clarity. 
- Limit palette-listed IPC commands to those appropriate for the current context (app vs session/workspace). 

### Description
- Added a `paletteCommandRequest` state in `Shell` and threaded it into `ChatView` and `ComposerV2` so the composer can be prefilled from the palette. 
- Implemented composer-side handling to insert text, focus, and set caret when a palette command is requested instead of executing it immediately. 
- Extended `CommandPalette` API with `onQuickTask`, `sessionContext`, and `onInsertCommand` props; filter IPC commands by `scope` and, when `sessionContext` is true, selecting a `session`-scoped command calls `onInsertCommand` (`/<name> `) rather than invoking execution. 
- Mapped the UI built-in command that used to toggle the sidebar to the new quick-task action and updated global shortcut handling so Ctrl/Cmd+B triggers quick-task (with legacy toggle as fallback). 
- Reworked default shortcuts and their numeric view bindings (reordered keys and removed obsolete entries), adjusted input-focus guards so palette opening works from editable fields, and cleaned up unreachable/new shortcut code paths. 
- Updated shortcuts settings UI: added `.km-action-title`/`.km-action-desc` styles and adjusted spacing in `views.css`, and updated `SettingsView` rendering to use the new title/description elements. 
- Minor type/import adjustments in overlays and command palette to surface `CommandScope` and populate item `scope` from IPC commands. 

### Testing
- Performed TypeScript typecheck on the renderer and compile of the renderer dev build, both succeeded. 
- Ran the renderer unit test suite and end-to-end smoke checks for command palette and composer interactions, all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a433142ef0c8323aedc954024602d6f)