### PR TITLE
fix: left-align shortcut action labels

### DIFF
--- a/apps/desktop/src/renderer/design/styles/interactions.css
+++ b/apps/desktop/src/renderer/design/styles/interactions.css
@@ -1428,6 +1428,10 @@
   display: flex;
   align-items: center;
 }
+.keymap .km-action {
+  align-items: flex-start;
+  flex-direction: column;
+}
 .keymap .km-row:last-child .km-action,
 .keymap .km-row:last-child .km-keys {
   border-bottom: none;


### PR DESCRIPTION
### Motivation
- Restore expected left alignment for the shortcut list action titles/descriptions which were being vertically centered by a later-loaded stylesheet.

### Description
- Add `.keymap .km-action { align-items: flex-start; flex-direction: column; }` to `apps/desktop/src/renderer/design/styles/interactions.css` so the action title/description stack left-aligned while the key column remains right-aligned.

### Testing
- Ran `git diff --check` which passed.
- Ran `pnpm --filter @spark/desktop typecheck` which failed due to unrelated existing TypeScript nullability errors in `CanvasWorkspaceView.tsx` and not caused by this CSS change.
- Attempted `npx gitnexus impact` and `npx gitnexus detect_changes` as required by repository policy but the CLI in this environment exited without returning usable analysis output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4477a853f48323a94017349c13b81a)