### PR TITLE
fix(canvas): agent 面板新建空画布默认展开 + 转剧本节点内容滚动

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -1505,6 +1505,7 @@
 
 .canvas-node-resource-text-icon {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   color: rgba(148, 163, 184, 0.54);
@@ -1512,6 +1513,7 @@
 
 .canvas-node-resource-text-content {
   min-height: 0;
+  flex: 1;
   overflow: auto;
   overscroll-behavior: contain;
   font-size: 13px;
@@ -1830,6 +1832,7 @@
 
 .canvas-node-resource-text-icon {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   color: rgba(148, 163, 184, 0.54);
@@ -1837,6 +1840,7 @@
 
 .canvas-node-resource-text-content {
   min-height: 0;
+  flex: 1;
   overflow: auto;
   overscroll-behavior: contain;
   font-size: 13px;

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -1,4 +1,13 @@
-import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  memo,
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { Button, Empty, Segmented, Tag } from '@lobehub/ui'
 import { Drawer, Input, Modal, Popover, Select, Spin, Tooltip, message } from 'antd'
 import { Icons } from '../../Icons'
@@ -1749,6 +1758,9 @@ export function CanvasWorkspaceView({
     undefined,
   )
   const [agentOpen, setAgentOpen] = useState(readAgentPanelOpen)
+  // 「新建空画布强制展开 Agent 面板」只判定一次：snapshot 首次加载完成且节点为空时强制展开。
+  // ref 守卫避免后续把节点删空时反复弹开；非空画布尊重用户上次的展开/折叠偏好（useState 已初始化）。
+  const forceExpandAgentOnEmptyCheckedRef = useRef(false)
   // 进入画布默认为平移模式：避免误触发框选/拖拽节点，更符合「先浏览」的直觉。
   const [activeTool, setActiveTool] = useState<CanvasTool>('pan')
   const [toolSwitchHint, setToolSwitchHint] = useState<{ tool: CanvasTool; nonce: number } | null>(
@@ -1895,6 +1907,15 @@ export function CanvasWorkspaceView({
       // Ignore storage failures.
     }
   }, [agentOpen])
+
+  // 进入「新建空画布」（首次加载即无节点）时强制展开 Agent 面板，方便用户立即开始对话；
+  // 已有内容的老画布尊重用户上次的展开/折叠偏好。useLayoutEffect 在浏览器绘制前定稿，避免一帧闪烁。
+  useLayoutEffect(() => {
+    if (forceExpandAgentOnEmptyCheckedRef.current) return
+    if (loading || !snapshot) return
+    forceExpandAgentOnEmptyCheckedRef.current = true
+    if (snapshot.nodes.length === 0) setAgentOpen(true)
+  }, [loading, snapshot])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
## 背景
用户反馈三个画布问题。本 PR 修复其中两个（1、3），第三个（4）经排查代码链路完整、未见静态 bug，详见下文。

## 1. 进入画布默认展开 Agent 面板 ✅ 已修复
**根因**：上个 PR 的「记住折叠偏好」迁移逻辑——只要用户折叠过一次，`localStorage` 里 `agent-panel-open='0'` 就一直被读回，导致每次进画布都折叠。代码逻辑自洽但不符合「进入即展开」诉求。

**修法（按用户确认的语义：折叠被记住，但新建空画布强制展开）**：
- `useState(readAgentPanelOpen)` 保留——已有内容的老画布尊重上次偏好。
- 新增 `useLayoutEffect`：snapshot 首次加载完成且**节点为 0**（即新建空画布）时 `setAgentOpen(true)`。
- 用 ref 守卫只触发一次（避免后续把节点删空时反复弹开）；`useLayoutEffect` 在绘制前定稿，避免一帧闪烁。

## 3. 转剧本节点内容无法滚动 ✅ 已修复
**根因**：`.canvas-node-resource-text-content` 缺 `flex:1`。它在 flex 列父容器 `.canvas-node-resource-text` 里默认 `flex:0 1 auto`，被父级 `overflow:hidden` 裁掉、`overflow:auto` 挂不上滚动 → 底部内容被切、滚轮无响应。对照普通文本分支 `.canvas-node-text` 是 `flex:1; min-height:0; overflow:auto` 三件套齐全能滚，只有 resource-text 这条漏了。

**修法**：给 `.canvas-node-resource-text-content` 补 `flex:1`（两份重复声明都改），图标 div 补 `flex:0 0 auto` 防被压缩。

> 注：画布全局规则刻意隐藏滚动条（`scrollbar-width:none` + `::-webkit-scrollbar{display:none}`），属设计选择——滚动靠滚轮/触控板/键盘，本 PR 不动它。如需为文本类节点单独放回可见滚动条，请另提。

## 4. 右键「添加到 Agent 对话」自动开面板 ⚠️ 未见静态 bug，待复测
逐段排查结论：菜单项（`CanvasNode.tsx` lobe-ui Dropdown + `CanvasStage.tsx` 自绘菜单）都正确接到 `handleAddNodeToAgent` / `handleAddSelectedToAgent`；两个 handler 都调了 `setAgentOpen(true)` + `closeCanvasFloatPanels('agent')`；`closeCanvasFloatPanels` 正确放过 agent；无任何 document 级监听或菜单关闭回调会把面板冲掉；合并后代码完整。**未改代码**。

最可能是测了合并前的旧构建。本 PR 修好问题 1 后面板默认就是开的，问题 4 场景（面板关着时右键）基本不再触发。请用新构建复测；若仍失败，我用 Spark Debug 插桩定位运行时原因。

## 验证
- `tsc --noEmit -p apps/desktop/tsconfig.json`：0 错误
- `canvasNodeHandleStyles.test.ts`（读取本次改动的 .less）：✅ 通过
- `canvasFileDrop.test.ts`：✅ 16/16

## 影响范围
仅 `apps/desktop/.../canvas/CanvasWorkspaceView.{tsx,less}`，2 文件 +26/-1。纯 renderer，不碰主进程 IPC，与并行开发无冲突。

Co-Authored-By: Claude <noreply@anthropic.com>