### PR TITLE
feat: copy-all, message multi-select, Agents loading state, and notification fixes

### DIFF
--- a/apps/desktop/src/renderer/design/views/AgentsView.less
+++ b/apps/desktop/src/renderer/design/views/AgentsView.less
@@ -785,3 +785,29 @@
     padding-top: 12px;
   }
 }
+
+
+.agents-loading-state {
+  display: flex;
+  min-height: 260px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--text-muted);
+}
+
+.agents-loading-state svg {
+  animation: spin 1s linear infinite;
+  color: var(--primary);
+}
+
+.agents-loading-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.agents-loading-desc {
+  font-size: 12px;
+}

--- a/apps/desktop/src/renderer/design/views/AgentsView.tsx
+++ b/apps/desktop/src/renderer/design/views/AgentsView.tsx
@@ -965,7 +965,13 @@ function AgentsTabContent({
             </div>
           </div>
 
-          {visibleAgents.length > 0 ? (
+          {loading && visibleAgents.length === 0 ? (
+            <div className="agents-loading-state" role="status" aria-live="polite">
+              <Icons.Spinner size={24} />
+              <div className="agents-loading-title">正在加载 Agent…</div>
+              <div className="agents-loading-desc">同步模型、工具、技能和工作流配置</div>
+            </div>
+          ) : visibleAgents.length > 0 ? (
             <>
               {selectionMode && selectedIds.size > 0 && (
                 <div className="agents-selectbar" role="region" aria-label="批量操作">

--- a/apps/desktop/src/renderer/design/views/ChatView.less
+++ b/apps/desktop/src/renderer/design/views/ChatView.less
@@ -4175,3 +4175,69 @@ body.side-chat-resizing {
   background: var(--accent);
   box-shadow: 0 0 0 2px var(--panel);
 }
+
+
+.chat-message-selectbar {
+  position: sticky;
+  top: 8px;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  margin: 0 auto 12px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--panel-elev);
+  box-shadow: var(--shadow-md);
+  font-size: var(--font-sm);
+}
+
+.chat-message-selectbar button {
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.chat-message-selectbar button:hover:not(:disabled) {
+  background: var(--hover);
+}
+
+.chat-message-selectbar button.danger {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+}
+
+.chat-message-selectbar button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.msg.is-selected .msg-bubble {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+.msg-select-check {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin: 0 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel-elev);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+}
+
+.msg-select-check input {
+  accent-color: var(--primary);
+}

--- a/apps/desktop/src/renderer/design/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/design/views/ChatView.tsx
@@ -22,6 +22,7 @@ import { Button, Dropdown, Popover, Tag as LobeTag, Tooltip } from '@lobehub/ui'
 import type { LucideIcon } from 'lucide-react'
 import {
   CheckCircle,
+  Copy,
   FilePenLine,
   FileSearch,
   FolderOpen,
@@ -151,7 +152,11 @@ import {
   hasFileDataTransfer,
 } from '../services/composer-attachments'
 import { shouldShowScrollToBottom } from './chat-scroll'
-import { getLastAssistantMessageMarkdown, isLocalCopySlashCommand } from './chat-copy'
+import {
+  getLastAssistantMessageMarkdown,
+  isLocalCopySlashCommand,
+  serializeMessagesToMarkdown,
+} from './chat-copy'
 import { hasVisibleTeamMemberActivityBlocks } from './chat-team-visibility'
 import { getLatestAgentStatus, isRunningAgentStatus } from './chat-session-status'
 import {
@@ -956,6 +961,33 @@ export function ChatView({
   const [scrollToBottomTrigger, setScrollToBottomTrigger] = useState(0)
   const [replyTo, setReplyTo] = useState<ReplyToState | null>(null)
   const { toast } = useToast()
+
+  useEffect(() => {
+    return (
+      window.spark?.on?.('stream:system-notification:navigate', (target) => {
+        if (target.target === 'session') {
+          sessionCtx.setActiveSession(target.sessionId as SessionId)
+          setTweak('view', 'chat')
+          return
+        }
+        if (target.target === 'view') {
+          setTweak('view', target.view as never)
+        }
+      }) ?? (() => {})
+    )
+  }, [sessionCtx, setTweak])
+
+  const handleCopyAllMessages = useCallback(() => {
+    const markdown = serializeMessagesToMarkdown(activeMessages)
+    if (!markdown) {
+      toast.info('当前会话暂无可复制的聊天记录')
+      return
+    }
+    navigator.clipboard
+      .writeText(markdown)
+      .then(() => toast.success('已复制全部聊天记录'))
+      .catch((err) => toast.error(err instanceof Error ? err.message : '复制失败'))
+  }, [activeMessages, toast])
 
   // ── 文件预览状态 ──
   const [filePreview, setFilePreview] = useState<{
@@ -3542,6 +3574,7 @@ function ChatTabbar({
   effectiveHostAgentId,
   agents,
   onClearMessages,
+  onCopyAllMessages,
   onExpandSidebar,
 }: {
   session: SessionSummary | null
@@ -3572,6 +3605,7 @@ function ChatTabbar({
   effectiveHostAgentId: string | null
   agents: ManagedAgent[]
   onClearMessages?: () => void
+  onCopyAllMessages?: () => void
   onExpandSidebar?: () => void
 }) {
   const [showClearConfirm, setShowClearConfirm] = useState(false)
@@ -3681,6 +3715,11 @@ function ChatTabbar({
               清空
             </button>
           </div>
+        )}
+        {onCopyAllMessages && (
+          <TabbarTooltipButton title="复制全部聊天记录" className="icon-btn" onClick={onCopyAllMessages}>
+            <TabbarIcon icon={Copy} />
+          </TabbarTooltipButton>
         )}
         {!showClearConfirm && onClearMessages && (
           <TabbarTooltipButton title="清空会话消息" className="icon-btn" onClick={handleClearClick}>
@@ -4897,6 +4936,8 @@ function ChatStream({
   const [agentIsRunning, setAgentIsRunning] = useState(false)
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
   const [isLoadingHistory, setIsLoadingHistory] = useState(false)
+  const [multiSelectMode, setMultiSelectMode] = useState(false)
+  const [selectedMessageIds, setSelectedMessageIds] = useState<Set<string>>(() => new Set())
   // 窗口化加载：是否还有更早历史 + 是否正在加载更早一页（顶部 loading 指示）
   const [hasMoreHistory, setHasMoreHistory] = useState(false)
   const [isLoadingOlder, setIsLoadingOlder] = useState(false)
@@ -5557,6 +5598,53 @@ function ChatStream({
     return { id: assistantAgentId, name: assistantName, avatarSrc: assistantAvatarSrc }
   }, [messages, agents, assistantAgentId, assistantName, assistantAvatarSrc])
 
+  const selectedMessages = useMemo(
+    () => messages.filter((msg) => selectedMessageIds.has(msg.id)),
+    [messages, selectedMessageIds],
+  )
+
+  const toggleMessageSelected = useCallback((messageId: string) => {
+    setSelectedMessageIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(messageId)) next.delete(messageId)
+      else next.add(messageId)
+      return next
+    })
+  }, [])
+
+  const enterMultiSelectMode = useCallback((messageId?: string) => {
+    setMultiSelectMode(true)
+    if (messageId != null) setSelectedMessageIds(new Set([messageId]))
+  }, [])
+
+  const exitMultiSelectMode = useCallback(() => {
+    setMultiSelectMode(false)
+    setSelectedMessageIds(new Set())
+  }, [])
+
+  const copySelectedMessages = useCallback(() => {
+    const markdown = serializeMessagesToMarkdown(selectedMessages)
+    if (!markdown) return
+    void navigator.clipboard.writeText(markdown)
+  }, [selectedMessages])
+
+  const deleteSelectedMessages = useCallback(() => {
+    const eventIds = selectedMessages.flatMap((msg) => msg.eventIds)
+    if (eventIds.length === 0) return
+    deleteMessageEvents({ sessionId, eventIds })
+      .then(() => {
+        const selected = new Set(selectedMessages.map((msg) => msg.id))
+        const removed = new Set(eventIds)
+        for (const msg of selectedMessages) builderRef.current.removeMessage(msg.id)
+        loadedEventsRef.current = loadedEventsRef.current.filter((e) => !removed.has(e.id))
+        const nextMessages = builderRef.current.getAllMessages().filter((msg) => !selected.has(msg.id))
+        setMessages(nextMessages)
+        onMessagesChange(nextMessages)
+        exitMultiSelectMode()
+      })
+      .catch(console.error)
+  }, [deleteMessageEvents, exitMultiSelectMode, onMessagesChange, selectedMessages, sessionId])
+
   const handleDeleteMessage = useCallback(
     (msgId: string, eventIds: string[]) => {
       deleteMessageEvents({ sessionId, eventIds })
@@ -5635,6 +5723,14 @@ function ChatStream({
     <div className="chat-stream-viewport">
       <div className="chat-stream" ref={streamRef}>
         <div className="chat-stream-inner">
+          {multiSelectMode && (
+            <div className="chat-message-selectbar">
+              <span>已选 {selectedMessageIds.size} 条</span>
+              <button type="button" onClick={copySelectedMessages} disabled={selectedMessageIds.size === 0}>复制</button>
+              <button type="button" className="danger" onClick={deleteSelectedMessages} disabled={selectedMessageIds.size === 0}>删除</button>
+              <button type="button" onClick={exitMultiSelectMode}>完成</button>
+            </div>
+          )}
           {isLoadingOlder && (
             <div className="chat-load-older" aria-hidden="true">
               <span className="chat-loading-spinner" />
@@ -5655,6 +5751,10 @@ function ChatStream({
                     }
                   : {})}
                 onDelete={() => handleDeleteMessage(msg.id, msg.eventIds)}
+                selectionMode={multiSelectMode}
+                selected={selectedMessageIds.has(msg.id)}
+                onToggleSelected={() => toggleMessageSelected(msg.id)}
+                onStartMultiSelect={() => enterMultiSelectMode(msg.id)}
                 {...(onReplyTo != null
                   ? {
                       onReply: (selectedText?: string) =>
@@ -5697,7 +5797,13 @@ function ChatStream({
                     {...(msg.status === 'streaming' ? { status: 'running' as const } : {})}
                     {...(msg.timestamp != null ? { timestamp: msg.timestamp } : {})}
                     {...(msg.status !== 'streaming'
-                      ? { onDelete: () => handleDeleteMessage(msg.id, msg.eventIds) }
+                      ? {
+                          onDelete: () => handleDeleteMessage(msg.id, msg.eventIds),
+                          selectionMode: multiSelectMode,
+                          selected: selectedMessageIds.has(msg.id),
+                          onToggleSelected: () => toggleMessageSelected(msg.id),
+                          onStartMultiSelect: () => enterMultiSelectMode(msg.id),
+                        }
                       : {})}
                     {...(onReplyTo != null && msg.status !== 'streaming'
                       ? {
@@ -8294,6 +8400,10 @@ const UserMsg = React.memo(
     mentionAgentName,
     onReply,
     onResend,
+    selectionMode = false,
+    selected = false,
+    onToggleSelected,
+    onStartMultiSelect,
   }: {
     children: ReactNode
     timestamp?: string | undefined
@@ -8306,6 +8416,10 @@ const UserMsg = React.memo(
     onReply?: (selectedText?: string) => void
     /** 重发：把这条消息的文本+附件重新塞回输入区 */
     onResend?: () => void
+    selectionMode?: boolean
+    selected?: boolean
+    onToggleSelected?: () => void
+    onStartMultiSelect?: () => void
   }) {
     const textContent = extractTextFromBlocks(blocks)
     const [contextMenu, setContextMenu] = useState<{
@@ -8367,6 +8481,14 @@ const UserMsg = React.memo(
           onClick: () => onReply(),
         })
       }
+      if (onStartMultiSelect != null) {
+        items.push({
+          key: 'multi-select',
+          label: '多选',
+          icon: <Icons.CheckSquare size={14} />,
+          onClick: onStartMultiSelect,
+        })
+      }
       if (onDelete != null) {
         items.push({
           key: 'delete',
@@ -8377,10 +8499,15 @@ const UserMsg = React.memo(
         })
       }
       return items
-    }, [contextMenu, onDelete, onReply, textContent])
+    }, [contextMenu, onDelete, onReply, onStartMultiSelect, textContent])
 
     return (
-      <div className="msg msg-user">
+      <div className={`msg msg-user${selected ? ' is-selected' : ''}`}>
+        {selectionMode && (
+          <label className="msg-select-check">
+            <input type="checkbox" checked={selected} onChange={onToggleSelected} />
+          </label>
+        )}
         {attachments.length > 0 && <UserMessageAttachments attachments={attachments} />}
         <div className="msg-user-line">
           <div className="msg-bubble msg-bubble-user" onContextMenu={handleContextMenu}>
@@ -8714,6 +8841,10 @@ const AssistantMessageRows = React.memo(function AssistantMessageRows({
   messageId,
   onReplyToMember,
   onDeleteMemberMessage,
+  selectionMode,
+  selected,
+  onToggleSelected,
+  onStartMultiSelect,
 }: {
   sessionId: SessionId
   status?: 'running'
@@ -8736,6 +8867,10 @@ const AssistantMessageRows = React.memo(function AssistantMessageRows({
     selectedText?: string
   }) => void
   onDeleteMemberMessage?: (msgId: string, eventIds: string[]) => void
+  selectionMode?: boolean
+  selected?: boolean
+  onToggleSelected?: () => void
+  onStartMultiSelect?: () => void
 }) {
   const segments = splitAssistantMessageBlocks(blocks)
   if (segments.length === 0) return null
@@ -8819,6 +8954,10 @@ const AssistantMessageRows = React.memo(function AssistantMessageRows({
             {...(timestamp != null ? { timestamp } : {})}
             {...(onDelete != null ? { onDelete } : {})}
             {...(onReply != null ? { onReply } : {})}
+            {...(selectionMode !== undefined ? { selectionMode } : {})}
+            {...(selected !== undefined ? { selected } : {})}
+            {...(onToggleSelected != null ? { onToggleSelected } : {})}
+            {...(onStartMultiSelect != null ? { onStartMultiSelect } : {})}
           />
         )
       })}
@@ -8964,6 +9103,10 @@ const AgentMsg = React.memo(function AgentMsg({
   onDelete,
   onReply,
   onFilePreview,
+  selectionMode = false,
+  selected = false,
+  onToggleSelected,
+  onStartMultiSelect,
 }: {
   sessionId: SessionId
   status?: 'running'
@@ -8978,6 +9121,10 @@ const AgentMsg = React.memo(function AgentMsg({
   onDelete?: () => void
   onReply?: (selectedText?: string) => void
   onFilePreview?: (filePath: string, fileType: PreviewFileType) => void
+  selectionMode?: boolean
+  selected?: boolean
+  onToggleSelected?: () => void
+  onStartMultiSelect?: () => void
 }) {
   // 首个"内容块"出现前的连续思考 → 顶部思考模块；其后穿插的阶段性思考保留在内容流里
   // 就地渲染（表现为类似工具日志的「思考过程」模块），避免把一个 turn 内多段思考全部堆到开头。
@@ -9082,6 +9229,14 @@ const AgentMsg = React.memo(function AgentMsg({
         onClick: () => onReply(),
       })
     }
+    if (onStartMultiSelect != null) {
+      items.push({
+        key: 'multi-select',
+        label: '多选',
+        icon: <Icons.CheckSquare size={14} />,
+        onClick: onStartMultiSelect,
+      })
+    }
     if (onDelete != null) {
       items.push({
         key: 'delete',
@@ -9092,14 +9247,19 @@ const AgentMsg = React.memo(function AgentMsg({
       })
     }
     return items
-  }, [contextMenu, onDelete, onReply, textContent])
+  }, [contextMenu, onDelete, onReply, onStartMultiSelect, textContent])
 
   return (
     <div
-      className={`msg msg-agent ${isCancelled ? 'is-cancelled' : ''} ${isPureError ? 'is-error' : ''}`}
+      className={`msg msg-agent ${isCancelled ? 'is-cancelled' : ''} ${isPureError ? 'is-error' : ''}${selected ? ' is-selected' : ''}`}
       data-running-agent-id={assistantId}
       data-running={running === true ? 'true' : 'false'}
     >
+      {selectionMode && (
+        <label className="msg-select-check">
+          <input type="checkbox" checked={selected} onChange={onToggleSelected} />
+        </label>
+      )}
       <div className="msg-agent-avatar">
         <AvatarImage src={assistantAvatarSrc} seed={assistantId} name={assistantName} />
       </div>

--- a/apps/desktop/src/renderer/design/views/chat-copy.ts
+++ b/apps/desktop/src/renderer/design/views/chat-copy.ts
@@ -37,3 +37,23 @@ export function getLastAssistantMessageMarkdown(messages: UIMessage[]): string |
   const markdown = serializeAssistantMessageToMarkdown(message)
   return markdown.length > 0 ? markdown : null
 }
+
+
+function getMessageRoleLabel(role: UIMessage['role']): string {
+  return role === 'user' ? '用户' : '助手'
+}
+
+export function serializeMessageToMarkdown(message: UIMessage): string {
+  const body = serializeAssistantMessageToMarkdown(message)
+  if (body.length === 0) return ''
+  const time = message.timestamp != null ? ` · ${message.timestamp}` : ''
+  return `## ${getMessageRoleLabel(message.role)}${time}\n\n${body}`.trim()
+}
+
+export function serializeMessagesToMarkdown(messages: UIMessage[]): string {
+  return messages
+    .map(serializeMessageToMarkdown)
+    .filter((part) => part.length > 0)
+    .join('\n\n---\n\n')
+    .trim()
+}

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -5356,10 +5356,12 @@ export class SessionService {
           title: 'Spark Agent - 任务完成',
           body: '当前任务已完成',
         })
-      } else if (status === 'error') {
+      } else if (status === 'error' || status === 'cancelled') {
         this.onHookTrigger?.(sessionId, 'session_fail', {
-          title: 'Spark Agent - 任务失败',
-          body: event.message ?? '任务执行出错，请检查',
+          title: status === 'cancelled' ? 'Spark Agent - 任务已取消' : 'Spark Agent - 任务失败',
+          body:
+            event.message ??
+            (status === 'cancelled' ? '当前任务已取消' : '任务执行出错，请检查'),
         })
       } else if (status === 'waiting_user') {
         this.onHookTrigger?.(sessionId, 'ask_user_question', {


### PR DESCRIPTION
### Motivation
- Improve conversation export and in-stream bulk actions so users can quickly copy or remove multiple messages at once. 
- Provide a smoother Agents page UX by showing a loading transition while cards are being fetched. 
- Fix system notification routing and hook semantics so clicks navigate to the correct view/session and cancelled runs surface as cancellations/failures. 

### Description
- Add a Chat titlebar action `复制全部聊天记录` that serializes visible messages to Markdown via `serializeMessagesToMarkdown` and copies to clipboard, and register a `stream:system-notification:navigate` listener to route notification clicks to the intended session or view. 
- Implement message multi-select in the timeline with `multiSelectMode` and `selectedMessageIds`, a sticky selection toolbar (`.chat-message-selectbar`) offering `复制` and `删除`, context-menu entry `多选`, per-message checkbox state, and handlers `enterMultiSelectMode`, `toggleMessageSelected`, `copySelectedMessages`, and `deleteSelectedMessages`. 
- Add an Agents loading placeholder shown when `loading && visibleAgents.length === 0` and corresponding styles in `AgentsView.less`. 
- Adjust session hook behavior in `SessionService.emitAndPersist` so `cancelled` agent status triggers the failure/cancel hook path with an appropriate title/body, and add related UI/style updates in `ChatView.less` for selected-message visuals. 

### Testing
- Ran TypeScript checks with `pnpm --filter @spark/desktop typecheck`, which completed successfully. 
- Ran static checks with `git diff --check` which returned no issues. 
- Attempted change analysis with `npx gitnexus detect_changes --scope compare --base_ref master`, but the local GitNexus environment produced warnings and did not provide a full impact report; a repository-local `.gitnexus/run.cjs` / registered MCP server was not available so `impact(...)` could not be executed prior to edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b25ad00808328bc0580285b3bf926)