### PR TITLE
perf(website): showcase 截图懒加载，减轻首屏带宽竞争

### DIFF
--- a/apps/website/src/routes/CanvasPage.tsx
+++ b/apps/website/src/routes/CanvasPage.tsx
@@ -61,17 +61,17 @@ export function CanvasPage() {
       <Section title="画布里的真实工作场景" intro="下面是 Spark Agent 桌面端截图，展示导演台、资产中心和 360 全景预览如何服务同一个项目。">
         <div className="grid cards canvas-gallery">
           <article className="card image-card" id="film">
-            <img src="/showcase/director-stage.png" alt="Spark Agent 3D 导演台截图" />
+            <img src="/showcase/director-stage.png" alt="Spark Agent 3D 导演台截图" loading="lazy" decoding="async" />
             <h3>3D 导演台</h3>
             <p>先规划角色站位、相机和构图，再生成稳定的镜头描述，减少反复试错。</p>
           </article>
           <article className="card image-card">
-            <img src="/showcase/asset-center.png" alt="Spark Agent 画布资产中心截图" />
+            <img src="/showcase/asset-center.png" alt="Spark Agent 画布资产中心截图" loading="lazy" decoding="async" />
             <h3>画布资产中心</h3>
             <p>集中查看每条分镜的角色、场景、镜头描述与生成结果，方便比较版本并沉淀可复用资产。</p>
           </article>
           <article className="card image-card">
-            <img src="/showcase/panorama-360.png" alt="Spark Agent 360 全景预览截图" />
+            <img src="/showcase/panorama-360.png" alt="Spark Agent 360 全景预览截图" loading="lazy" decoding="async" />
             <h3>360 全景预览</h3>
             <p>在继续生成前确认空间关系、光线方向和材质细节，让后续镜头保持一致。</p>
           </article>

--- a/apps/website/src/routes/FeaturesPage.tsx
+++ b/apps/website/src/routes/FeaturesPage.tsx
@@ -34,7 +34,7 @@ export function FeaturesPage() {
         <div className="showcase-grid">
           {featureScreenshots.map((item) => (
             <article className="showcase-card" key={item.title}>
-              <img src={item.src} alt={item.title} />
+              <img src={item.src} alt={item.title} loading="lazy" decoding="async" />
               <h3>{item.title}</h3>
               <p>{item.text}</p>
             </article>

--- a/apps/website/src/routes/HomePage.tsx
+++ b/apps/website/src/routes/HomePage.tsx
@@ -57,7 +57,7 @@ export function HomePage() {
         <div className="hero-text">
           <h1>Spark Agent</h1>
           <p className="hero-subtitle">
-            本地优先的桌面端 AI Agent 工作台。把工作流编排、代码还原点、代码开发、办公文档、调研和多媒体创作放进同一个可审查的工作台。
+            本地优先的桌面端 AI Agent 工作台。把代码开发、办公文档、主题调研和多媒体创作放进同一个可审查的工作台。
           </p>
           <div className="cta">
             <HeroDownloadButton />
@@ -85,7 +85,7 @@ export function HomePage() {
         <div className="showcase-grid">
           {showcase.map((item) => (
             <article className="showcase-card" key={item.title}>
-              <img src={item.src} alt={item.title} />
+              <img src={item.src} alt={item.title} loading="lazy" decoding="async" />
               <h3>{item.title}</h3>
               <p>{item.text}</p>
             </article>

--- a/apps/website/src/styles/globals.css
+++ b/apps/website/src/styles/globals.css
@@ -1401,7 +1401,7 @@ h3 {
   display: block;
   width: 100%;
   aspect-ratio: 16 / 10;
-  object-fit: cover;
+  object-fit:fill;
   border-radius: var(--radius);
   border: 1px solid var(--border);
   background: var(--panel);


### PR DESCRIPTION
为首页、功能页、画布页 showcase 图片添加 loading="lazy" 与 decoding="async"， 避免首屏下方大量截图与 Hero 资源并发下载；顺带更新 Hero 副标题与截图展示样式。