### PR TITLE
Add OAuth2 support for MCP servers (desktop + agent-runtime) with UI and IPC

### DIFF
--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -143,6 +143,7 @@ import type {
 } from '@spark/protocol'
 import type { SessionListResponse, SystemNotificationNavigateRequest } from '@spark/protocol'
 import { MediaModelManifestSchema, isAutoRouterProvider } from '@spark/protocol'
+import { McpOAuthService } from '../services/mcp-oauth/McpOAuthService.js'
 import type {
   SessionEventHandler,
   ApprovalHandler,
@@ -1206,9 +1207,34 @@ function getNoProjectWorkspaceId(): string | null {
 let _mcpService: McpService | null = null
 export function getMcpService(): McpService {
   if (_mcpService == null) {
-    _mcpService = new McpService(new McpServerRepository(getDatabase()))
+    _mcpService = new McpService(new McpServerRepository(getDatabase()), getMcpOAuthService())
   }
   return _mcpService
+}
+
+
+let _mcpOAuthService: McpOAuthService | null = null
+function getMcpOAuthService(): McpOAuthService {
+  if (_mcpOAuthService == null) {
+    _mcpOAuthService = new McpOAuthService({ get: (id) => { const row = new McpServerRepository(getDatabase()).get(id); return row == null ? null : { id: row.id, configJson: row.config_json } } })
+  }
+  return _mcpOAuthService
+}
+
+
+function extractMcpOAuthStaticClient(configJson: string): { configJson: string; clientId?: string; clientSecret?: string; hasClientSecret: boolean } {
+  try {
+    const config = JSON.parse(configJson) as Record<string, unknown>
+    const auth = config.auth != null && typeof config.auth === 'object' ? config.auth as Record<string, unknown> : null
+    if (auth?.type !== 'oauth2') return { configJson, hasClientSecret: false }
+    const clientId = typeof auth.clientId === 'string' ? auth.clientId : undefined
+    const clientSecret = typeof auth.clientSecret === 'string' ? auth.clientSecret : undefined
+    if (clientSecret != null) delete auth.clientSecret
+    if (clientSecret != null || auth.hasClientSecret != null) auth.hasClientSecret = clientSecret != null && clientSecret.length > 0
+    return { configJson: JSON.stringify(config), ...(clientId != null ? { clientId } : {}), ...(clientSecret != null ? { clientSecret } : {}), hasClientSecret: clientSecret != null && clientSecret.length > 0 }
+  } catch {
+    return { configJson, hasClientSecret: false }
+  }
 }
 
 function getSkillService(): SkillService {
@@ -1793,6 +1819,7 @@ function getSessionService(): SessionService {
       // SessionService 自建一份，agent 侧的 mcp_status / getServerStatus 会
       // 永远查到一个从未启动过连接的幽灵实例，无论真实服务器是否可用都报 disconnected。
       getMcpService(),
+      getMcpOAuthService(),
     )
     // 接入画布 Agent 桥：仅当 session 已 attach 到画布弹窗时返回 MCP server
     _sessionService.setCanvasMcpProvider(getCanvasHostBridge().asMcpProvider())
@@ -4643,6 +4670,7 @@ export function registerAllIpcHandlers(): void {
     return { deleted }
   })
 
+
   // ─── MCP Handlers ───────────────────────────────────────────────────────────
 
   typedIpcHandle('mcp:list', async (req) => {
@@ -4653,13 +4681,24 @@ export function registerAllIpcHandlers(): void {
   })
 
   typedIpcHandle('mcp:create', async (req) => {
-    const server = getMcpService().createServer(req)
+    const oauthClient = extractMcpOAuthStaticClient(req.configJson)
+    const server = getMcpService().createServer({ ...req, configJson: oauthClient.configJson })
+    if (oauthClient.clientId != null || oauthClient.clientSecret != null) {
+      await getMcpOAuthService().saveStaticClient(server.id, oauthClient)
+    }
     pushConfigChanged('mcp', 'create', server.id)
     return { server }
   })
 
   typedIpcHandle('mcp:update', async (req) => {
     const { id, ...fields } = req
+    if (fields.configJson != null) {
+      const oauthClient = extractMcpOAuthStaticClient(fields.configJson)
+      fields.configJson = oauthClient.configJson
+      if (oauthClient.clientId != null || oauthClient.clientSecret != null) {
+        await getMcpOAuthService().saveStaticClient(id, oauthClient)
+      }
+    }
     const server = getMcpService().updateServer(id, fields)
     pushConfigChanged('mcp', 'update', id)
     return { server }
@@ -4690,6 +4729,28 @@ export function registerAllIpcHandlers(): void {
     log.info(`mcp:server-status requested, serverId=${req.serverId}`)
     const status = getMcpService().getServerStatus(req.serverId)
     return status
+  })
+
+  typedIpcHandle('mcp:authorize', async (req) => {
+    await getMcpOAuthService().authorize(req.serverId)
+    try {
+      await getMcpService().startServer(req.serverId)
+    } catch (err) {
+      log.warn(`mcp:authorize completed but reconnect failed, serverId=${req.serverId}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    pushConfigChanged('mcp', 'update', req.serverId)
+    return { authorized: true }
+  })
+
+  typedIpcHandle('mcp:deauthorize', async (req) => {
+    await getMcpService().stopServer(req.serverId)
+    await getMcpOAuthService().deauthorize(req.serverId)
+    pushConfigChanged('mcp', 'update', req.serverId)
+    return { deauthorized: true }
+  })
+
+  typedIpcHandle('mcp:auth-status', async (req) => {
+    return { status: await getMcpOAuthService().getAuthStatus(req.serverId) }
   })
 
   typedIpcHandle('mcp:server-tools', async (req) => {

--- a/apps/desktop/src/main/services/mcp-oauth/McpOAuthService.ts
+++ b/apps/desktop/src/main/services/mcp-oauth/McpOAuthService.ts
@@ -1,0 +1,261 @@
+import { createServer, type Server } from 'node:http'
+import { randomBytes } from 'node:crypto'
+import {
+  auth,
+  discoverOAuthServerInfo,
+  refreshAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js'
+import type { OAuthClientInformationMixed, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js'
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js'
+import { createLogger } from '@spark/shared'
+import { SparkMcpOAuthProvider, type McpOAuthStore, type SparkOAuthTokens } from '@spark/agent-runtime'
+
+const log = createLogger('mcp:oauth')
+const REFRESH_SKEW_SECONDS = 120
+const AUTHORIZE_TIMEOUT_MS = 180_000
+
+export type McpOAuthStatus = 'unconfigured' | 'needs-auth' | 'authorizing' | 'authorized' | 'failed'
+
+type OAuthConfig = {
+  type?: string
+  scope?: string
+  dcr?: boolean
+  clientId?: string
+  clientSecret?: string
+}
+
+type ServerConfig = { url?: string; auth?: OAuthConfig }
+type McpServerLike = { id: string; configJson: string }
+
+export interface McpOAuthServerSource { get(id: string): McpServerLike | null | undefined }
+
+export class DesktopMcpOAuthStore implements McpOAuthStore {
+  private stores = new Map<string, import('../Auth/TokenStore.js').TokenStore>()
+
+  async getTokens(serverId: string): Promise<SparkOAuthTokens | undefined> { return await this.read(serverId, 'tokens') }
+  async saveTokens(serverId: string, tokens: SparkOAuthTokens): Promise<void> { await this.write(serverId, 'tokens', tokens) }
+  async clearTokens(serverId: string): Promise<void> { await this.remove(serverId, 'tokens') }
+  async getClientInformation(serverId: string): Promise<OAuthClientInformationMixed | undefined> { return await this.read(serverId, 'client_information') }
+  async saveClientInformation(serverId: string, info: OAuthClientInformationMixed): Promise<void> { await this.write(serverId, 'client_information', info) }
+  async clearClientInformation(serverId: string): Promise<void> { await this.remove(serverId, 'client_information') }
+  async getDiscoveryState(serverId: string): Promise<OAuthDiscoveryState | undefined> { return await this.read(serverId, 'discovery_state') }
+  async saveDiscoveryState(serverId: string, state: OAuthDiscoveryState): Promise<void> { await this.write(serverId, 'discovery_state', state) }
+  async clearDiscoveryState(serverId: string): Promise<void> { await this.remove(serverId, 'discovery_state') }
+  async clearAll(serverId: string): Promise<void> { await (await this.store(serverId)).clear() }
+
+  private async store(serverId: string) {
+    let store = this.stores.get(serverId)
+    if (store == null) {
+      const { TokenStore } = await import('../Auth/TokenStore.js')
+      store = new TokenStore(`spark-mcp-oauth:${serverId}`)
+      await store.load()
+      this.stores.set(serverId, store)
+    }
+    return store
+  }
+
+  private async payload(serverId: string): Promise<Record<string, unknown>> {
+    const session = (await this.store(serverId)).get() as Record<string, unknown>
+    if (typeof session.token !== 'string' || session.token.trim().length === 0) return {}
+    try {
+      const parsed = JSON.parse(session.token) as unknown
+      return parsed != null && typeof parsed === 'object' ? parsed as Record<string, unknown> : {}
+    } catch (err) {
+      log.warn(`Ignoring corrupted MCP OAuth secure payload for ${serverId}: ${err instanceof Error ? err.message : String(err)}`)
+      return {}
+    }
+  }
+
+  private async read<T>(serverId: string, key: string): Promise<T | undefined> {
+    const payload = await this.payload(serverId)
+    const raw = payload[key]
+    if (typeof raw !== 'string') return undefined
+    try { return JSON.parse(raw) as T } catch { return undefined }
+  }
+
+  private async write(serverId: string, key: string, value: unknown): Promise<void> {
+    const store = await this.store(serverId)
+    const payload = await this.payload(serverId)
+    await store.save({ token: JSON.stringify({ ...payload, [key]: JSON.stringify(value) }), refreshToken: 'mcp-oauth', userId: serverId })
+  }
+
+  private async remove(serverId: string, key: string): Promise<void> {
+    const store = await this.store(serverId)
+    const payload = await this.payload(serverId)
+    delete payload[key]
+    await store.save({ token: JSON.stringify(payload), refreshToken: 'mcp-oauth', userId: serverId })
+  }
+}
+
+export class McpOAuthService {
+  private readonly authorizing = new Set<string>()
+  private readonly failed = new Map<string, string>()
+
+  constructor(
+    private readonly source: McpOAuthServerSource,
+    private readonly store: McpOAuthStore = new DesktopMcpOAuthStore(),
+  ) {}
+
+  async saveStaticClient(serverId: string, client: { clientId?: string; clientSecret?: string }): Promise<void> {
+    const clientId = client.clientId?.trim()
+    if (!clientId) return
+    const existing = await this.store.getClientInformation(serverId)
+    const existingSecret = existing != null && 'client_secret' in existing && typeof existing.client_secret === 'string'
+      ? existing.client_secret
+      : undefined
+    const clientSecret = client.clientSecret != null && client.clientSecret.length > 0 ? client.clientSecret : existingSecret
+    await this.store.saveClientInformation(serverId, {
+      client_id: clientId,
+      ...(clientSecret != null && clientSecret.length > 0 ? { client_secret: clientSecret } : {}),
+    })
+  }
+
+  async getAccessToken(serverId: string): Promise<string | null> {
+    const server = this.source.get(serverId)
+    const cfg = parseServerConfig(server?.configJson)
+    if (cfg?.auth?.type !== 'oauth2' || cfg.url == null) return null
+    const tokens = await this.refreshIfNeeded(serverId, cfg)
+    return tokens?.access_token ?? null
+  }
+
+  async refreshIfNeeded(serverId: string, cfg = parseServerConfig(this.source.get(serverId)?.configJson)): Promise<SparkOAuthTokens | undefined> {
+    if (cfg?.auth?.type !== 'oauth2' || cfg.url == null) return undefined
+    const tokens = await this.store.getTokens(serverId)
+    if (tokens?.access_token == null) return undefined
+    if (tokens.expires_at == null || tokens.expires_at - nowSeconds() > REFRESH_SKEW_SECONDS) return tokens
+    if (tokens.refresh_token == null) {
+      await this.store.clearTokens(serverId)
+      this.failed.set(serverId, 'OAuth token expired and no refresh token is available')
+      return undefined
+    }
+    try {
+      const clientInformation = await this.store.getClientInformation(serverId)
+      if (clientInformation == null) throw new Error('OAuth client information is missing')
+      const serverInfo = await discoverOAuthServerInfo(cfg.url)
+      const refreshed = await refreshAuthorization(serverInfo.authorizationServerUrl, {
+        ...(serverInfo.authorizationServerMetadata != null ? { metadata: serverInfo.authorizationServerMetadata } : {}),
+        clientInformation,
+        refreshToken: tokens.refresh_token,
+        ...(serverInfo.resourceMetadata?.resource != null ? { resource: new URL(serverInfo.resourceMetadata.resource) } : {}),
+      })
+      const saved = withExpiresAt({ ...refreshed, refresh_token: refreshed.refresh_token ?? tokens.refresh_token })
+      await this.store.saveTokens(serverId, saved)
+      this.failed.delete(serverId)
+      return saved
+    } catch (err) {
+      await this.store.clearTokens(serverId)
+      const message = err instanceof Error ? err.message : String(err)
+      this.failed.set(serverId, message)
+      log.warn(`MCP OAuth refresh failed for ${serverId}: ${message}`)
+      return undefined
+    }
+  }
+
+  async getAuthStatus(serverId: string): Promise<McpOAuthStatus> {
+    if (this.authorizing.has(serverId)) return 'authorizing'
+    const server = this.source.get(serverId)
+    const cfg = parseServerConfig(server?.configJson)
+    if (cfg?.auth?.type !== 'oauth2') return 'unconfigured'
+    return (await this.getAccessToken(serverId)) != null ? 'authorized' : this.failed.has(serverId) ? 'failed' : 'needs-auth'
+  }
+
+  async deauthorize(serverId: string): Promise<void> {
+    await this.store.clearAll(serverId)
+    this.failed.delete(serverId)
+  }
+
+  async authorize(serverId: string): Promise<void> {
+    const server = this.source.get(serverId)
+    const cfg = parseServerConfig(server?.configJson)
+    if (server == null || cfg?.url == null || cfg.auth?.type !== 'oauth2') throw new Error('MCP OAuth server is not configured')
+    if (this.authorizing.has(serverId)) throw new Error('MCP OAuth authorization is already in progress')
+    if (cfg.auth.dcr === false && !cfg.auth.clientId?.trim() && (await this.store.getClientInformation(serverId)) == null) {
+      throw new Error('OAuth static client_id is required when DCR is disabled')
+    }
+    const { server: callbackServer, redirectUrl, waitForCode } = await createLoopbackCallback()
+    const state = randomBytes(16).toString('hex')
+    this.authorizing.add(serverId)
+    this.failed.delete(serverId)
+    try {
+      const provider = new SparkMcpOAuthProvider({
+        serverId,
+        redirectUrl,
+        store: this.store,
+        ...(cfg.auth.scope != null ? { scope: cfg.auth.scope } : {}),
+        ...(cfg.auth.dcr === false ? { staticClient: { ...(cfg.auth.clientId != null ? { clientId: cfg.auth.clientId } : {}), ...(cfg.auth.clientSecret != null ? { clientSecret: cfg.auth.clientSecret } : {}) } } : {}),
+        state,
+        onAuthorizationUrl: async (url: URL) => {
+          const { shell } = await import('electron')
+          await shell.openExternal(url.toString())
+        },
+      })
+      await auth(provider, { serverUrl: cfg.url, ...(cfg.auth.scope != null ? { scope: cfg.auth.scope } : {}) })
+      const params = await waitForCode
+      if (params.state !== state) throw new Error('OAuth state mismatch')
+      await auth(provider, { serverUrl: cfg.url, authorizationCode: params.code, ...(cfg.auth.scope != null ? { scope: cfg.auth.scope } : {}) })
+      const tokens = await this.store.getTokens(serverId)
+      if (tokens?.access_token == null) throw new Error('OAuth authorization completed without an access token')
+      this.failed.delete(serverId)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this.failed.set(serverId, message)
+      throw err
+    } finally {
+      this.authorizing.delete(serverId)
+      callbackServer.close()
+    }
+    log.info(`MCP OAuth authorization completed for ${serverId}`)
+  }
+}
+
+function parseServerConfig(configJson?: string): ServerConfig | null {
+  if (configJson == null) return null
+  try { return JSON.parse(configJson) as ServerConfig } catch { return null }
+}
+function nowSeconds(): number { return Math.floor(Date.now() / 1000) }
+function withExpiresAt(tokens: OAuthTokens): SparkOAuthTokens {
+  const expiresAt = tokens.expires_in != null ? nowSeconds() + Number(tokens.expires_in) : undefined
+  return { ...tokens, ...(expiresAt != null ? { expires_at: expiresAt } : {}) }
+}
+
+async function createLoopbackCallback(): Promise<{ server: Server; redirectUrl: string; waitForCode: Promise<{ code: string; state?: string }> }> {
+  let done = false
+  let settle!: (value: { code: string; state?: string }) => void
+  let reject!: (error: Error) => void
+  const waitForCode = new Promise<{ code: string; state?: string }>((resolve, rejectPromise) => { settle = resolve; reject = rejectPromise })
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+    if (url.pathname !== '/callback') { res.writeHead(404).end(); return }
+    if (done) { res.writeHead(409).end('OAuth callback already consumed'); return }
+    done = true
+    const error = url.searchParams.get('error')
+    if (error != null) {
+      const desc = url.searchParams.get('error_description')
+      res.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' }).end('Authorization failed. You can close this window.')
+      reject(new Error(desc != null ? `${error}: ${desc}` : error))
+      return
+    }
+    const code = url.searchParams.get('code')
+    if (!code) { res.writeHead(400).end('Missing code'); reject(new Error('OAuth callback missing code')); return }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' }).end('<html><body>Authorization complete. You can close this window.</body></html>')
+    const state = url.searchParams.get('state') ?? undefined
+    settle({ code, ...(state != null ? { state } : {}) })
+  })
+  await new Promise<void>((resolve, rejectListen) => {
+    server.once('error', rejectListen)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', rejectListen)
+      resolve()
+    })
+  })
+  const address = server.address()
+  if (address == null || typeof address === 'string') throw new Error('Failed to bind OAuth callback server')
+  const timer = setTimeout(() => {
+    if (!done) {
+      done = true
+      reject(new Error('OAuth authorization timed out'))
+    }
+  }, AUTHORIZE_TIMEOUT_MS)
+  waitForCode.finally(() => clearTimeout(timer)).catch(() => undefined)
+  return { server, redirectUrl: `http://127.0.0.1:${address.port}/callback`, waitForCode }
+}

--- a/apps/desktop/src/renderer/design/views/McpView.tsx
+++ b/apps/desktop/src/renderer/design/views/McpView.tsx
@@ -30,6 +30,7 @@ import { useApp } from '../AppContext'
 import './McpView.less'
 
 type StatusFilter = 'all' | 'ok' | 'warn' | 'err' | 'off'
+type McpOAuthStatus = 'unconfigured' | 'needs-auth' | 'authorizing' | 'authorized' | 'failed'
 type McpTransport = 'stdio' | 'http' | 'sse'
 
 type ParsedConfig = {
@@ -41,6 +42,7 @@ type ParsedConfig = {
   url?: string
   headers?: Record<string, string>
   env?: Record<string, string>
+  auth?: { type?: 'none' | 'oauth2'; scope?: string; dcr?: boolean; clientId?: string; clientSecret?: string; hasClientSecret?: boolean }
   tools?: string[]
   description?: string
 }
@@ -55,6 +57,8 @@ type ServerDerived = {
   status: 'ok' | 'warn' | 'err' | 'off'
   tools: number
   statusLabel: string
+  authStatus: McpOAuthStatus
+  authEnabled: boolean
 }
 
 type DraftBase = {
@@ -66,6 +70,11 @@ type DraftBase = {
   url: string
   description: string
   env: Array<{ key: string; value: string }>
+  authType: 'none' | 'oauth2'
+  authScope: string
+  authDcr: boolean
+  authClientId: string
+  authClientSecret: string
   enabled: boolean
 }
 
@@ -88,6 +97,11 @@ const EMPTY_DRAFT: DraftBase = {
   url: '',
   description: '',
   env: [],
+  authType: 'none',
+  authScope: '',
+  authDcr: true,
+  authClientId: '',
+  authClientSecret: '',
   enabled: true,
 }
 
@@ -118,6 +132,15 @@ function serializeConfig(draft: DraftBase): string {
   } else {
     config.url = draft.url.trim()
   }
+  if (draft.transport !== 'stdio' && draft.authType === 'oauth2') {
+    config.auth = {
+      type: 'oauth2',
+      scope: draft.authScope.trim(),
+      dcr: draft.authDcr,
+      ...(!draft.authDcr ? { clientId: draft.authClientId.trim(), hasClientSecret: draft.authClientSecret.trim().length > 0 } : {}),
+      ...(!draft.authDcr && draft.authClientSecret.trim().length > 0 ? { clientSecret: draft.authClientSecret.trim() } : {}),
+    }
+  }
   const env: Record<string, string> = {}
   for (const { key, value } of draft.env) {
     const k = key.trim()
@@ -144,12 +167,14 @@ function normalizeTransport(config: ParsedConfig): McpTransport {
   return 'stdio'
 }
 
-function deriveServer(item: McpServerItem): ServerDerived {
+function deriveServer(item: McpServerItem, authStatus: McpOAuthStatus = 'unconfigured'): ServerDerived {
   const config = parseConfig(item.configJson)
   const transport = normalizeTransport(config)
   const endpoint = transport === 'stdio' ? (config.command ?? '') : (config.url ?? '')
   const valid = endpoint.trim().length > 0
-  const status: ServerDerived['status'] = !item.enabled ? 'off' : valid ? 'ok' : 'warn'
+  const authEnabled = config.auth?.type === 'oauth2'
+  const needsAuth = authEnabled && authStatus !== 'authorized'
+  const status: ServerDerived['status'] = !item.enabled ? 'off' : !valid ? 'warn' : authStatus === 'failed' ? 'err' : needsAuth ? 'warn' : 'ok'
   const desc =
     config.description?.trim() && config.description.trim().length > 0
       ? config.description.trim()
@@ -158,6 +183,10 @@ function deriveServer(item: McpServerItem): ServerDerived {
         : `${transport} · ${config.url ?? '未配置 URL'}`
   let statusLabel: string
   if (status === 'off') statusLabel = '未启用'
+  else if (authStatus === 'authorized') statusLabel = '已授权'
+  else if (authStatus === 'authorizing') statusLabel = '授权中'
+  else if (authStatus === 'failed') statusLabel = '授权失败'
+  else if (needsAuth) statusLabel = '需要授权'
   else if (status === 'warn') statusLabel = '配置不完整'
   else statusLabel = '本地配置'
 
@@ -171,6 +200,8 @@ function deriveServer(item: McpServerItem): ServerDerived {
     status,
     tools: config.tools?.length ?? 0,
     statusLabel,
+    authStatus,
+    authEnabled,
   }
 }
 
@@ -187,6 +218,11 @@ function draftFromItem(item: McpServerItem | null): DraftBase {
     url: config.url ?? '',
     description: config.description ?? '',
     env,
+    authType: config.auth?.type === 'oauth2' ? 'oauth2' : 'none',
+    authScope: config.auth?.scope ?? '',
+    authDcr: config.auth?.dcr !== false,
+    authClientId: config.auth?.clientId ?? '',
+    authClientSecret: '',
     enabled: item.enabled,
   }
 }
@@ -205,20 +241,39 @@ export function McpView() {
   const [draft, setDraft] = useState<DraftBase>(EMPTY_DRAFT)
   const [draftError, setDraftError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
+  const [authStatuses, setAuthStatuses] = useState<Record<string, McpOAuthStatus>>({})
+  const [authorizingId, setAuthorizingId] = useState<string | null>(null)
 
   const { invoke: listMcp, loading } = useIpcInvoke('mcp:list')
   const { invoke: createMcp } = useIpcInvoke('mcp:create')
   const { invoke: updateMcp } = useIpcInvoke('mcp:update')
   const { invoke: deleteMcp } = useIpcInvoke('mcp:delete')
+  const { invoke: authorizeMcp } = useIpcInvoke('mcp:authorize')
+  const { invoke: deauthorizeMcp } = useIpcInvoke('mcp:deauthorize')
+  const { invoke: getAuthStatus } = useIpcInvoke('mcp:auth-status')
 
   const refresh = useCallback(() => {
     listMcp(scopeFilter === 'all' ? {} : { scope: scopeFilter })
-      .then((res) => setServers(res.servers ?? []))
+      .then(async (res) => {
+        const nextServers = res.servers ?? []
+        setServers(nextServers)
+        const entries = await Promise.all(nextServers.map(async (server) => {
+          const config = parseConfig(server.configJson)
+          if (config.auth?.type !== 'oauth2') return [server.id, 'unconfigured'] as const
+          try {
+            const auth = await getAuthStatus({ serverId: server.id })
+            return [server.id, auth.status] as const
+          } catch {
+            return [server.id, 'failed'] as const
+          }
+        }))
+        setAuthStatuses(Object.fromEntries(entries))
+      })
       .catch((err) => {
         const errorMsg = err instanceof Error ? err.message : '加载 MCP 服务器失败'
         message.error(errorMsg)
       })
-  }, [listMcp, scopeFilter])
+  }, [listMcp, getAuthStatus, scopeFilter])
 
   useRefreshable(refresh)
 
@@ -227,7 +282,7 @@ export function McpView() {
     return () => window.clearTimeout(id)
   }, [refresh])
 
-  const derived = useMemo(() => servers.map(deriveServer), [servers])
+  const derived = useMemo(() => servers.map((server) => deriveServer(server, authStatuses[server.id] ?? 'unconfigured')), [servers, authStatuses])
 
   const statusCounts = useMemo(() => {
     return {
@@ -290,6 +345,9 @@ export function McpView() {
       } catch {
         return 'URL 格式不正确'
       }
+    }
+    if (value.transport !== 'stdio' && value.authType === 'oauth2' && !value.authDcr && value.authClientId.trim().length === 0) {
+      return '关闭动态注册时需要填写 Client ID'
     }
     return null
   }
@@ -365,6 +423,32 @@ export function McpView() {
     },
     [requestConfirm, deleteMcp, refresh],
   )
+
+
+  const handleAuthorize = useCallback(async (item: McpServerItem) => {
+    setAuthorizingId(item.id)
+    setAuthStatuses((prev) => ({ ...prev, [item.id]: 'authorizing' }))
+    try {
+      await authorizeMcp({ serverId: item.id })
+      message.success('MCP 授权已完成')
+      refresh()
+    } catch (err) {
+      setAuthStatuses((prev) => ({ ...prev, [item.id]: 'failed' }))
+      message.error(err instanceof Error ? err.message : 'MCP 授权失败')
+    } finally {
+      setAuthorizingId(null)
+    }
+  }, [authorizeMcp, refresh])
+
+  const handleDeauthorize = useCallback(async (item: McpServerItem) => {
+    try {
+      await deauthorizeMcp({ serverId: item.id })
+      message.success('已断开授权')
+      refresh()
+    } catch (err) {
+      message.error(err instanceof Error ? err.message : '断开授权失败')
+    }
+  }, [deauthorizeMcp, refresh])
 
   return (
     <>
@@ -501,6 +585,9 @@ export function McpView() {
                         onToggle={(next) => void handleToggle(item, next)}
                         onEdit={() => openEdit(item)}
                         onDelete={() => void handleDelete(item)}
+                        onAuthorize={() => void handleAuthorize(item)}
+                        onDeauthorize={() => void handleDeauthorize(item)}
+                        authorizing={authorizingId === item.id}
                       />
                     )
                   })}
@@ -548,11 +635,17 @@ function McpCard({
   onToggle,
   onEdit,
   onDelete,
+  onAuthorize,
+  onDeauthorize,
+  authorizing,
 }: {
   server: ServerDerived
   onToggle: (next: boolean) => void
   onEdit: () => void
   onDelete: () => void
+  onAuthorize: () => void
+  onDeauthorize: () => void
+  authorizing: boolean
 }) {
   const logoText = server.name.slice(0, 2).toUpperCase() || 'MCP'
   const statusClass =
@@ -609,6 +702,15 @@ function McpCard({
           </span>
         )}
         <div className="mv_toolbar_spacer" />
+        {server.authEnabled && (
+          server.authStatus === 'authorized' ? (
+            <Button type="text" size="small" onClick={onDeauthorize}>断开授权</Button>
+          ) : (
+            <Button type="primary" size="small" loading={authorizing} onClick={onAuthorize}>
+              {server.authStatus === 'failed' ? '重新授权' : '连接授权'}
+            </Button>
+          )
+        )}
         <Tooltip title="编辑">
           <Button type="text" size="small" icon={<Icons.Edit />} onClick={onEdit} />
         </Tooltip>
@@ -852,6 +954,46 @@ function McpForm({
           </div>
         </div>
       </section>
+
+      {!isStdio && (
+        <section className="mv_drawer_section">
+          <header className="mv_drawer_section_head">
+            <span className="mv_drawer_section_icon">🔐</span>
+            <span className="mv_drawer_section_title">认证方式</span>
+            <span className="mv_drawer_section_hint">OAuth 2.0 / PKCE</span>
+          </header>
+          <div className="mv_drawer_section_body">
+            <div className="mv_form_grid">
+              <label className="mv_form_label">认证</label>
+              <div className="mv_form_field">
+                <div className="mv_segmented">
+                  {(['none', 'oauth2'] as const).map((authType) => (
+                    <button key={authType} type="button" className={`mv_segmented_item ${draft.authType === authType ? 'mv_segmented_active' : ''}`} onClick={() => update('authType', authType)}>
+                      {authType === 'none' ? '无' : 'OAuth 2.0'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {draft.authType === 'oauth2' && (
+                <>
+                  <label className="mv_form_label">Scope</label>
+                  <div className="mv_form_field"><LobeInput value={draft.authScope} onChange={(event) => update('authScope', event.target.value)} placeholder="可选 OAuth scope" /></div>
+                  <label className="mv_form_label">动态注册</label>
+                  <div className="mv_form_field mv_form_field_inline"><Switch checked={draft.authDcr} onChange={(checked) => update('authDcr', checked)} checkedChildren="ON" unCheckedChildren="OFF" /></div>
+                  {!draft.authDcr && (
+                    <>
+                      <label className="mv_form_label">Client ID</label>
+                      <div className="mv_form_field"><LobeInput value={draft.authClientId} onChange={(event) => update('authClientId', event.target.value)} placeholder="静态 client_id" /></div>
+                      <label className="mv_form_label">Client Secret</label>
+                      <div className="mv_form_field"><LobeInput type="password" value={draft.authClientSecret} onChange={(event) => update('authClientSecret', event.target.value)} placeholder="可选，保存到安全存储迁移前暂存配置" /></div>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
 
       {/* ── 环境变量 ── */}
       <section className="mv_drawer_section">

--- a/packages/agent-runtime/src/__tests__/mcp/oauth-provider.test.ts
+++ b/packages/agent-runtime/src/__tests__/mcp/oauth-provider.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryMcpOAuthStore, SparkMcpOAuthProvider } from '../../mcp/oauth/index.js'
+
+describe('SparkMcpOAuthProvider', () => {
+  it('builds OAuth client metadata with PKCE authorization code settings', () => {
+    const provider = new SparkMcpOAuthProvider({
+      serverId: 'server-1',
+      redirectUrl: 'http://127.0.0.1:1234/callback',
+      store: new InMemoryMcpOAuthStore(),
+      scope: 'openid profile',
+    })
+
+    expect(provider.clientMetadata).toMatchObject({
+      client_name: 'Spark Agent',
+      redirect_uris: ['http://127.0.0.1:1234/callback'],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: 'openid profile',
+    })
+  })
+
+  it('persists tokens, client information, discovery state and supports invalidation scopes', async () => {
+    const store = new InMemoryMcpOAuthStore()
+    const provider = new SparkMcpOAuthProvider({
+      serverId: 'server-1',
+      redirectUrl: 'http://127.0.0.1:1234/callback',
+      store,
+    })
+
+    await provider.saveClientInformation({ client_id: 'client-1', client_secret: 'secret' })
+    await provider.saveTokens({ access_token: 'access', refresh_token: 'refresh', token_type: 'Bearer', expires_in: 60 })
+    await provider.saveDiscoveryState({ authorizationServerUrl: 'https://auth.example.com' })
+
+    expect(await provider.clientInformation()).toMatchObject({ client_id: 'client-1', client_secret: 'secret' })
+    expect(await provider.tokens()).toMatchObject({ access_token: 'access', refresh_token: 'refresh', expires_at: expect.any(Number) })
+    expect(await provider.discoveryState()).toMatchObject({ authorizationServerUrl: 'https://auth.example.com' })
+
+    await provider.invalidateCredentials('tokens')
+    expect(await provider.tokens()).toBeUndefined()
+    expect(await provider.clientInformation()).toMatchObject({ client_id: 'client-1' })
+
+    await provider.invalidateCredentials('all')
+    expect(await provider.clientInformation()).toBeUndefined()
+    expect(await provider.discoveryState()).toBeUndefined()
+  })
+
+  it('uses static client information when DCR is disabled', async () => {
+    const provider = new SparkMcpOAuthProvider({
+      serverId: 'server-1',
+      redirectUrl: 'http://127.0.0.1:1234/callback',
+      store: new InMemoryMcpOAuthStore(),
+      staticClient: { clientId: 'static-client', clientSecret: 'static-secret' },
+    })
+
+    expect(provider.clientMetadata.token_endpoint_auth_method).toBe('client_secret_post')
+    await expect(provider.clientInformation()).resolves.toMatchObject({
+      client_id: 'static-client',
+      client_secret: 'static-secret',
+    })
+  })
+})

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -210,3 +210,6 @@ export type {
 export { MemoryStoreService } from './services/memory/memory-store.service.js'
 export { MemoryWriterService } from './services/memory/memory-writer.service.js'
 export { EmbeddingService } from './services/memory/embedding.service.js'
+
+export { SparkMcpOAuthProvider } from './mcp/oauth/oauth-provider.js'
+export type { McpOAuthStore, SparkOAuthTokens } from './mcp/oauth/oauth-store.js'

--- a/packages/agent-runtime/src/mcp/index.ts
+++ b/packages/agent-runtime/src/mcp/index.ts
@@ -6,3 +6,5 @@ export { StreamableHttpTransport } from './transport/streamable-http-transport.j
 export type { McpTransport, McpTransportConfig, StdioTransportConfig, SseTransportConfig, HttpTransportConfig, JsonRpcRequest, JsonRpcResponse, JsonRpcNotification } from './transport/types.js'
 export { resolveMcpConfig, validateMcpConfigJson } from './config-normalize.js'
 export type { ResolvedMcpConfig } from './config-normalize.js'
+
+export * from './oauth/index.js'

--- a/packages/agent-runtime/src/mcp/oauth/index.ts
+++ b/packages/agent-runtime/src/mcp/oauth/index.ts
@@ -1,0 +1,2 @@
+export * from './oauth-store.js'
+export * from './oauth-provider.js'

--- a/packages/agent-runtime/src/mcp/oauth/oauth-provider.ts
+++ b/packages/agent-runtime/src/mcp/oauth/oauth-provider.ts
@@ -1,0 +1,90 @@
+import type { OAuthClientInformationMixed, OAuthClientMetadata, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js'
+import type { OAuthClientProvider, OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js'
+import type { McpOAuthStore, SparkOAuthTokens } from './oauth-store.js'
+
+export interface SparkMcpOAuthProviderOptions {
+  serverId: string
+  redirectUrl: string
+  store: McpOAuthStore
+  scope?: string
+  staticClient?: { clientId?: string; clientSecret?: string }
+  onAuthorizationUrl?: (url: URL) => void | Promise<void>
+  state?: string
+}
+
+export class SparkMcpOAuthProvider implements OAuthClientProvider {
+  private verifier: string | undefined
+  private readonly requestedScope: string | undefined
+
+  constructor(private readonly options: SparkMcpOAuthProviderOptions) {
+    this.requestedScope = options.scope?.trim() || undefined
+  }
+
+  get redirectUrl(): string { return this.options.redirectUrl }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      client_name: 'Spark Agent',
+      redirect_uris: [this.redirectUrl],
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: this.options.staticClient?.clientSecret ? 'client_secret_post' : 'none',
+      ...(this.requestedScope != null ? { scope: this.requestedScope } : {}),
+    }
+  }
+
+  state(): string { return this.options.state ?? 'spark-oauth' }
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    const saved = await this.options.store.getClientInformation(this.options.serverId)
+    if (saved != null) return saved
+    const clientId = this.options.staticClient?.clientId?.trim()
+    if (!clientId) return undefined
+    return {
+      client_id: clientId,
+      ...(this.options.staticClient?.clientSecret ? { client_secret: this.options.staticClient.clientSecret } : {}),
+    }
+  }
+
+  async saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void> {
+    await this.options.store.saveClientInformation(this.options.serverId, clientInformation)
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> { return await this.options.store.getTokens(this.options.serverId) }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    const now = Math.floor(Date.now() / 1000)
+    const withExpiry: SparkOAuthTokens = {
+      ...tokens,
+      ...(tokens.expires_in != null ? { expires_at: now + Number(tokens.expires_in) } : {}),
+    }
+    await this.options.store.saveTokens(this.options.serverId, withExpiry)
+  }
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    await this.options.onAuthorizationUrl?.(authorizationUrl)
+  }
+
+  saveCodeVerifier(codeVerifier: string): void { this.verifier = codeVerifier }
+
+  codeVerifier(): string {
+    if (this.verifier == null) throw new Error('OAuth code verifier is missing')
+    return this.verifier
+  }
+
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    await this.options.store.saveDiscoveryState(this.options.serverId, state)
+  }
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    return await this.options.store.getDiscoveryState(this.options.serverId)
+  }
+
+  async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): Promise<void> {
+    if (scope === 'all') await this.options.store.clearAll(this.options.serverId)
+    if (scope === 'client') await this.options.store.clearClientInformation(this.options.serverId)
+    if (scope === 'tokens') await this.options.store.clearTokens(this.options.serverId)
+    if (scope === 'discovery') await this.options.store.clearDiscoveryState(this.options.serverId)
+    if (scope === 'verifier' || scope === 'all') this.verifier = undefined
+  }
+}

--- a/packages/agent-runtime/src/mcp/oauth/oauth-store.ts
+++ b/packages/agent-runtime/src/mcp/oauth/oauth-store.ts
@@ -1,0 +1,38 @@
+import type { OAuthClientInformationMixed, OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js'
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js'
+
+export type SparkOAuthTokens = OAuthTokens & { expires_at?: number }
+
+export interface McpOAuthStore {
+  getTokens(serverId: string): Promise<SparkOAuthTokens | undefined>
+  saveTokens(serverId: string, tokens: SparkOAuthTokens): Promise<void>
+  clearTokens(serverId: string): Promise<void>
+  getClientInformation(serverId: string): Promise<OAuthClientInformationMixed | undefined>
+  saveClientInformation(serverId: string, info: OAuthClientInformationMixed): Promise<void>
+  clearClientInformation(serverId: string): Promise<void>
+  getDiscoveryState(serverId: string): Promise<OAuthDiscoveryState | undefined>
+  saveDiscoveryState(serverId: string, state: OAuthDiscoveryState): Promise<void>
+  clearDiscoveryState(serverId: string): Promise<void>
+  clearAll(serverId: string): Promise<void>
+}
+
+export class InMemoryMcpOAuthStore implements McpOAuthStore {
+  private readonly tokens = new Map<string, SparkOAuthTokens>()
+  private readonly clients = new Map<string, OAuthClientInformationMixed>()
+  private readonly discovery = new Map<string, OAuthDiscoveryState>()
+
+  async getTokens(serverId: string): Promise<SparkOAuthTokens | undefined> { return this.tokens.get(serverId) }
+  async saveTokens(serverId: string, tokens: SparkOAuthTokens): Promise<void> { this.tokens.set(serverId, tokens) }
+  async clearTokens(serverId: string): Promise<void> { this.tokens.delete(serverId) }
+  async getClientInformation(serverId: string): Promise<OAuthClientInformationMixed | undefined> { return this.clients.get(serverId) }
+  async saveClientInformation(serverId: string, info: OAuthClientInformationMixed): Promise<void> { this.clients.set(serverId, info) }
+  async clearClientInformation(serverId: string): Promise<void> { this.clients.delete(serverId) }
+  async getDiscoveryState(serverId: string): Promise<OAuthDiscoveryState | undefined> { return this.discovery.get(serverId) }
+  async saveDiscoveryState(serverId: string, state: OAuthDiscoveryState): Promise<void> { this.discovery.set(serverId, state) }
+  async clearDiscoveryState(serverId: string): Promise<void> { this.discovery.delete(serverId) }
+  async clearAll(serverId: string): Promise<void> {
+    this.tokens.delete(serverId)
+    this.clients.delete(serverId)
+    this.discovery.delete(serverId)
+  }
+}

--- a/packages/agent-runtime/src/services/mcp-server.service.ts
+++ b/packages/agent-runtime/src/services/mcp-server.service.ts
@@ -17,6 +17,11 @@ import { createLogger } from '@spark/shared'
 
 const log = createLogger('mcp:service')
 
+export interface McpOAuthTokenProvider {
+  getAccessToken(serverId: string): Promise<string | null>
+  getAuthStatus?(serverId: string): Promise<'unconfigured' | 'needs-auth' | 'authorizing' | 'authorized' | 'failed'>
+}
+
 export type McpChangeAction =
   | 'create'
   | 'update'
@@ -47,7 +52,10 @@ export class McpService {
   private clients = new Map<string, McpClient>()
   private changeEmitter = new EventEmitter()
 
-  constructor(private readonly repo: McpServerRepository) {}
+  constructor(
+    private readonly repo: McpServerRepository,
+    private readonly oauthProvider?: McpOAuthTokenProvider,
+  ) {}
 
   // ─── Change Events ────────────────────────────────────────────────────────
 
@@ -84,7 +92,7 @@ export class McpService {
     // Auto-start when enabled is not explicitly false. Fire-and-forget so the IPC
     // response isn't blocked on the connection handshake; start failures are logged
     // and surface via getServerStatus without rolling back the DB row.
-    if (params.enabled !== false) {
+    if (params.enabled !== false && !isOAuthMcpConfig(params.configJson)) {
       void this.startServer(row.id).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
         log.warn(`Auto-start failed for newly created MCP server ${row.name}: ${message}`)
@@ -122,8 +130,8 @@ export class McpService {
           void this.startServer(id)
         }
       })
-    } else if (row.enabled === 1 && fields.enabled === true) {
-      // Toggling from disabled → enabled on an unconnected server: start it.
+    } else if (row.enabled === 1 && fields.enabled === true && !isOAuthMcpConfig(row.config_json)) {
+      // Toggling from disabled → enabled on an unconnected non-OAuth server: start it.
       void this.startServer(id).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err)
         log.warn(`Failed to start MCP server ${row.name} after enable: ${message}`)
@@ -172,7 +180,7 @@ export class McpService {
       throw new Error(`MCP server ${serverId} is disabled`)
     }
 
-    const config = this.parseConfig(row.config_json, row.id, row.name)
+    const config = await this.parseConfig(row.config_json, row.id, row.name)
     const client = new McpClient(row.id, row.name, config)
     client.setToolsChangedHandler((payload) => {
       this.emitChange('tools-changed', payload.serverId, payload.serverName)
@@ -298,7 +306,7 @@ export class McpService {
   /**
    * 解析 MCP 服务器配置 JSON 为 TransportConfig
    */
-  private parseConfig(configJson: string, _serverId: string, serverName: string): McpTransportConfig {
+  private async parseConfig(configJson: string, serverId: string, serverName: string): Promise<McpTransportConfig> {
     let config: Record<string, unknown>
     try {
       config = JSON.parse(configJson) as Record<string, unknown>
@@ -311,7 +319,19 @@ export class McpService {
     if (resolved == null) {
       throw new Error(`MCP server "${serverName}" 配置缺少有效传输（url 或 command）`)
     }
+    if (resolved.type === 'http' || resolved.type === 'sse') {
+      const auth = (config.auth as { type?: string } | undefined)
+      if (auth?.type === 'oauth2') {
+        const token = await this.oauthProvider?.getAccessToken(serverId)
+        if (token == null) throw new Error(`MCP server "${serverName}" requires OAuth authorization`)
+        return { ...resolved, headers: { ...(resolved.headers ?? {}), Authorization: `Bearer ${token}` } }
+      }
+    }
     return resolved
+  }
+
+  async getServerAuthStatus(serverId: string): Promise<'unconfigured' | 'needs-auth' | 'authorizing' | 'authorized' | 'failed'> {
+    return await this.oauthProvider?.getAuthStatus?.(serverId) ?? 'unconfigured'
   }
 }
 
@@ -324,5 +344,15 @@ function toMcpServerItem(row: McpServerRow): McpServerItem {
     enabled: row.enabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  }
+}
+
+
+function isOAuthMcpConfig(configJson: string): boolean {
+  try {
+    const config = JSON.parse(configJson) as { auth?: { type?: unknown } }
+    return config.auth?.type === 'oauth2'
+  } catch {
+    return false
   }
 }

--- a/packages/agent-runtime/src/services/platform-bridge.service.ts
+++ b/packages/agent-runtime/src/services/platform-bridge.service.ts
@@ -248,7 +248,7 @@ export class PlatformBridgeService {
       case 'mcp.create': return this.mcpCreate(d, params)
       case 'mcp.update': return this.mcpUpdate(d, params)
       case 'mcp.delete': return this.mcpDelete(d, params)
-      case 'mcp.status': return this.mcpStatus(d, params)
+      case 'mcp.status': return await this.mcpStatus(d, params)
 
       // ── Providers ──
       case 'providers.list': return this.providerList(d, params)
@@ -541,7 +541,7 @@ export class PlatformBridgeService {
     return { success: ok }
   }
 
-  private mcpStatus(d: PlatformBridgeDeps, params: Record<string, unknown>) {
+  private async mcpStatus(d: PlatformBridgeDeps, params: Record<string, unknown>) {
     const id = params.id != null ? String(params.id) : undefined
     const servers = d.mcpRepo.listAll()
     const statuses: Record<string, string> = {}
@@ -553,6 +553,11 @@ export class PlatformBridgeService {
       }
       // 反映真实连接状态，而不是仅仅“已启用”——否则 agent 自检时会把没连上的
       // 服务误判为可用。connected 才代表工具已就绪。
+      const authStatus = await d.mcpService.getServerAuthStatus(s.id)
+      if (authStatus === 'needs-auth' || authStatus === 'authorizing' || authStatus === 'failed') {
+        statuses[s.id] = authStatus
+        continue
+      }
       const status = d.mcpService.getServerStatus(s.id)
       statuses[s.id] = status.error != null ? 'error' : status.connected ? 'connected' : 'disconnected'
     }

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -85,6 +85,7 @@ import type {
 } from '../core/index.js'
 import * as keystore from '@spark/shared/keystore'
 import { MANAGED_MCP_SCOPE, McpService } from './mcp-server.service.js'
+import type { McpOAuthTokenProvider } from './mcp-server.service.js'
 import { resolveMcpConfig } from '../mcp/index.js'
 import type { McpChangeEvent } from './mcp-server.service.js'
 import { PlatformBridgeService } from './platform-bridge.service.js'
@@ -526,8 +527,9 @@ export class SessionService {
      * 生产环境必须传入 apps/desktop/src/main/ipc/index.ts 的 getMcpService()。
      */
     mcpService?: McpService,
+    private readonly mcpOAuthProvider?: McpOAuthTokenProvider,
   ) {
-    this.mcpService = mcpService ?? new McpService(new McpServerRepository(db))
+    this.mcpService = mcpService ?? new McpService(new McpServerRepository(db), mcpOAuthProvider)
     this.platformBridge = new PlatformBridgeService()
     this.mcpService.onChange((_event: McpChangeEvent) => {
       this.mcpVersion += 1
@@ -2533,7 +2535,7 @@ export class SessionService {
     }
 
     // Build MCP server config from our McpService for the SDK
-    const mcpServers = this.buildMcpServersForSDK(options.allowedMcpServerIds)
+    const mcpServers = await this.buildMcpServersForSDK(options.allowedMcpServerIds)
     if (config.imageGenerationMcpServer != null) {
       mcpServers.spark_image = config.imageGenerationMcpServer
     }
@@ -3102,7 +3104,7 @@ export class SessionService {
       return
     }
 
-    const mcpServers = this.buildMcpServersForSDK(options.allowedMcpServerIds)
+    const mcpServers = await this.buildMcpServersForSDK(options.allowedMcpServerIds)
     if (config.platformManagementMcpServer != null) {
       mcpServers.spark_platform = config.platformManagementMcpServer
     }
@@ -3410,7 +3412,7 @@ export class SessionService {
   /**
    * Build MCP server configs in the SDK's expected format from our McpService.
    */
-  private buildMcpServersForSDK(allowedServerIds?: Set<string>): Record<string, SDKMcpServerConfig> {
+  private async buildMcpServersForSDK(allowedServerIds?: Set<string>): Promise<Record<string, SDKMcpServerConfig>> {
     const result: Record<string, SDKMcpServerConfig> = {}
     const servers = this.mcpService.listServers()
 
@@ -3435,10 +3437,20 @@ export class SessionService {
             ...(resolved.cwd != null ? { cwd: resolved.cwd } : {}),
           }
         } else {
+          const auth = (cfg.auth as { type?: string } | undefined)
+          let headers = resolved.headers
+          if (auth?.type === 'oauth2') {
+            const token = await this.mcpOAuthProvider?.getAccessToken(server.id)
+            if (token == null) {
+              log.warn(`Skipping OAuth MCP server "${server.name}": authorization required`)
+              continue
+            }
+            headers = { ...(headers ?? {}), Authorization: `Bearer ${token}` }
+          }
           result[server.name] = {
             type: resolved.type,
             url: resolved.url,
-            ...(resolved.headers != null ? { headers: resolved.headers } : {}),
+            ...(headers != null ? { headers } : {}),
           }
         }
       } catch {
@@ -5121,7 +5133,7 @@ export class SessionService {
       : crypto.randomUUID()
 
     // Member 自身的 MCP 工具
-    const memberMcpServers = this.buildMcpServersForSDK(getAllowedMcpServerIds(member, null))
+    const memberMcpServers = await this.buildMcpServersForSDK(getAllowedMcpServerIds(member, null))
     // 内置联网搜索对团队成员同样默认挂载
     const memberWebSearchServer = await this.resolveWebSearchMcpServer(workspaceRootPath)
     if (memberWebSearchServer != null) memberMcpServers.spark_search = memberWebSearchServer

--- a/packages/protocol/src/ipc/index.ts
+++ b/packages/protocol/src/ipc/index.ts
@@ -1412,7 +1412,15 @@ export interface McpServerStatusResponse {
   connected: boolean
   toolCount: number
   error?: string
+  authStatus?: 'unconfigured' | 'needs-auth' | 'authorizing' | 'authorized' | 'failed'
 }
+
+export interface McpAuthorizeRequest { serverId: string }
+export interface McpAuthorizeResponse { authorized: boolean }
+export interface McpDeauthorizeRequest { serverId: string }
+export interface McpDeauthorizeResponse { deauthorized: boolean }
+export interface McpAuthStatusRequest { serverId: string }
+export interface McpAuthStatusResponse { status: 'unconfigured' | 'needs-auth' | 'authorizing' | 'authorized' | 'failed' }
 
 export interface McpServerToolsRequest {
   serverId: string
@@ -4874,6 +4882,9 @@ export interface IpcChannelMap {
   'mcp:stop-server': [McpStopServerRequest, McpStopServerResponse]
   'mcp:server-status': [McpServerStatusRequest, McpServerStatusResponse]
   'mcp:server-tools': [McpServerToolsRequest, McpServerToolsResponse]
+  'mcp:authorize': [McpAuthorizeRequest, McpAuthorizeResponse]
+  'mcp:deauthorize': [McpDeauthorizeRequest, McpDeauthorizeResponse]
+  'mcp:auth-status': [McpAuthStatusRequest, McpAuthStatusResponse]
 
   // Skills
   'skill:list': [SkillListRequest, SkillListResponse]

--- a/packages/protocol/src/schemas/index.ts
+++ b/packages/protocol/src/schemas/index.ts
@@ -781,6 +781,9 @@ export const IpcSchemaRegistry = {
     enabled: z.boolean().optional(),
   }),
   'mcp:delete': z.object({ id: z.string().uuid() }),
+  'mcp:authorize': z.object({ serverId: z.string().uuid() }),
+  'mcp:deauthorize': z.object({ serverId: z.string().uuid() }),
+  'mcp:auth-status': z.object({ serverId: z.string().uuid() }),
   'skill:list': z.object({ scope: z.string().min(1).max(80).optional() }),
   'skill:create': z.object({
     id: z.string().min(1).max(120),


### PR DESCRIPTION
### Motivation

- Add OAuth 2.0 (PKCE / DCR) support for MCP servers so HTTP/SSE MCP endpoints can require user authorization and have tokens injected into requests.
- Surface OAuth status and controls in the desktop UI and expose authorize/deauthorize flows over IPC so users can complete authorization from the app.

### Description

- Implemented a desktop-side `McpOAuthService` that manages OAuth flows with a loopback callback, secure token storage via `DesktopMcpOAuthStore`, static client migration, and `authorize`/`deauthorize` APIs; wired it into the main IPC (`mcp:create`, `mcp:update`, `mcp:authorize`, `mcp:deauthorize`, `mcp:auth-status`).
- Extended `McpService` to accept an optional token provider, prevent auto-start of OAuth-configured servers until authorized, and inject `Authorization: Bearer <token>` headers for HTTP/SSE transports when available; added `getServerAuthStatus` helper and `isOAuthMcpConfig` detection.
- Added agent-runtime OAuth helper library: `SparkMcpOAuthProvider`, `McpOAuthStore` interface, `InMemoryMcpOAuthStore`, plus exports and index wiring so runtime code can perform DCR/PKCE flows and persist discovery/client/tokens.
- Updated session/platform bridge logic and SDK server building to await token resolution and skip OAuth MCP servers when authorization is missing, and updated protocol and schemas to add `mcp:authorize`, `mcp:deauthorize`, and `mcp:auth-status` IPC messages and `authStatus` fields.
- Desktop UI changes in `McpView`: show auth status on MCP cards, add auth controls on cards, add OAuth settings in the add/edit drawer (scope, DCR toggle, client id/secret), and poll auth status when listing servers.
- Added unit tests `packages/agent-runtime/src/__tests__/mcp/oauth-provider.test.ts` for `SparkMcpOAuthProvider` behavior and store interactions, and exported runtime types in `packages/agent-runtime/src/index.ts`.

### Testing

- Added unit tests `packages/agent-runtime/src/__tests__/mcp/oauth-provider.test.ts` and ran them with `vitest`, and they passed. 
- Exercised IPC handlers locally by listing/creating/updating MCP servers and verifying UI shows auth controls and that `mcp:authorize` / `mcp:deauthorize` flows update status (manual verification during development).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c5cfd57f48328855c6ab610a413cc)