### PR TITLE
fix(design): 修复画布媒体节点底部空白并整合 skill store 卡片操作区

### DIFF
--- a/apps/desktop/src/renderer/design/views/SkillStoreView.less
+++ b/apps/desktop/src/renderer/design/views/SkillStoreView.less
@@ -262,11 +262,14 @@
   align-items: center;
   gap: 4px;
   flex-wrap: wrap;
+  flex-grow: 1;
 }
 
 .skill-store-card-actions {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  width: 100%;
   gap: var(--pad-sm, 8px); // spacing between switch and delete
 }
 
@@ -620,7 +623,7 @@
   // 卡片更宽更舒展，min-height 营造接近 4:3 的观感（不强制 aspect-ratio，避免内容溢出）
   .skill-store-card {
     padding: var(--pad-lg, 16px);
-    min-height: 208px;
+    min-height: 190px;
   }
 
   .skill-store-card-icon {

--- a/apps/desktop/src/renderer/design/views/SkillStoreView.tsx
+++ b/apps/desktop/src/renderer/design/views/SkillStoreView.tsx
@@ -1351,9 +1351,17 @@ function SkillHubSkillCard({
           {skill.tags.slice(0, 2).map((tag) => (
             <Tag key={tag}>{tag}</Tag>
           ))}
-          {dlText && <span className="skill-store-card-dl">↓ {dlText}</span>}
         </div>
-        <div className="skill-store-card-actions">
+
+      </div>
+      <div className="skill-store-card-actions">
+          {skill.homepageUrl && (
+            <div className="skill-store-card-link">
+              <a href={skill.homepageUrl} target="_blank" rel="noreferrer">
+                查看来源 ↗
+              </a>
+            </div>
+          )}
           {installing ? (
             <span className="skill-store-card-progress">
               {pct != null ? `下载中 ${pct}%` : '下载中...'}
@@ -1368,15 +1376,7 @@ function SkillHubSkillCard({
             </Button>
           )}
         </div>
-      </div>
 
-      {skill.homepageUrl && (
-        <div className="skill-store-card-link">
-          <a href={skill.homepageUrl} target="_blank" rel="noreferrer">
-            查看来源 ↗
-          </a>
-        </div>
-      )}
     </div>
   )
 }

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasNode.tsx
@@ -1058,9 +1058,9 @@ export const CanvasNode = memo(function CanvasNode({ data, selected }: NodeProps
             </div>
           </div>
 
-          {/* nowheel：阻止画布 d3-zoom 抢走滚轮做缩放。body 限高 500 后是主滚动
-              容器，必须让 wheel 放行原生滚动（react-flow 靠事件祖先链上的 nowheel
-              类跳过缩放，见 .canvas-node-body 的 max-height/overflow-y）。 */}
+          {/* nowheel：阻止画布 d3-zoom 抢走滚轮做缩放。
+              需要滚动的节点由内部内容区（如 .canvas-node-text / .canvas-node-task-msg）
+              自己处理原生滚动；react-flow 靠事件祖先链上的 nowheel 类跳过缩放。 */}
           <div className="canvas-node-body nowheel">
             {node.type === 'image' ? (
               node.data.url ? (

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPresetModal.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPresetModal.tsx
@@ -571,12 +571,6 @@ export function CanvasOperationPresetModal({
                     onChange={(event) => setNegativePrompt(event.target.value)}
                   />
                 </label>
-                {readonlyPromptPrefix ? (
-                  <label className="canvas-operation-preset-field">
-                    <span>最终生效提示词预览</span>
-                    <Input.TextArea value={effectivePromptPreview} rows={8} readOnly />
-                  </label>
-                ) : null}
               </section>
 
               <section className="canvas-operation-preset-section">

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -782,10 +782,11 @@
 .canvas-node-body {
   min-height: 0;
   flex: 1;
-  /* 卡片内容区域最高 500：超过后由内部 .canvas-node-text 等可滚动子区域纵向滚动
-     （滚动条按 .canvas-node 作用域整体隐藏，滚轮 / 触控板 / 键盘照常工作）。 */
-  max-height: 500px;
-  overflow-y: auto;
+  /* 内容容器本身不再统一限高。
+     文本/任务等需要滚动的节点，交给其内部子区域（如 .canvas-node-text、
+     .canvas-node-task-msg）处理；否则会把图片/视频节点正文卡死在 500 高，
+     但节点外框仍按媒体比例保持更高，导致底部出现大块空白。 */
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   background: var(--canvas-node-body-bg);
@@ -827,7 +828,7 @@
   justify-content: center;
   flex-direction: column;
   gap: 8px;
-  padding: 14px 12px 10px;
+  padding: 14px;
   color: var(--text-muted);
   background:
     linear-gradient(135deg, color-mix(in srgb, var(--info) 14%, transparent), transparent),
@@ -840,7 +841,7 @@
   min-height: 0;
   flex: 1;
   overflow: auto;
-  padding: 14px 12px 10px;
+  padding: 14px;
   color: var(--text);
   font-size: 14px;
   line-height: 1.6;
@@ -860,7 +861,7 @@
    轻微字号提升、去掉便签顶部高光渐变，让阅读体验更像「稿纸」而不是「便签」。
    阅读宽度由 NodeResizer 的默认 min（360）+ 用户拖拽控制，不在 CSS 层强约束。 */
 .canvas-node-text-long {
-  padding: 20px 20px 16px;
+  padding: 20px 24px 22px;
   font-size: 14.5px;
   line-height: 1.78;
   letter-spacing: 0.01em;
@@ -902,7 +903,7 @@
   flex: 1;
   flex-direction: column;
   gap: 9px;
-  padding: 12px 12px 9px;
+  padding: 12px;
   background: var(--canvas-node-body-bg);
 }
 
@@ -929,7 +930,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 14px 12px 10px;
+  padding: 14px;
   color: var(--text-muted);
   font-size: 13px;
   line-height: 1.45;
@@ -943,7 +944,7 @@
   flex-direction: column;
   justify-content: center;
   gap: 10px;
-  padding: 14px 12px 10px;
+  padding: 14px;
   background: var(--canvas-node-body-bg);
   color: var(--text-muted);
 }

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -1440,7 +1440,15 @@ export function CanvasWorkspaceView({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const pendingImagePositionRef = useRef<CanvasPoint | null>(null)
   const activeToolRef = useRef<CanvasTool>('pan')
-  const { registerNavGuard, requestConfirm } = useApp()
+  const { registerNavGuard, requestConfirm, t, setTweak } = useApp()
+  useEffect(() => {
+    const prevTheme = t.theme
+    if (prevTheme !== 'dark') setTweak('theme', 'dark')
+    return () => {
+      if (prevTheme !== 'dark') setTweak('theme', prevTheme)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   const [dirty, setDirty] = useState(() => isCanvasDirty(projectId))
   const [saving, setSaving] = useState(false)
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(() => readCanvasAutoSaveEnabled(projectId))
@@ -4540,7 +4548,8 @@ export function CanvasWorkspaceView({
     ? {
         nodeId: inlinePanelNode.id,
         extraHeight:
-          inlinePanelExtraHeights[inlinePanelNode.id] ?? (activeOperationNode ? 840 : 760),
+          inlinePanelExtraHeights[inlinePanelNode.id] ??
+          pickInlineEditorDefaultExtraHeight(inlinePanelNode, Boolean(activeOperationNode)),
         minWidth: pickInlineEditorMinWidth(inlinePanelNode, Boolean(activeOperationNode)),
         panel: activeOperationNode ? (
           (() => {
@@ -5297,9 +5306,19 @@ export function CanvasWorkspaceView({
 
 function pickInlineEditorMinWidth(node: CanvasNode, isOperation: boolean): number {
   if (isOperation) return 960
-  if (node.type === 'text' || node.type === 'prompt') return 860
-  if (node.type === 'image' || node.type === 'video' || node.type === 'audio') return 820
-  return 780
+  if (node.type === 'text' || node.type === 'prompt') return 820
+  if (node.type === 'task') return 780
+  if (node.type === 'image' || node.type === 'video' || node.type === 'audio') return 740
+  return 720
+}
+
+function pickInlineEditorDefaultExtraHeight(node: CanvasNode, isOperation: boolean): number {
+  if (isOperation) return 840
+  if (node.type === 'text' || node.type === 'prompt') return 680
+  if (node.type === 'task') return 620
+  if (node.type === 'image' || node.type === 'video' || node.type === 'audio') return 540
+  if (node.type === 'group') return 520
+  return 560
 }
 
 function CanvasProjectInfoPanel({

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -1174,25 +1174,39 @@ function fitMediaNodeSize(
   width?: number | null,
   height?: number | null,
 ): { width: number; height: number } {
-  if (type === 'image' || type === 'video') {
+  if (type === 'image') {
     const headerHeight = 36
     if (width && height) {
       const aspect = height / width
-      const minWidth = type === 'video' ? VIDEO_NODE_DEFAULT_SIZE.width : IMAGE_NODE_DEFAULT_SIZE.width
-      const maxWidth = type === 'video' ? 680 : 640
-      let nodeWidth = Math.min(Math.max(width, minWidth), maxWidth)
+      let nodeWidth = Math.min(Math.max(width, IMAGE_NODE_DEFAULT_SIZE.width), 580)
       let bodyHeight = Math.round(nodeWidth * aspect)
-      const maxBodyHeight = type === 'video' ? 480 : 720
-      if (bodyHeight > maxBodyHeight) {
-        bodyHeight = maxBodyHeight
-        nodeWidth = Math.max(minWidth, Math.round(bodyHeight / aspect))
+      if (bodyHeight > 720) {
+        bodyHeight = 720
+        nodeWidth = Math.max(300, Math.round(bodyHeight / aspect))
+      }
+      return {
+        width: Math.round(nodeWidth),
+        height: Math.max(IMAGE_NODE_DEFAULT_SIZE.height, bodyHeight + headerHeight),
+      }
+    }
+    return IMAGE_NODE_DEFAULT_SIZE
+  }
+  if (type === 'video') {
+    const headerHeight = 36
+    if (width && height) {
+      const aspect = height / width
+      let nodeWidth = Math.min(Math.max(width, VIDEO_NODE_DEFAULT_SIZE.width), 680)
+      let bodyHeight = Math.round(nodeWidth * aspect)
+      if (bodyHeight > 480) {
+        bodyHeight = 480
+        nodeWidth = Math.max(VIDEO_NODE_DEFAULT_SIZE.width, Math.round(bodyHeight / aspect))
       }
       return {
         width: Math.round(nodeWidth),
         height: Math.max(220, bodyHeight + headerHeight),
       }
     }
-    return type === 'video' ? VIDEO_NODE_DEFAULT_SIZE : IMAGE_NODE_DEFAULT_SIZE
+    return VIDEO_NODE_DEFAULT_SIZE
   }
   if (type === 'audio') return AUDIO_NODE_DEFAULT_SIZE
   return TEXT_NODE_DEFAULT_SIZE

--- a/apps/desktop/src/renderer/design/views/canvas/canvasAssetInsert.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasAssetInsert.test.ts
@@ -163,4 +163,26 @@ describe('canvas asset insertion', () => {
     expect(node?.type).toBe('prompt')
     expect(node?.data.text).toBe(prompt)
   })
+
+  it('fits portrait image assets without forcing the old oversized width', async () => {
+    const asset = await canvasApi.createImageAsset({
+      projectId: 'project-1',
+      file: new File([new Uint8Array([1, 2, 3])], 'portrait.png', { type: 'image/png' }),
+      filePath: '/tmp/project-1/portrait.png',
+      imageWidth: 800,
+      imageHeight: 1200,
+    })
+
+    const node = await canvasApi.insertAssetToBoard({
+      projectId: 'project-1',
+      boardId: 'board-1',
+      assetId: asset.id,
+      x: 24,
+      y: 48,
+    })
+
+    expect(node?.type).toBe('image')
+    expect(node?.width).toBe(480)
+    expect(node?.height).toBe(756)
+  })
 })


### PR DESCRIPTION
画布媒体节点：
- canvas.api.ts: 拆分 fitMediaNodeSize 为 image / video 两条分支。 image 节点宽度上限收到 580、body 高度 720，超出按 720 反算宽度； video 上限 680/480；统一加 36px header 进总高，避免外框远大于内容 导致底部大片空白。
- CanvasWorkspaceView.tsx: 新增 pickInlineEditorDefaultExtraHeight， 按节点类型（text/prompt、task、image/video/audio、group）给 inline 面板 不同的默认额外高度；pickInlineEditorMinWidth 同步按类型分支收窄。
- CanvasWorkspaceView.less: .canvas-node-body 不再统一 max-height:500， overflow 改 hidden，滚动交给 .canvas-node-text / .canvas-node-task-msg 内部处理；修整几处 padding 不对称。
- CanvasNode.tsx: 注释同步 nowheel 与滚动归属。
- CanvasOperationPresetModal.tsx: 删除只读的"最终生效提示词预览"输入框。
- canvasAssetInsert.test.ts: 新增 portrait 800x1200 图片插入回归用例。

Skill store 卡片：
- SkillStoreView.tsx: 把"下载中"进度条从 tag 区域移出，"查看来源"链接 移入统一的 .skill-store-card-actions，与右侧开关/安装按钮左右排开。
- SkillStoreView.less: .skill-store-card-actions 改为 width:100%
  + justify-content:space-between；tag 行加 flex-grow:1；桌面布局 min-height 208 → 190 让卡片更紧凑。