### PR TITLE
Canvas: Add Shortcut Help modal and keyboard zoom/pan controls

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasBottomDock.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasBottomDock.tsx
@@ -30,6 +30,7 @@ export function CanvasBottomDock({
   onFitView,
   onCenterSelected,
   onToggleGrid,
+  onOpenShortcutHelp,
   gridVisible,
   selectedCount,
   canUndo,
@@ -48,6 +49,7 @@ export function CanvasBottomDock({
   onFitView: () => void
   onCenterSelected: () => void
   onToggleGrid: () => void
+  onOpenShortcutHelp: () => void
   gridVisible: boolean
   selectedCount: number
   canUndo: boolean
@@ -228,6 +230,15 @@ export function CanvasBottomDock({
               aria-label="重做"
               disabled={!canRedo}
               onClick={() => closeAddMenuAndRun(onRedo)}
+            />
+          </Tooltip>
+          <Tooltip title="画布帮助 / 快捷键" placement="top">
+            <Button
+              size="small"
+              type="text"
+              icon={<Icons.HelpCircle size={15} />}
+              aria-label="画布帮助 / 快捷键"
+              onClick={() => closeAddMenuAndRun(onOpenShortcutHelp)}
             />
           </Tooltip>
         </div>

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasStage.tsx
@@ -76,6 +76,8 @@ export type CanvasStageViewport = Viewport & {
 
 export type CanvasStageViewportControls = {
   fitView: () => void
+  zoomBy: (delta: number) => void
+  panBy: (delta: { x: number; y: number }) => void
   centerNodes: (nodeIds: string[]) => boolean
   focusNodes: (
     nodeIds: string[],
@@ -404,6 +406,23 @@ export function CanvasStage({
       fitView: () => {
         void flowInstanceRef.current?.fitView({ padding: 0.2, minZoom: 0.55, maxZoom: 1.15, duration: 260 })
       },
+      zoomBy: (delta: number) => {
+        const instance = flowInstanceRef.current
+        if (!instance) return
+        const current = latestViewportRef.current
+        const nextZoom = Math.max(0.2, Math.min(2, current.zoom + delta))
+        const nextViewport = { ...current, zoom: nextZoom }
+        void instance.setViewport(nextViewport, { duration: 180 })
+        notifyViewportChange(nextViewport)
+      },
+      panBy: (delta: { x: number; y: number }) => {
+        const instance = flowInstanceRef.current
+        if (!instance) return
+        const current = latestViewportRef.current
+        const nextViewport = { ...current, x: current.x + delta.x, y: current.y + delta.y }
+        void instance.setViewport(nextViewport, { duration: 160 })
+        notifyViewportChange(nextViewport)
+      },
       centerNodes: (nodeIds: string[]) => {
         const bounds = resolveNodeBounds(nodeIds)
         if (!bounds) return false
@@ -448,7 +467,7 @@ export function CanvasStage({
       },
     })
     return () => onViewportControlsChange(null)
-  }, [onViewportControlsChange])
+  }, [notifyViewportChange, onViewportControlsChange])
 
   const cancelScheduledSync = useCallback(() => {
     if (syncFrameRef.current == null) return

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -10329,41 +10329,170 @@ body.canvas-agent-panel-resizing {
   }
 }
 
+.canvas-shortcut-help-wrap {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 0 18px 76px;
+}
+
+.canvas-shortcut-help-modal {
+  top: auto;
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.canvas-shortcut-help-modal .ant-modal-content {
+  position: relative;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 72%, transparent);
+  border-radius: 22px;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(34, 211, 238, 0.08), transparent 35%),
+    color-mix(in srgb, #111 88%, var(--surface-2));
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.46);
+}
+
+.canvas-shortcut-help-modal .ant-modal-close {
+  display: none;
+}
+
 .canvas-shortcut-help {
+  position: relative;
+  padding: 28px 30px 30px;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.canvas-shortcut-help-close {
+  position: absolute;
+  top: 18px;
+  right: 18px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 0;
+  border-radius: 999px;
+  color: rgba(255, 255, 255, 0.82);
+  background: transparent;
+  cursor: pointer;
+}
+
+.canvas-shortcut-help-close:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.canvas-shortcut-help-grid {
   display: grid;
-  gap: 10px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  min-height: 360px;
+}
+
+.canvas-shortcut-help-column {
+  min-width: 0;
+  padding: 0 22px;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.canvas-shortcut-help-column:first-child {
+  padding-left: 0;
+}
+
+.canvas-shortcut-help-column:last-child {
+  padding-right: 26px;
+  border-right: 0;
+}
+
+.canvas-shortcut-help-column h3 {
+  margin: 0 0 20px;
+  color: var(--canvas-accent-cyan, #22d3ee);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.canvas-shortcut-help-list {
+  display: grid;
+  gap: 14px;
 }
 
 .canvas-shortcut-help-row {
   display: grid;
-  grid-template-columns: 132px 1fr;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  background: color-mix(in srgb, var(--surface-2) 78%, transparent);
+  gap: 14px;
+  min-height: 34px;
+}
+
+.canvas-shortcut-help-row > span:first-child {
+  min-width: 0;
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.canvas-shortcut-help-keys {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  max-width: 150px;
 }
 
 .canvas-shortcut-help-row kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 26px;
-  padding: 3px 8px;
-  border: 1px solid color-mix(in srgb, var(--border) 72%, var(--text-muted));
-  border-radius: 7px;
-  color: var(--text-strong);
-  background: color-mix(in srgb, var(--surface-1) 86%, white);
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--border) 75%, transparent);
+  min-width: 34px;
+  min-height: 30px;
+  padding: 3px 9px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 9px;
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.045);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.03),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.08);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 12px;
-  font-weight: 700;
+  font-size: 13px;
+  font-weight: 650;
+  white-space: nowrap;
 }
 
-.canvas-shortcut-help-row span {
-  color: var(--text-muted);
-  font-size: 13px;
+@media (max-width: 980px) {
+  .canvas-shortcut-help-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    row-gap: 26px;
+  }
+
+  .canvas-shortcut-help-column:nth-child(2) {
+    border-right: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .canvas-shortcut-help-wrap {
+    padding: 0 10px 64px;
+  }
+
+  .canvas-shortcut-help {
+    padding: 24px 18px;
+  }
+
+  .canvas-shortcut-help-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .canvas-shortcut-help-column,
+  .canvas-shortcut-help-column:first-child,
+  .canvas-shortcut-help-column:last-child {
+    padding: 0;
+    border-right: 0;
+  }
 }
 
 .canvas-operation-preset-dialog .ant-modal-content {

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -1380,6 +1380,62 @@ function toolLabel(tool: CanvasTool): string {
   return tool === 'pan' ? '平移画布' : '选择节点'
 }
 
+
+const CANVAS_SHORTCUT_HELP_GROUPS: Array<{
+  title: string
+  items: Array<{ keys: string[]; desc: string }>
+}> = [
+  {
+    title: '创作 / 节点',
+    items: [
+      { keys: ['Tab'], desc: '在选择 / 平移工具之间切换' },
+      { keys: ['双击节点'], desc: '展开节点编辑面板' },
+      { keys: ['Esc'], desc: '关闭当前浮层 / 弹窗 / 编辑面板' },
+      { keys: ['Delete', 'Backspace'], desc: '删除选中节点或连线' },
+      { keys: ['Ctrl / Cmd', '点击'], desc: '追加选择节点' },
+      { keys: ['Shift', '点击'], desc: '追加选择节点' },
+      { keys: ['框选'], desc: '批量选择节点' },
+    ],
+  },
+  {
+    title: '视图 / 缩放',
+    items: [
+      { keys: ['滚轮'], desc: '缩放画布' },
+      { keys: ['Ctrl / Cmd', '+'], desc: '放大画布' },
+      { keys: ['Ctrl / Cmd', '-'], desc: '缩小画布' },
+      { keys: ['Ctrl / Cmd', '0'], desc: '适配全部节点' },
+      { keys: ['底部工具栏', '适配'], desc: '一键查看完整画布' },
+      { keys: ['底部工具栏', '网格'], desc: '显示 / 隐藏画布网格' },
+    ],
+  },
+  {
+    title: '移动画布',
+    items: [
+      { keys: ['Space', '拖拽'], desc: '临时抓手平移画布' },
+      { keys: ['平移工具', '拖拽'], desc: '移动视图' },
+      { keys: ['方向键 ↑'], desc: '向上平移画布' },
+      { keys: ['方向键 ↓'], desc: '向下平移画布' },
+      { keys: ['方向键 ←'], desc: '向左平移画布' },
+      { keys: ['方向键 →'], desc: '向右平移画布' },
+      { keys: ['底部工具栏', '回到选中'], desc: '把视图移动到选中节点' },
+    ],
+  },
+  {
+    title: '其他 / 工具栏入口',
+    items: [
+      { keys: ['Ctrl / Cmd', 'S'], desc: '保存画布' },
+      { keys: ['Ctrl / Cmd', 'Z'], desc: '撤销' },
+      { keys: ['Ctrl / Cmd', 'Shift', 'Z'], desc: '重做' },
+      { keys: ['Ctrl / Cmd', '\\'], desc: '展开 / 折叠右侧面板' },
+      { keys: ['Ctrl / Cmd', 'R'], desc: '刷新当前画布数据' },
+      { keys: ['Ctrl / Cmd', 'Shift', 'S'], desc: '开启 / 关闭自动保存' },
+      { keys: ['底部工具栏', '任务节点'], desc: '打开任务节点类型列表' },
+      { keys: ['底部工具栏', '资源节点'], desc: '打开资源内容节点列表' },
+      { keys: ['底部工具栏', '资产中心'], desc: '打开项目资产中心' },
+    ],
+  },
+]
+
 export function CanvasWorkspaceView({
   projectId,
   onBack,
@@ -3101,6 +3157,106 @@ export function CanvasWorkspaceView({
       })
       .catch(() => {})
   }, [snapshot, projectId, refresh])
+
+  // 画布快捷键：只绑定到已有画布动作，避免在输入框、弹窗或抽屉中误触。
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableKeyboardTarget(event.target)) return
+      if (leaveOpen || saveToLibraryNodeId != null || annotatingImageNodeId != null) return
+      if (
+        agentOpen ||
+        filmCenterOpen ||
+        inlineAiOpen ||
+        historyOpen ||
+        templateOpen ||
+        shortcutHelpOpen
+      ) {
+        return
+      }
+
+      const mod = event.metaKey || event.ctrlKey
+      const key = event.key.toLowerCase()
+      const stop = () => {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+
+      if (mod && !event.altKey && key === 'z') {
+        stop()
+        if (event.shiftKey) {
+          void handleRedoCanvasChange()
+        } else {
+          void handleUndoCanvasChange()
+        }
+        return
+      }
+
+      if (mod && !event.altKey && !event.shiftKey && key === 'r') {
+        stop()
+        void refresh()
+        return
+      }
+
+      if (mod && event.shiftKey && !event.altKey && key === 's') {
+        stop()
+        handleAutoSaveToggle(!autoSaveEnabledRef.current)
+        return
+      }
+
+      if (mod && !event.altKey && !event.shiftKey && (event.key === '+' || event.key === '=')) {
+        stop()
+        canvasViewportControlsRef.current?.zoomBy(0.12)
+        return
+      }
+
+      if (mod && !event.altKey && !event.shiftKey && event.key === '-') {
+        stop()
+        canvasViewportControlsRef.current?.zoomBy(-0.12)
+        return
+      }
+
+      if (mod && !event.altKey && !event.shiftKey && event.key === '0') {
+        stop()
+        handleFitCanvasView()
+        return
+      }
+
+      if (!mod && !event.altKey && !event.shiftKey) {
+        const step = 80
+        if (event.key === 'ArrowUp') {
+          stop()
+          canvasViewportControlsRef.current?.panBy({ x: 0, y: step })
+        } else if (event.key === 'ArrowDown') {
+          stop()
+          canvasViewportControlsRef.current?.panBy({ x: 0, y: -step })
+        } else if (event.key === 'ArrowLeft') {
+          stop()
+          canvasViewportControlsRef.current?.panBy({ x: step, y: 0 })
+        } else if (event.key === 'ArrowRight') {
+          stop()
+          canvasViewportControlsRef.current?.panBy({ x: -step, y: 0 })
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [
+    agentOpen,
+    annotatingImageNodeId,
+    filmCenterOpen,
+    handleAutoSaveToggle,
+    handleFitCanvasView,
+    handleRedoCanvasChange,
+    handleUndoCanvasChange,
+    historyOpen,
+    inlineAiOpen,
+    leaveOpen,
+    refresh,
+    saveToLibraryNodeId,
+    shortcutHelpOpen,
+    templateOpen,
+  ])
 
   // 全局 ESC：按优先级关闭最上层弹窗（避免多个弹窗同时收到事件）。
   // 顺序对应"视觉层级"：确认对话框 > 二级模态 > 主弹窗 > 侧栏抽屉。
@@ -5152,6 +5308,7 @@ export function CanvasWorkspaceView({
             onUndo={() => void handleUndoCanvasChange()}
             onRedo={() => void handleRedoCanvasChange()}
             onToggleGrid={handleToggleGrid}
+            onOpenShortcutHelp={() => setShortcutHelpOpen(true)}
             onFitView={handleFitCanvasView}
             onCenterSelected={handleCenterSelectedNode}
             gridVisible={snapshot.board.settings.grid === true}
@@ -5385,14 +5542,6 @@ export function CanvasWorkspaceView({
                 <Icons.Layers size={16} />
                 <span>模板</span>
               </button>
-              <button
-                type="button"
-                className="canvas-side-utility-btn"
-                onClick={() => setShortcutHelpOpen(true)}
-              >
-                <Icons.HelpCircle size={16} />
-                <span>帮助</span>
-              </button>
             </div>
             {sidePanelTab === 'production' && (
               <CanvasProductionPanel
@@ -5538,26 +5687,42 @@ export function CanvasWorkspaceView({
       />
       <Modal
         open={shortcutHelpOpen}
-        title="画布快捷键"
+        title={null}
         footer={null}
-        width={520}
+        width="min(96vw, 1120px)"
+        centered={false}
+        className="canvas-shortcut-help-modal"
+        wrapClassName="canvas-shortcut-help-wrap"
         onCancel={() => setShortcutHelpOpen(false)}
       >
         <div className="canvas-shortcut-help">
-          {[
-            ['Tab', '在选择 / 平移工具之间切换'],
-            ['Esc', '关闭当前浮层或弹窗'],
-            ['Ctrl / Cmd + \\', '展开 / 折叠右侧面板'],
-            ['拖拽空白画布', '使用平移工具移动视图'],
-            ['框选', '使用选择工具批量选择节点'],
-            ['Ctrl / Cmd + 点击', '追加选择节点'],
-            ['Shift + 点击', '追加选择节点'],
-          ].map(([key, desc]) => (
-            <div key={key} className="canvas-shortcut-help-row">
-              <kbd>{key}</kbd>
-              <span>{desc}</span>
-            </div>
-          ))}
+          <button
+            type="button"
+            className="canvas-shortcut-help-close"
+            aria-label="关闭画布快捷键帮助"
+            onClick={() => setShortcutHelpOpen(false)}
+          >
+            <Icons.X size={26} />
+          </button>
+          <div className="canvas-shortcut-help-grid">
+            {CANVAS_SHORTCUT_HELP_GROUPS.map((group) => (
+              <section key={group.title} className="canvas-shortcut-help-column">
+                <h3>{group.title}</h3>
+                <div className="canvas-shortcut-help-list">
+                  {group.items.map((item) => (
+                    <div key={`${group.title}:${item.desc}`} className="canvas-shortcut-help-row">
+                      <span>{item.desc}</span>
+                      <span className="canvas-shortcut-help-keys">
+                        {item.keys.map((key) => (
+                          <kbd key={key}>{key}</kbd>
+                        ))}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
         </div>
       </Modal>
       <input


### PR DESCRIPTION
### Motivation
- Provide an in-app reference for canvas shortcuts and expose common viewport actions to keyboard users. 
- Enable programmatic zooming and panning so keyboard shortcuts can manipulate the canvas viewport smoothly.

### Description
- Added a bottom-dock help button and new `onOpenShortcutHelp` prop to `CanvasBottomDock` to open the shortcut help modal. 
- Implemented a responsive shortcut help modal UI and styles (`CanvasWorkspaceView.tsx` and `.less`) driven by `CANVAS_SHORTCUT_HELP_GROUPS`. 
- Added keyboard shortcut handling in `CanvasWorkspaceView` to support undo/redo, refresh, autosave toggle, zoom in/out, fit view, and arrow-key panning, and wired it to `canvasViewportControlsRef.current` calls. 
- Extended `CanvasStage` viewport controls with `zoomBy` and `panBy` implementations and adjusted dependency usage (`notifyViewportChange`) to support programmatic viewport updates.

### Testing
- Ran TypeScript build via `yarn build` to ensure type correctness and compilation, which succeeded. 
- Executed the existing unit test suite via `yarn test`, and all tests passed. 
- Ran linter via `yarn lint` with no new lint errors detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a447b3105588323b373250742d9a1bc)