### PR TITLE
Agent panel default-expand

### DIFF
--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -1505,6 +1505,7 @@
 
 .canvas-node-resource-text-icon {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   color: rgba(148, 163, 184, 0.54);
@@ -1512,6 +1513,7 @@
 
 .canvas-node-resource-text-content {
   min-height: 0;
+  flex: 1;
   overflow: auto;
   overscroll-behavior: contain;
   font-size: 13px;
@@ -1830,6 +1832,7 @@
 
 .canvas-node-resource-text-icon {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   color: rgba(148, 163, 184, 0.54);
@@ -1837,6 +1840,7 @@
 
 .canvas-node-resource-text-content {
   min-height: 0;
+  flex: 1;
   overflow: auto;
   overscroll-behavior: contain;
   font-size: 13px;

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -1,4 +1,13 @@
-import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  memo,
+  startTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { Button, Empty, Segmented, Tag } from '@lobehub/ui'
 import { Drawer, Input, Modal, Popover, Select, Spin, Tooltip, message } from 'antd'
 import { Icons } from '../../Icons'
@@ -1749,6 +1758,9 @@ export function CanvasWorkspaceView({
     undefined,
   )
   const [agentOpen, setAgentOpen] = useState(readAgentPanelOpen)
+  // 「新建空画布强制展开 Agent 面板」只判定一次：snapshot 首次加载完成且节点为空时强制展开。
+  // ref 守卫避免后续把节点删空时反复弹开；非空画布尊重用户上次的展开/折叠偏好（useState 已初始化）。
+  const forceExpandAgentOnEmptyCheckedRef = useRef(false)
   // 进入画布默认为平移模式：避免误触发框选/拖拽节点，更符合「先浏览」的直觉。
   const [activeTool, setActiveTool] = useState<CanvasTool>('pan')
   const [toolSwitchHint, setToolSwitchHint] = useState<{ tool: CanvasTool; nonce: number } | null>(
@@ -1895,6 +1907,15 @@ export function CanvasWorkspaceView({
       // Ignore storage failures.
     }
   }, [agentOpen])
+
+  // 进入「新建空画布」（首次加载即无节点）时强制展开 Agent 面板，方便用户立即开始对话；
+  // 已有内容的老画布尊重用户上次的展开/折叠偏好。useLayoutEffect 在浏览器绘制前定稿，避免一帧闪烁。
+  useLayoutEffect(() => {
+    if (forceExpandAgentOnEmptyCheckedRef.current) return
+    if (loading || !snapshot) return
+    forceExpandAgentOnEmptyCheckedRef.current = true
+    if (snapshot.nodes.length === 0) setAgentOpen(true)
+  }, [loading, snapshot])
 
   useEffect(
     () => () => {


### PR DESCRIPTION
Agent panel default-expand:
- Entering a new/empty canvas (first load with zero nodes) now forces the
  agent panel open; existing canvases still honor the user's last
  expand/collapse preference. useLayoutEffect resolves before paint to avoid
  a one-frame flash, and a ref guard keeps it from re-popping when nodes are
  later deleted back to zero.

Resource-output (转剧本) text node could not scroll:
- .canvas-node-resource-text-content was missing flex:1, so inside its
  flex-column parent it got clipped by the parent overflow:hidden and
  overflow:auto never engaged -> bottom content cut off, wheel/touchpad did
  nothing. Added flex:1 to both duplicated declarations; added flex:0 0 auto
  to the resource-text icon so it isn't squeezed.