### PR TITLE
fix(website): exclude test files from tsc type check

### DIFF
--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -17,5 +17,6 @@
     "jsx": "react-jsx"
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"],
   "references": []
 }


### PR DESCRIPTION
CI 构建执行 tsc --noEmit 时，HomePage.test.tsx 导入的 vitest 模块 找不到（未在 devDependencies 中安装），导致类型检查失败、构建中断。
在 tsconfig.json 添加 exclude 规则，生产构建不再检查测试文件；
测试文件保留在仓库中，后续配置测试环境后可正常使用。