### PR TITLE
fix(canvas): preserve task diagnostics and runtime routing

### DIFF
--- a/apps/desktop/src/main/ipc/canvas-prompt-runtime.test.ts
+++ b/apps/desktop/src/main/ipc/canvas-prompt-runtime.test.ts
@@ -27,6 +27,9 @@ describe('canvas prompt runtime adapter', () => {
     expect(request.prompt).toBe('[角色 ref-1: 小满]\n雨夜')
     expect(request.prompt).not.toContain('只输出可执行分镜')
     expect(request.system).toContain('你是导演')
+    expect(request.system.indexOf('你是导演')).toBeLessThan(
+      request.system.indexOf('只输出可执行分镜'),
+    )
     expect(request.images).toEqual([{ url: 'https://cdn/ref.png' }])
     expect(request.relationManifest).toEqual([
       { blockId: 'r1', sourceNodeId: 'n1', relation: 'character', order: 0 },

--- a/apps/desktop/src/main/ipc/canvas-prompt-runtime.ts
+++ b/apps/desktop/src/main/ipc/canvas-prompt-runtime.ts
@@ -79,12 +79,14 @@ export function buildCanvasSystemPrompt(input: {
   negativePrompt?: string
 }): string {
   const sections = [
-    input.capabilityPrompt,
-    input.presetPrompt,
     input.agentPrompt,
     ...(input.skillPrompts && input.skillPrompts.length > 0
       ? [`[Selected Skills]\n${input.skillPrompts.filter((item) => item.trim()).join('\n\n')}`]
       : []),
+    input.presetPrompt,
+    // Functional capability contracts come last so an agent persona or selected
+    // skill cannot silently replace a required output schema.
+    input.capabilityPrompt,
     input.negativePrompt?.trim() ? `约束（不可违反）：${input.negativePrompt.trim()}` : undefined,
   ]
   return sections

--- a/apps/desktop/src/main/ipc/canvasTextTaskRuntime.test.ts
+++ b/apps/desktop/src/main/ipc/canvasTextTaskRuntime.test.ts
@@ -9,7 +9,7 @@ describe('canvasTextTaskRuntime', () => {
   it('routes custom providers through the session runtime when the selected agent uses Codex', () => {
     expect(
       resolveCanvasTextExecutionAdapter(
-        { id: 'custom-openai-provider' },
+        { id: 'custom-openai-provider', provider: 'openai', codexApiKind: 'chat' },
         { agentAdapter: 'codex' },
       ),
     ).toBe('codex')
@@ -18,18 +18,43 @@ describe('canvasTextTaskRuntime', () => {
   it('keeps ordinary API providers on the direct HTTP path for Claude agents', () => {
     expect(
       resolveCanvasTextExecutionAdapter(
-        { id: 'custom-anthropic-provider' },
+        { id: 'custom-anthropic-provider', provider: 'anthropic' },
         { agentAdapter: 'claude-sdk' },
       ),
     ).toBeNull()
   })
 
   it('preserves built-in local CLI routing', () => {
-    expect(resolveCanvasTextExecutionAdapter({ id: 'local-codex-cli' }, null)).toBe('codex')
-    expect(resolveCanvasTextExecutionAdapter({ id: 'local-cli' }, null)).toBe('claude-sdk')
     expect(
-      resolveCanvasTextExecutionAdapter({ id: 'local-cli' }, { agentAdapter: 'codex' }),
+      resolveCanvasTextExecutionAdapter({ id: 'local-codex-cli', provider: 'openai' }, null),
+    ).toBe('codex')
+    expect(
+      resolveCanvasTextExecutionAdapter({ id: 'local-cli', provider: 'anthropic' }, null),
     ).toBe('claude-sdk')
+    expect(
+      resolveCanvasTextExecutionAdapter(
+        { id: 'local-cli', provider: 'anthropic' },
+        { agentAdapter: 'codex' },
+      ),
+    ).toBe('claude-sdk')
+  })
+
+  it('keeps Anthropic-compatible API providers on Messages even for Codex agents', () => {
+    expect(
+      resolveCanvasTextExecutionAdapter(
+        { id: 'minimax-anthropic', provider: 'anthropic' },
+        { agentAdapter: 'codex' },
+      ),
+    ).toBeNull()
+  })
+
+  it('keeps legacy OpenAI-compatible Chat providers off the Responses runtime', () => {
+    expect(
+      resolveCanvasTextExecutionAdapter(
+        { id: 'legacy-deepseek', provider: 'openai' },
+        { agentAdapter: 'codex' },
+      ),
+    ).toBeNull()
   })
 
   it('resolves the requested model before agent and provider defaults', () => {

--- a/apps/desktop/src/main/ipc/canvasTextTaskRuntime.ts
+++ b/apps/desktop/src/main/ipc/canvasTextTaskRuntime.ts
@@ -11,12 +11,24 @@ export interface CanvasTextTaskAgentConfig {
 }
 
 export function resolveCanvasTextExecutionAdapter(
-  profile: Pick<ProviderProfile, 'id'>,
+  profile: Pick<ProviderProfile, 'id' | 'provider' | 'codexApiKind'>,
   agent: CanvasTextTaskAgentConfig | null,
 ): SessionAgentAdapter | null {
   if (isLocalCodexCliProvider(profile)) return 'codex'
   if (isBuiltInLocalCliProvider(profile)) return 'claude-sdk'
-  if (agent?.agentAdapter === 'codex') return 'codex'
+  // Agent adapter describes the preferred host, not the remote provider wire protocol.
+  // Anthropic-compatible profiles must stay on the direct Messages API path; forcing
+  // them through Codex would make the SDK probe a non-existent `/responses` WebSocket.
+  // Legacy OpenAI-compatible profiles may not have codexApiKind persisted. Keep those
+  // on the direct HTTP path, whose compatibility default is Chat Completions, instead
+  // of letting the session runtime default them to Responses.
+  if (
+    agent?.agentAdapter === 'codex' &&
+    profile.provider !== 'anthropic' &&
+    (profile.codexApiKind === 'chat' || profile.codexApiKind === 'responses')
+  ) {
+    return 'codex'
+  }
   return null
 }
 

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -714,7 +714,7 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
     setMaxClipCustom(SHOT_MAX_CLIP_PRESETS.includes(safeMaxClip) ? '' : String(safeMaxClip))
     // 只在切换节点时重载草稿，避免保存后的 snapshot 刷新把用户刚输入的配置重置掉。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [node.id])
+  }, [node.id, task?.id])
 
   useEffect(() => {
     let cancelled = false

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
@@ -9,6 +9,7 @@ import { CanvasTaskInputSnapshotList } from './CanvasTaskInputSnapshotList'
 
 type TaskFilter = 'all' | 'active' | 'failed' | 'completed'
 type ClearTaskScope = 'active' | 'failed'
+export type CanvasTaskRetryRuntimeSource = 'current-node' | 'original-task'
 
 export function CanvasTaskQueue({
   tasks,
@@ -26,7 +27,7 @@ export function CanvasTaskQueue({
   onCancelTask: (taskId: string) => void
   onClearTasks: (scope: ClearTaskScope) => void | Promise<void>
   onDeleteTasks: (taskIds: string[]) => void | Promise<void>
-  onRetryTask: (task: CanvasTask) => void
+  onRetryTask: (task: CanvasTask, runtimeSource: CanvasTaskRetryRuntimeSource) => void
   onSelectNode: (nodeId: string) => void
 }) {
   const [filter, setFilter] = useState<TaskFilter>('all')
@@ -428,34 +429,33 @@ function TaskDetailModal({
   assets: CanvasAsset[]
   onClose: () => void
   onCancelTask: (taskId: string) => void
-  onRetryTask: (task: CanvasTask) => void
+  onRetryTask: (task: CanvasTask, runtimeSource: CanvasTaskRetryRuntimeSource) => void
   onSelectNode: (nodeId: string) => void
 }) {
   if (!task) return null
 
   const inputNodes = nodes.filter((node) => task.inputNodeIds.includes(node.id))
   const outputNodes = nodes.filter((node) => task.outputNodeIds.includes(node.id))
-  // 节点已代表其背后资产（节点带 assetId）时，资产版块就是冗余展示，
-  // 节点版块既能定位跳转又带原标题。仅显示那些没被任何对应节点代表的纯资产引用。
-  const inputNodeAssetIds = new Set(
-    inputNodes.map((n) => n.assetId).filter((id): id is string => Boolean(id))
-  )
-  const outputNodeAssetIds = new Set(
-    outputNodes.map((n) => n.assetId).filter((id): id is string => Boolean(id))
-  )
-  const inputAssets = assets.filter(
-    (asset) => task.inputAssetIds.includes(asset.id) && !inputNodeAssetIds.has(asset.id)
-  )
-  const outputAssets = assets.filter(
-    (asset) => task.outputAssetIds.includes(asset.id) && !outputNodeAssetIds.has(asset.id)
-  )
-  const taskNode = nodes.find((node) => node.taskId === task.id)
+  // Keep assets visible even when a node also represents them. Diagnostic views favor
+  // complete lineage over UI deduplication.
+  const inputAssets = assets.filter((asset) => task.inputAssetIds.includes(asset.id))
+  const outputAssets = assets.filter((asset) => task.outputAssetIds.includes(asset.id))
+  const taskNode =
+    (task.operationNodeId
+      ? nodes.find((node) => node.id === task.operationNodeId)
+      : undefined) ?? nodes.find((node) => node.taskId === task.id)
   const canCancel = isTaskActive(task)
   const raw = isRecord(task.rawResponse) ? task.rawResponse : null
-  const outputText = stringField(raw?.outputText) || stringField(raw?.text)
+  const outputText =
+    task.modelOutputText || stringField(raw?.outputText) || stringField(raw?.text)
   const parsedEntities = raw?.parsedEntities
   const displayPrompt = task.compiledUserText || task.prompt || ''
-  const detailParams = buildCanvasTaskDetailParams(task)
+  const detailParams = {
+    ...buildCanvasTaskDetailParams(task),
+    ...(task.shotScriptConfig == null && taskNode?.data.shotScriptConfig
+      ? { shotScriptConfig: taskNode.data.shotScriptConfig }
+      : {}),
+  }
   const httpResponse = task.requestCall?.response
   const submitResponse = task.submitResponse ?? httpResponse?.body
   const providerResponseText = task.rawResponse != null ? formatJson(task.rawResponse) : ''
@@ -503,8 +503,13 @@ function TaskDetailModal({
           <Button size="middle" disabled={!canCancel} onClick={() => onCancelTask(task.id)}>
             中断取消
           </Button>
-          <Button size="middle" onClick={() => onRetryTask(task)}>
-            {task.status === 'failed' || task.status === 'cancelled' ? '重试' : '再次运行'}
+          {taskNode && (
+            <Button size="middle" onClick={() => onRetryTask(task, 'current-node')}>
+              使用当前节点模型重试
+            </Button>
+          )}
+          <Button size="middle" type="text" onClick={() => onRetryTask(task, 'original-task')}>
+            按原任务模型重试
           </Button>
         </Space>
 
@@ -526,9 +531,19 @@ function TaskDetailModal({
           ]}
         />
 
-        {outputText && (
-          <DetailBlock title="模型输出">
-            <pre>{outputText}</pre>
+        <DetailBlock title="模型原始输出（解析失败也保留）">
+          <pre>{outputText || '（Provider/Agent 未返回任何文本）'}</pre>
+        </DetailBlock>
+
+        {task.systemPrompt && (
+          <DetailBlock title="最终 System Prompt">
+            <pre>{task.systemPrompt}</pre>
+          </DetailBlock>
+        )}
+
+        {displayPrompt && (
+          <DetailBlock title="最终 User Prompt">
+            <pre>{displayPrompt}</pre>
           </DetailBlock>
         )}
 
@@ -600,36 +615,26 @@ function TaskDetailModal({
 
         <DetailBlock title="运行日志">
           <div className="canvas-task-log-list">
-            <TaskLogItem time={task.createdAt} label="任务创建" />
-            {(task.agentId || task.providerProfileId || task.modelId) && (
-              <TaskLogItem
-                time={task.updatedAt}
-                label={`运行配置：${[
-                  task.agentId ? `Agent ${task.agentId}` : '',
-                  task.providerProfileId ? `Profile ${task.providerProfileId}` : '',
-                  task.provider ? `Provider ${task.provider}` : '',
-                  task.modelId ? `Model ${task.modelId}` : '',
-                ]
-                  .filter(Boolean)
-                  .join(' / ')}`}
-              />
+            {task.runtimeEvents && task.runtimeEvents.length > 0 ? (
+              task.runtimeEvents.map((event, index) => (
+                <TaskLogItem
+                  key={`${event.at}-${event.kind}-${index}`}
+                  time={event.at}
+                  label={event.detail ? `${event.label}：${event.detail}` : event.label}
+                />
+              ))
+            ) : (
+              <>
+                <TaskLogItem time={task.createdAt} label="任务创建（旧任务无详细事件）" />
+                <TaskLogItem time={task.updatedAt} label={`最后状态：${task.status}`} />
+                {task.completedAt && <TaskLogItem time={task.completedAt} label="任务结束" />}
+              </>
             )}
-            {displayPrompt && (
-              <TaskLogItem time={task.updatedAt} label={`Prompt ${displayPrompt.length} 字符`} />
-            )}
-            {outputText && (
-              <TaskLogItem time={task.updatedAt} label={`模型输出 ${outputText.length} 字符`} />
-            )}
-            {task.requestId && (
-              <TaskLogItem time={task.updatedAt} label={`Provider request: ${task.requestId}`} />
-            )}
-            <TaskLogItem time={task.updatedAt} label={`状态更新为 ${task.status}`} />
-            {task.completedAt && <TaskLogItem time={task.completedAt} label="任务结束" />}
           </div>
         </DetailBlock>
 
         {shouldShowProviderResponse && (
-          <DetailBlock title="最终 Provider 响应">
+          <DetailBlock title="运行时 / Provider 诊断数据">
             <pre>{formatJson(task.rawResponse)}</pre>
           </DetailBlock>
         )}

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceSidePanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceSidePanel.tsx
@@ -5,7 +5,10 @@ import { downloadAsset } from './CanvasAssetsPanel'
 import { CanvasAssetManagerPanel } from './CanvasAssetManagerPanel'
 import { CanvasInspector } from './CanvasInspector'
 import { CanvasProjectInfoPanel } from './CanvasProjectInfoPanel'
-import { CanvasTaskQueue } from './CanvasTaskQueue'
+import {
+  CanvasTaskQueue,
+  type CanvasTaskRetryRuntimeSource,
+} from './CanvasTaskQueue'
 import type { CanvasNode, CanvasProjectSettings } from './canvas.types'
 
 export type CanvasSidePanelTab = 'details' | 'tasks' | 'assets' | 'project'
@@ -45,7 +48,7 @@ type CanvasWorkspaceSidePanelProps = {
   onCancelTask: (taskId: string) => void
   onClearTasks: (scope: any) => void
   onDeleteTasks: (taskIds: string[]) => void
-  onRetryTask: (task: any) => void
+  onRetryTask: (task: any, runtimeSource: CanvasTaskRetryRuntimeSource) => void
   onSelectNode: (nodeId: string) => void
   onInsertAsset: (assetId: string) => void
   onInsertSubview: (ownerAsset: any, sourceImageAsset: any, subview: any) => void

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -20,7 +20,10 @@ import {
   type CanvasStageViewportControls,
 } from './CanvasStage'
 import type { PendingCanvasConnection } from './canvasPendingConnection'
-import { CanvasTaskQueue } from './CanvasTaskQueue'
+import {
+  CanvasTaskQueue,
+  type CanvasTaskRetryRuntimeSource,
+} from './CanvasTaskQueue'
 import { CanvasToolbar, type CanvasTool } from './CanvasToolbar'
 import { downloadAsset, downloadCanvasResource } from './CanvasAssetsPanel'
 import { CanvasAssetManagerPanel } from './CanvasAssetManagerPanel'
@@ -125,7 +128,18 @@ import {
   CANVAS_FUNCTIONAL_MENU_LABEL,
   canvasBaseCreateOperations,
 } from './canvasNodeGenerationMenu'
-import { buildEntityExtractionPrompt, parseExtractedEntities } from './canvasEntityExtract'
+import {
+  buildEntityExtractionPrompt,
+  extractEntityKindLabel,
+  parseExtractedEntities,
+  resolveExtractEntityKindFromWorkflow,
+  type ExtractEntityKind,
+} from './canvasEntityExtract'
+import {
+  mergeCanvasTrackedWorkflowDiagnostics,
+  type CanvasTrackedWorkflowDiagnostics,
+  type CaptureCanvasTrackedWorkflowDiagnostics,
+} from './canvasTrackedWorkflowDiagnostics'
 import {
   DEFAULT_SHOT_SCRIPT_CONFIG,
   applyShotScriptConfigToPrompt,
@@ -175,7 +189,10 @@ import {
   type CanvasPromptSubmission,
 } from './canvasPromptSubmission'
 import { migrateLegacyPrompt } from './canvasPromptDocument'
-import { stripCanvasFunctionalPromptInput } from './canvasPromptInitialization'
+import {
+  normalizeCanvasFunctionalSystemPrompt,
+  stripCanvasFunctionalPromptInput,
+} from './canvasPromptInitialization'
 import { summarizeCanvasSelectionContext } from './canvasContextMenuModel'
 import {
   buildCanvasOperationSystemPrompt,
@@ -218,16 +235,11 @@ import './CanvasWorkspaceView.less'
 import './uiux-v4/index.less'
 
 type CanvasPoint = { x: number; y: number }
-type TrackedCanvasWorkflowResult = {
+type TrackedCanvasWorkflowResult = CanvasTrackedWorkflowDiagnostics & {
   count?: number
   outputNodeIds?: string[]
   outputAssetIds?: string[]
   message?: string
-  rawResponse?: unknown
-  agentId?: string | null
-  providerProfileId?: string | null
-  provider?: string | null
-  modelId?: string | null
 }
 type PreparedImageUpload = {
   file: File
@@ -4882,8 +4894,13 @@ export function CanvasWorkspaceView({
       modelId?: string
       skillIds?: string[]
       modelParams?: Record<string, unknown>
+      taskPipelineRole?: CanvasPipelineRole
+      outputPipelineRole?: CanvasPipelineRole
+      shotScriptConfig?: ShotScriptConfig
     } & CanvasPromptTaskFields,
-    run: () => Promise<TrackedCanvasWorkflowResult>,
+    run: (
+      captureDiagnostics: CaptureCanvasTrackedWorkflowDiagnostics,
+    ) => Promise<TrackedCanvasWorkflowResult>,
   ): Promise<TrackedCanvasWorkflowResult> => {
     const snapshot = snapshotRef.current
     if (!snapshot) throw new Error('画布尚未加载')
@@ -4909,6 +4926,9 @@ export function CanvasWorkspaceView({
       ...(request.modelId ? { modelId: request.modelId } : {}),
       ...(request.skillIds ? { skillIds: request.skillIds } : {}),
       ...(request.modelParams ? { modelParams: request.modelParams } : {}),
+      ...(request.taskPipelineRole ? { taskPipelineRole: request.taskPipelineRole } : {}),
+      ...(request.outputPipelineRole ? { outputPipelineRole: request.outputPipelineRole } : {}),
+      ...(request.shotScriptConfig ? { shotScriptConfig: request.shotScriptConfig } : {}),
       ...(request.promptDocument ? { promptDocument: request.promptDocument } : {}),
       ...(request.promptSnapshot ? { promptSnapshot: request.promptSnapshot } : {}),
       ...(request.compiledUserText !== undefined
@@ -4923,20 +4943,36 @@ export function CanvasWorkspaceView({
     await refreshTaskSnapshot()
     restoreCanvasViewport(viewportBeforeRun)
 
+    let diagnostics: CanvasTrackedWorkflowDiagnostics = {}
+    const captureDiagnostics: CaptureCanvasTrackedWorkflowDiagnostics = (next) => {
+      diagnostics = mergeCanvasTrackedWorkflowDiagnostics(diagnostics, next)
+    }
     try {
-      const result = await run()
+      const result = await run(captureDiagnostics)
+      const effectiveDiagnostics = mergeCanvasTrackedWorkflowDiagnostics(diagnostics, result)
       await canvasApi.finishWorkflowTask(projectId, taskId, {
         status: 'completed',
         ...(result.outputNodeIds ? { outputNodeIds: result.outputNodeIds } : {}),
         ...(result.outputAssetIds ? { outputAssetIds: result.outputAssetIds } : {}),
         ...(result.message ? { message: result.message } : {}),
-        ...(result.rawResponse !== undefined ? { rawResponse: result.rawResponse } : {}),
-        ...(result.agentId !== undefined ? { agentId: result.agentId } : {}),
-        ...(result.providerProfileId !== undefined
-          ? { providerProfileId: result.providerProfileId }
+        ...(effectiveDiagnostics.rawResponse !== undefined
+          ? { rawResponse: effectiveDiagnostics.rawResponse }
           : {}),
-        ...(result.provider !== undefined ? { provider: result.provider } : {}),
-        ...(result.modelId !== undefined ? { modelId: result.modelId } : {}),
+        ...(effectiveDiagnostics.modelOutputText !== undefined
+          ? { modelOutputText: effectiveDiagnostics.modelOutputText }
+          : {}),
+        ...(effectiveDiagnostics.agentId !== undefined
+          ? { agentId: effectiveDiagnostics.agentId }
+          : {}),
+        ...(effectiveDiagnostics.providerProfileId !== undefined
+          ? { providerProfileId: effectiveDiagnostics.providerProfileId }
+          : {}),
+        ...(effectiveDiagnostics.provider !== undefined
+          ? { provider: effectiveDiagnostics.provider }
+          : {}),
+        ...(effectiveDiagnostics.modelId !== undefined
+          ? { modelId: effectiveDiagnostics.modelId }
+          : {}),
       })
       await refreshTaskSnapshot()
       restoreCanvasViewport(viewportBeforeRun)
@@ -4948,6 +4984,16 @@ export function CanvasWorkspaceView({
         errorMsg: 'workflow_failed',
         errorDetail: errorMessage,
         message: `失败：${errorMessage}`,
+        ...(diagnostics.rawResponse !== undefined ? { rawResponse: diagnostics.rawResponse } : {}),
+        ...(diagnostics.modelOutputText !== undefined
+          ? { modelOutputText: diagnostics.modelOutputText }
+          : {}),
+        ...(diagnostics.agentId !== undefined ? { agentId: diagnostics.agentId } : {}),
+        ...(diagnostics.providerProfileId !== undefined
+          ? { providerProfileId: diagnostics.providerProfileId }
+          : {}),
+        ...(diagnostics.provider !== undefined ? { provider: diagnostics.provider } : {}),
+        ...(diagnostics.modelId !== undefined ? { modelId: diagnostics.modelId } : {}),
       })
       await refreshTaskSnapshot()
       restoreCanvasViewport(viewportBeforeRun)
@@ -5520,6 +5566,12 @@ export function CanvasWorkspaceView({
       case 'screenplay.extract_scenes':
         await handlePrepareExtractEntitiesOperation(textSourceNode, sourceText, 'scene')
         break
+      case 'screenplay.extract_props':
+        await handlePrepareExtractEntitiesOperation(textSourceNode, sourceText, 'prop')
+        break
+      case 'screenplay.extract_effects':
+        await handlePrepareExtractEntitiesOperation(textSourceNode, sourceText, 'effect')
+        break
       case 'screenplay.storyboard_grid':
         handleStoryboardGridFromNode(textSourceNode)
         break
@@ -5821,6 +5873,7 @@ export function CanvasWorkspaceView({
       nodeMessage: '确认分镜脚本 Prompt、Agent 与模型后点击开始任务',
       taskPipelineRole: 'shot',
       outputPipelineRole: 'shot',
+      modelParams: { workflow: 'shot_script', responseFormat: 'json' },
       shotScriptConfig: DEFAULT_SHOT_SCRIPT_CONFIG,
     })
   }
@@ -5848,7 +5901,7 @@ export function CanvasWorkspaceView({
   const handlePrepareExtractEntitiesOperation = async (
     node: CanvasNode,
     sourceText: string,
-    kind: 'character' | 'scene',
+    kind: ExtractEntityKind,
   ) => {
     if (!sourceText) {
       message.warning('该节点没有可用文本，无法抽取')
@@ -5856,7 +5909,7 @@ export function CanvasWorkspaceView({
     }
     const snapshot = snapshotRef.current
     if (!snapshot) return
-    const label = kind === 'character' ? '提取角色' : '提取场景'
+    const label = `提取${extractEntityKindLabel(kind)}`
     const styleBible = buildProductionBiblePrompt(snapshot.project.metadata)
     await createConfiguredOperationNode({
       sourceNode: node,
@@ -5866,6 +5919,7 @@ export function CanvasWorkspaceView({
       nodeMessage: `确认${label} Prompt、Agent 与模型后点击开始任务`,
       modelParams: { workflow: `extract_${kind}`, responseFormat: 'json' },
       taskPipelineRole: kind,
+      outputPipelineRole: kind,
     })
   }
 
@@ -6422,13 +6476,16 @@ export function CanvasWorkspaceView({
         ? { systemPrompt: stripCanvasFunctionalPromptInput(promptPlaceholder, op.id) }
         : {}),
       message: '请连接上游文本节点并确认 Prompt 后开始任务',
+      ...(op.produces ? { taskPipelineRole: op.produces } : {}),
       ...(op.produces ? { outputPipelineRole: op.produces } : {}),
       ...(op.id === 'screenplay.to_shot_script'
         ? { shotScriptConfig: DEFAULT_SHOT_SCRIPT_CONFIG }
         : {}),
       ...(op.kind === 'extract'
         ? { modelParams: { workflow: `extract_${op.extractKind}`, responseFormat: 'json' } }
-        : {}),
+        : op.id === 'screenplay.to_shot_script'
+          ? { modelParams: { workflow: 'shot_script', responseFormat: 'json' } }
+          : {}),
     })
     const created = findLatestCreatedOperationNode(next?.nodes ?? [], operation, existingNodeIds)
     if (created) {
@@ -6450,7 +6507,7 @@ export function CanvasWorkspaceView({
   const handleExtractEntities = async (
     node: CanvasNode,
     sourceText: string,
-    kind: 'character' | 'scene',
+    kind: ExtractEntityKind,
     options: {
       prompt?: string
       userPrompt?: string
@@ -6472,7 +6529,7 @@ export function CanvasWorkspaceView({
     }
     const snapshot = snapshotRef.current
     if (!snapshot) return
-    const label = kind === 'character' ? '提取角色' : '提取场景'
+    const label = `提取${extractEntityKindLabel(kind)}`
     const styleBible = buildProductionBiblePrompt(snapshot.project.metadata)
     const extractionPrompt =
       options.promptSubmission?.prompt.trim() ||
@@ -6506,9 +6563,11 @@ export function CanvasWorkspaceView({
           message: `正在${label}...`,
           ...runtime,
           modelParams: extractionModelParams,
+          taskPipelineRole: kind,
+          outputPipelineRole: kind,
           ...promptTaskFields,
         },
-        async () => {
+        async (captureDiagnostics) => {
           const response = await window.spark.invoke('canvas:task:generate-text', {
             ...(options.promptSubmission ?? {}),
             operation: 'text_generate',
@@ -6519,6 +6578,18 @@ export function CanvasWorkspaceView({
             ...(runtime.reasoningEffort ? { reasoningEffort: runtime.reasoningEffort } : {}),
             ...(runtime.skillIds ? { skillIds: runtime.skillIds } : {}),
             modelParams: extractionModelParams,
+          })
+          captureDiagnostics({
+            modelOutputText: response.text,
+            rawResponse:
+              response.rawResponse ?? {
+                status: response.status,
+                error: response.error ?? null,
+              },
+            agentId: runtime.agentId ?? null,
+            providerProfileId: (response.providerProfileId || runtime.providerProfileId) ?? null,
+            provider: response.provider || null,
+            modelId: (response.model || runtime.modelId) ?? null,
           })
           if (response.status !== 'succeeded' || !response.text) {
             throw new Error(response.error?.message ?? '抽取失败')
@@ -6987,16 +7058,70 @@ export function CanvasWorkspaceView({
     })
   }
 
-  const handleRetryTask = async (task: CanvasTask) => {
+  const handleRetryTask = async (
+    task: CanvasTask,
+    runtimeSource: CanvasTaskRetryRuntimeSource,
+  ) => {
     const snapshot = snapshotRef.current
     if (!snapshot) return
-    const taskNode = snapshot.nodes.find((node) => node.taskId === task.id)
+    const taskNode =
+      (task.operationNodeId
+        ? snapshot.nodes.find((node) => node.id === task.operationNodeId)
+        : undefined) ?? snapshot.nodes.find((node) => node.taskId === task.id)
+    const retryModelParams =
+      runtimeSource === 'current-node'
+        ? { ...task.modelParams, ...(taskNode?.data.modelParams ?? {}) }
+        : task.modelParams
+    const retryExtractKind = resolveExtractEntityKindFromWorkflow(retryModelParams.workflow)
+    if (taskNode && isOperationNode(taskNode) && retryExtractKind) {
+      const retryInputNodes = task.inputNodeIds
+        .map((nodeId) => snapshot.nodes.find((node) => node.id === nodeId && !node.hidden))
+        .filter((node): node is CanvasNode => node != null)
+      const sourceNode = retryInputNodes[0]
+      const sourceText = retryInputNodes
+        .map((node) => resolveCanvasPipelineTextSource(node, snapshot).sourceText.trim())
+        .filter(Boolean)
+        .join('\n\n')
+      if (!sourceNode || !sourceText) {
+        message.warning('该抽取任务的原始输入已不存在，无法重试')
+        return
+      }
+      const runtime = runtimeSource === 'current-node' ? taskNode.data : task
+      const promptSubmission: CanvasPromptSubmission = {
+        prompt: task.compiledUserText ?? task.prompt ?? sourceText,
+        ...pickCanvasPromptTaskFields(task),
+      }
+      const viewportBeforeRetry = await persistCurrentCanvasViewport()
+      try {
+        await handleExtractEntities(sourceNode, sourceText, retryExtractKind, {
+          promptSubmission,
+          ...(task.prompt != null ? { userPrompt: task.prompt } : {}),
+          ...(runtime.agentId ? { agentId: runtime.agentId } : {}),
+          ...(runtime.providerProfileId
+            ? { providerProfileId: runtime.providerProfileId }
+            : {}),
+          ...(runtime.modelId ? { modelId: runtime.modelId } : {}),
+          ...(runtime.reasoningEffort ? { reasoningEffort: runtime.reasoningEffort } : {}),
+          ...(runtime.skillIds ? { skillIds: runtime.skillIds } : {}),
+          modelParams: retryModelParams,
+          bindToNodeId: taskNode.id,
+          inputNodeIds: task.inputNodeIds,
+          inputAssetIds: task.inputAssetIds,
+        })
+      } finally {
+        restoreCanvasViewport(viewportBeforeRetry)
+      }
+      return
+    }
     // 失败/取消的任务如果存在关联的操作节点，则绑定到原节点重试，
     // 这样原节点的状态会立即刷新为「运行中」，而不是留下一个显示「失败」的旧节点。
     if (taskNode && isOperationNode(taskNode)) {
       const viewportBeforeRetry = await persistCurrentCanvasViewport()
       try {
-        await retryOperationNode(taskNode.id)
+        await retryOperationNode(taskNode.id, {
+          sourceTaskId: task.id,
+          runtimeSource,
+        })
       } finally {
         restoreCanvasViewport(viewportBeforeRetry)
       }
@@ -7134,12 +7259,13 @@ export function CanvasWorkspaceView({
                       opTask && typeof opTask.modelParams?.workflow === 'string'
                         ? opTask.modelParams.workflow
                         : ''
+                    const extractKind = resolveExtractEntityKindFromWorkflow(workflow)
                     // 统一行为：先收起弹窗，再继续执行任务，避免提交后弹窗长时间不关。
                     const closePanel = () => {
                       setActiveOperationPanelNodeId(null)
                       setSelectedNodeIds([])
                     }
-                    if (workflow === 'extract_character' || workflow === 'extract_scene') {
+                    if (extractKind) {
                       const sourceNode = hydratedTaskInputNodes[0]
                       if (!sourceNode) {
                         message.warning('该抽取节点缺少原始输入，无法重新执行')
@@ -7209,7 +7335,7 @@ export function CanvasWorkspaceView({
                       void handleExtractEntities(
                         sourceNode,
                         sourceText,
-                        workflow === 'extract_character' ? 'character' : 'scene',
+                        extractKind,
                         {
                           prompt: promptSubmission.prompt,
                           userPrompt: params.prompt,
@@ -7259,7 +7385,10 @@ export function CanvasWorkspaceView({
                       })
                     const resolvedPreset = readCanvasResolvedPresetTarget(presetTargetId)
                     const systemPrompt =
-                      params.systemPrompt?.trim() ||
+                      normalizeCanvasFunctionalSystemPrompt(
+                        params.systemPrompt,
+                        presetTargetId,
+                      ) ||
                       buildCanvasOperationSystemPrompt(operation, resolvedPreset.prompt)
                     const promptSubmission = await buildCanvasPromptSubmission({
                       document: promptDocument,
@@ -7332,6 +7461,9 @@ export function CanvasWorkspaceView({
                         ...(Object.keys(styledTask.modelParams).length > 0
                           ? { modelParams: styledTask.modelParams }
                           : {}),
+                        ...(params.shotScriptConfig
+                          ? { shotScriptConfig: params.shotScriptConfig }
+                          : {}),
                         ...(params.skipParameterValidation
                           ? { skipParameterValidation: true }
                           : {}),
@@ -7350,6 +7482,10 @@ export function CanvasWorkspaceView({
                     }
                   }}
                   onRetry={async () => {
+                    if (opTask) {
+                      await handleRetryTask(opTask, 'current-node')
+                      return
+                    }
                     const viewportBeforeRetry = await persistCurrentCanvasViewport()
                     try {
                       await retryOperationNode(opNode.id)
@@ -7372,7 +7508,14 @@ export function CanvasWorkspaceView({
                       ...opNode.data,
                       ...(params.promptDocument ? { promptDocument: params.promptDocument } : {}),
                       ...(params.inputBindings ? { inputBindings: params.inputBindings } : {}),
-                      ...(params.systemPrompt ? { systemPrompt: params.systemPrompt } : {}),
+                      ...(params.systemPrompt
+                        ? {
+                            systemPrompt: normalizeCanvasFunctionalSystemPrompt(
+                              params.systemPrompt,
+                              presetTargetId,
+                            ),
+                          }
+                        : {}),
                       negativePrompt: params.negativePrompt,
                       message: params.message,
                       modelParams: params.modelParams,
@@ -8041,7 +8184,9 @@ export function CanvasWorkspaceView({
                   onCancelTask={(taskId) => void cancelTask(taskId)}
                   onClearTasks={(scope) => void clearTasks(scope)}
                   onDeleteTasks={(taskIds) => void deleteTasks(taskIds)}
-                  onRetryTask={(task) => void handleRetryTask(task)}
+                  onRetryTask={(task, runtimeSource) =>
+                    void handleRetryTask(task, runtimeSource)
+                  }
                   onSelectNode={(nodeId) => setSelectedNodeIds([nodeId])}
                 />
               </div>
@@ -8106,7 +8251,11 @@ export function CanvasWorkspaceView({
           tasks={snapshot.tasks}
           onInsertAsset={(assetId) => void handleInsertAsset(assetId)}
           onLocateTaskNode={(taskId) => {
-            const node = snapshot.nodes.find((n) => n.taskId === taskId)
+            const task = snapshot.tasks.find((candidate) => candidate.id === taskId)
+            const node =
+              (task?.operationNodeId
+                ? snapshot.nodes.find((candidate) => candidate.id === task.operationNodeId)
+                : undefined) ?? snapshot.nodes.find((candidate) => candidate.taskId === taskId)
             if (node) {
               setSelectedNodeIds([node.id])
               message.info(`已定位到任务节点：${node.title ?? node.type}`)
@@ -8114,7 +8263,7 @@ export function CanvasWorkspaceView({
           }}
           onRetryTask={(taskId) => {
             const task = snapshot.tasks.find((t) => t.id === taskId)
-            if (task) void handleRetryTask(task)
+            if (task) void handleRetryTask(task, 'original-task')
           }}
         />
       </Drawer>

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -6,6 +6,7 @@ import type {
   CanvasNode,
   CanvasNodeType,
   CanvasOperationType,
+  CanvasPipelineRole,
   CanvasProject,
   CanvasProjectSettings,
   CanvasSnapshot,
@@ -89,8 +90,18 @@ import type {
 import { buildCanvasRetryInputRoles, pickCanvasPromptTaskFields } from './canvasPromptTaskFields'
 import { buildTaskInputFiles } from './canvasTaskInputFiles'
 import { summarizeCanvasTaskInputFiles } from './canvasTaskInputDiagnostics'
+import {
+  appendCanvasTaskRuntimeEvent,
+  appendCanvasTaskModelOutputEvent,
+  initialCanvasTaskRuntimeEvents,
+  syncCanvasNodeRuntimeData,
+  syncCanvasTaskRuntimeToNode,
+} from './canvasTaskLifecycle'
 import { materializeCanvasTaskInputFiles } from './canvasWorkspaceTaskInput'
-import { buildCanvasVisiblePromptDocument } from './canvasPromptInitialization'
+import {
+  buildCanvasVisiblePromptDocument,
+  normalizeCanvasFunctionalSystemPrompt,
+} from './canvasPromptInitialization'
 import { reconcilePromptConnections } from './canvasPromptConnections'
 import {
   buildCanvasOperationSystemPrompt,
@@ -218,6 +229,9 @@ type CanvasWorkflowTaskStartRequest = {
   reasoningEffort?: SessionReasoningEffort
   skillIds?: string[]
   modelParams?: Record<string, unknown>
+  taskPipelineRole?: CanvasPipelineRole
+  outputPipelineRole?: CanvasPipelineRole
+  shotScriptConfig?: ShotScriptConfig
 } & CanvasPromptTaskFields
 
 type CanvasWorkflowTaskFinishRequest = {
@@ -229,6 +243,7 @@ type CanvasWorkflowTaskFinishRequest = {
   errorMsg?: string | null
   errorDetail?: string | null
   rawResponse?: unknown
+  modelOutputText?: string | null
   agentId?: string | null
   providerProfileId?: string | null
   provider?: string | null
@@ -417,6 +432,7 @@ export function isCanvasDirty(projectId: string): boolean {
 export function __resetCanvasHotCache(): void {
   hotMemory = null
   hotOverflow = null
+  canvasTaskDiagnosticsMigratedDbs = new WeakSet<CanvasDb>()
   if (hotPersistTimer != null) {
     clearTimeout(hotPersistTimer)
     hotPersistTimer = null
@@ -635,6 +651,7 @@ function readDb(): CanvasDb {
   // 内存缓存优先：首次加载后不再重复 JSON.parse（性能关键路径）
   if (hotMemory != null) {
     migrateFilmAssetDbInPlace(hotMemory)
+    migrateCanvasTaskDiagnosticsInPlace(hotMemory)
     return hotMemory
   }
   // 内存兜底优先：此时 localStorage 是不完整/过期的
@@ -642,6 +659,7 @@ function readDb(): CanvasDb {
     const parsed = { ...emptyDb(), ...cloneDb(hotOverflow) }
     hotMemory = parsed
     migrateFilmAssetDbInPlace(parsed)
+    migrateCanvasTaskDiagnosticsInPlace(parsed)
     return parsed
   }
   try {
@@ -654,6 +672,7 @@ function readDb(): CanvasDb {
     const parsed = { ...emptyDb(), ...JSON.parse(raw) } as CanvasDb
     hotMemory = parsed
     migrateFilmAssetDbInPlace(parsed)
+    migrateCanvasTaskDiagnosticsInPlace(parsed)
     return parsed
   } catch {
     const empty = emptyDb()
@@ -682,6 +701,73 @@ function migrateFilmAssetDbInPlace(db: CanvasDb): void {
     // persistHotDb 内部已处理配额失败（转内存），不会抛
     persistHotDb(db)
   }
+}
+
+/** Backfill optional diagnostic fields without changing task content or status. */
+let canvasTaskDiagnosticsMigratedDbs = new WeakSet<CanvasDb>()
+function migrateCanvasTaskDiagnosticsInPlace(db: CanvasDb): void {
+  if (canvasTaskDiagnosticsMigratedDbs.has(db)) return
+  let touched = false
+  const nodeById = new Map(db.nodes.map((node) => [node.id, node]))
+  const operationNodeByTaskId = new Map<string, CanvasNode>()
+  for (const node of db.nodes) {
+    if (node.taskId && isOperationNode(node)) operationNodeByTaskId.set(node.taskId, node)
+  }
+  for (const edge of db.edges) {
+    if (!edge.taskId || operationNodeByTaskId.has(edge.taskId)) continue
+    const operationNodeId =
+      edge.type === 'used_as_input'
+        ? edge.targetNodeId
+        : edge.type === 'generated'
+          ? edge.sourceNodeId
+          : null
+    const operationNode = operationNodeId ? nodeById.get(operationNodeId) : undefined
+    if (operationNode && isOperationNode(operationNode)) {
+      operationNodeByTaskId.set(edge.taskId, operationNode)
+    }
+  }
+  for (const task of db.tasks) {
+    const operationNode = operationNodeByTaskId.get(task.id)
+    if (task.operationNodeId == null && operationNode) {
+      task.operationNodeId = operationNode.id
+      touched = true
+    }
+    if (task.taskPipelineRole === undefined && operationNode?.data.pipelineRole) {
+      task.taskPipelineRole = operationNode.data.pipelineRole
+      touched = true
+    }
+    if (task.outputPipelineRole === undefined && operationNode?.data.outputPipelineRole) {
+      task.outputPipelineRole = operationNode.data.outputPipelineRole
+      touched = true
+    }
+    if (
+      task.completedAt == null &&
+      (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled')
+    ) {
+      task.completedAt = task.updatedAt
+      touched = true
+    }
+    if (
+      task.modelOutputText == null &&
+      task.rawResponse != null &&
+      typeof task.rawResponse === 'object' &&
+      !Array.isArray(task.rawResponse)
+    ) {
+      const rawResponse = task.rawResponse as Record<string, unknown>
+      const legacyOutput =
+        typeof rawResponse.outputText === 'string'
+          ? rawResponse.outputText
+          : typeof rawResponse.text === 'string'
+            ? rawResponse.text
+            : ''
+      if (legacyOutput.trim()) {
+        task.modelOutputText = legacyOutput
+        touched = true
+      }
+    }
+  }
+  canvasTaskDiagnosticsMigratedDbs.add(db)
+  if (touched) persistHotDb(db)
 }
 
 /**
@@ -3848,12 +3934,17 @@ export const canvasApi = {
       node.data = nextData
       node.updatedAt = at
 
-      // Operation node data is the editable configuration shown to the user/Agent.
-      // Keep the bound task aligned so retry uses the latest persisted values.
+      // Operation node data is editable current configuration. Only the pending
+      // placeholder task may follow those edits; once execution starts, the task is
+      // an immutable diagnostic snapshot used by history and original-task retry.
       const task = node.taskId
         ? db.tasks.find((item) => item.id === node.taskId && item.projectId === projectId)
         : null
-      if (task) {
+      if (
+        task?.status === 'pending' &&
+        task.outputNodeIds.length === 0 &&
+        task.outputAssetIds.length === 0
+      ) {
         if (Object.prototype.hasOwnProperty.call(data, 'prompt')) task.prompt = data.prompt ?? null
         if (Object.prototype.hasOwnProperty.call(data, 'negativePrompt'))
           task.negativePrompt = data.negativePrompt ?? null
@@ -3871,6 +3962,8 @@ export const canvasApi = {
           task.skillIds = data.skillIds ?? []
         if (Object.prototype.hasOwnProperty.call(data, 'reasoningEffort'))
           task.reasoningEffort = data.reasoningEffort ?? null
+        if (Object.prototype.hasOwnProperty.call(data, 'shotScriptConfig'))
+          task.shotScriptConfig = data.shotScriptConfig ?? null
         task.updatedAt = at
       }
 
@@ -4027,6 +4120,7 @@ export const canvasApi = {
         ? { outputPipelineRole: request.outputPipelineRole }
         : {}),
     }
+    syncCanvasNodeRuntimeData(taskNodeData, request)
     const requestPrompt = request.promptDocument
       ? (request.compiledUserText ?? request.prompt)
       : buildCanvasOperationPrompt(request.operation, request.prompt)
@@ -4064,6 +4158,7 @@ export const canvasApi = {
       status: 'pending',
       progress: 12,
       title: defaultTaskTitle,
+      operationNodeId: taskNode.id,
       prompt: requestPrompt ?? null,
       negativePrompt: request.negativePrompt ?? null,
       inputNodeIds: request.inputNodeIds ?? [],
@@ -4077,6 +4172,10 @@ export const canvasApi = {
       modelId: request.modelId ?? null,
       reasoningEffort: request.reasoningEffort ?? null,
       modelParams: request.modelParams ?? {},
+      taskPipelineRole: request.taskPipelineRole ?? null,
+      outputPipelineRole: request.outputPipelineRole ?? null,
+      shotScriptConfig: request.shotScriptConfig ?? null,
+      runtimeEvents: initialCanvasTaskRuntimeEvents(at),
       ...pickCanvasPromptTaskFields(request),
       createdAt: at,
       updatedAt: at,
@@ -4148,6 +4247,11 @@ export const canvasApi = {
     if (request.reasoningEffort != null) taskNodeData.reasoningEffort = request.reasoningEffort
     if (request.skillIds != null) taskNodeData.skillIds = request.skillIds
     if (request.modelParams != null) taskNodeData.modelParams = request.modelParams
+    if (request.taskPipelineRole != null) taskNodeData.pipelineRole = request.taskPipelineRole
+    if (request.outputPipelineRole != null)
+      taskNodeData.outputPipelineRole = request.outputPipelineRole
+    if (request.shotScriptConfig != null)
+      taskNodeData.shotScriptConfig = request.shotScriptConfig
 
     let taskNode: CanvasNode
     const bindNode = request.bindToNodeId
@@ -4201,6 +4305,7 @@ export const canvasApi = {
       status: 'running',
       progress,
       title: request.title,
+      operationNodeId: taskNode.id,
       prompt: requestPrompt ?? null,
       negativePrompt: null,
       inputNodeIds: request.inputNodeIds ?? [],
@@ -4215,6 +4320,10 @@ export const canvasApi = {
       modelId: request.modelId ?? null,
       reasoningEffort: request.reasoningEffort ?? null,
       modelParams: request.modelParams ?? {},
+      taskPipelineRole: request.taskPipelineRole ?? null,
+      outputPipelineRole: request.outputPipelineRole ?? null,
+      shotScriptConfig: request.shotScriptConfig ?? null,
+      runtimeEvents: initialCanvasTaskRuntimeEvents(at, '本地工作流任务创建'),
       ...pickCanvasPromptTaskFields(request),
       createdAt: at,
       updatedAt: at,
@@ -4264,10 +4373,26 @@ export const canvasApi = {
     if (result.errorMsg !== undefined) task.errorMsg = result.errorMsg
     if (result.errorDetail !== undefined) task.errorDetail = result.errorDetail
     if (result.rawResponse !== undefined) task.rawResponse = result.rawResponse
+    if (result.modelOutputText !== undefined) task.modelOutputText = result.modelOutputText
     if (result.agentId !== undefined) task.agentId = result.agentId
     if (result.providerProfileId !== undefined) task.providerProfileId = result.providerProfileId
     if (result.provider !== undefined) task.provider = result.provider
     if (result.modelId !== undefined) task.modelId = result.modelId
+    if (result.modelOutputText != null) {
+      appendCanvasTaskModelOutputEvent(task, at, result.modelOutputText)
+    }
+    appendCanvasTaskRuntimeEvent(task, {
+      at,
+      kind:
+        status === 'completed' ? 'completed' : status === 'cancelled' ? 'cancelled' : 'failed',
+      label:
+        status === 'completed'
+          ? '本地工作流完成'
+          : status === 'cancelled'
+            ? '本地工作流已取消'
+            : '本地工作流失败',
+      ...(task.errorDetail ? { detail: task.errorDetail } : {}),
+    })
 
     const defaultMessage =
       status === 'completed'
@@ -4377,11 +4502,19 @@ export const canvasApi = {
     const operationPreset = readCanvasResolvedPresetTarget(presetTargetId, {
       hasImageInput: inputNodes.some((node) => node.type === 'image'),
     })
+    const explicitSystemPrompt = normalizeCanvasFunctionalSystemPrompt(
+      nonEmptyString(input.systemPrompt),
+      presetTargetId,
+    )
     const systemPrompt = buildCanvasOperationSystemPrompt(
       input.operation,
-      operationPreset.prompt,
+      // An explicit functional contract is authoritative. Generic operation presets
+      // are only a fallback for generic nodes and must not be concatenated into it.
+      explicitSystemPrompt.length === 0 || presetTargetId !== input.operation
+        ? operationPreset.prompt
+        : undefined,
       project?.settings?.prompt,
-      input.systemPrompt,
+      explicitSystemPrompt || undefined,
     )
     const promptDocument = buildCanvasVisiblePromptDocument({
       prompt: explicitPrompt ?? '',
@@ -4505,6 +4638,7 @@ export const canvasApi = {
           input.operation as CanvasNodeType,
           nextCanvasNodeSequence(db, input.projectId, input.operation as CanvasNodeType),
         ),
+      operationNodeId: node.id,
       prompt: explicitPrompt ?? null,
       negativePrompt: negativePrompt ?? null,
       inputNodeIds: input.inputNodeIds,
@@ -4518,6 +4652,10 @@ export const canvasApi = {
       modelId,
       reasoningEffort,
       modelParams,
+      taskPipelineRole: input.taskPipelineRole ?? null,
+      outputPipelineRole: input.outputPipelineRole ?? null,
+      shotScriptConfig: input.shotScriptConfig ?? null,
+      runtimeEvents: initialCanvasTaskRuntimeEvents(at, '操作节点草稿创建'),
       promptDocument,
       ...(systemPrompt ? { systemPrompt } : {}),
       createdAt: at,
@@ -4549,12 +4687,21 @@ export const canvasApi = {
    * 重试操作节点：基于原 task 参数创建全新 task + output 流程。
    * 旧 output 节点和旧 task 不动。新 output 放在旧 output 右侧。
    */
-  async retryOperationNode(projectId: string, nodeId: string): Promise<CanvasSnapshot> {
+  async retryOperationNode(
+    projectId: string,
+    nodeId: string,
+    options?: {
+      sourceTaskId?: string
+      runtimeSource?: 'current-node' | 'original-task'
+    },
+  ): Promise<CanvasSnapshot> {
     const db = readDb()
     const node = db.nodes.find((n) => n.id === nodeId && n.projectId === projectId && !n.hidden)
-    if (!node || !node.taskId) throw new Error('操作节点未关联任务')
-    const oldTask = db.tasks.find((t) => t.id === node.taskId && t.projectId === projectId)
+    if (!node || (!node.taskId && !options?.sourceTaskId)) throw new Error('操作节点未关联任务')
+    const sourceTaskId = options?.sourceTaskId ?? node.taskId
+    const oldTask = db.tasks.find((t) => t.id === sourceTaskId && t.projectId === projectId)
     if (!oldTask) throw new Error('未找到原任务')
+    const useCurrentRuntime = options?.runtimeSource !== 'original-task'
     const oldOutputNodes = db.nodes.filter((n) => oldTask.outputNodeIds.includes(n.id))
     const baseX =
       oldOutputNodes.length > 0
@@ -4581,6 +4728,31 @@ export const canvasApi = {
       buildTaskInputFiles(retryInputNodes, buildCanvasRetryInputRoles(oldTask.relationManifest)),
       oldTask.provider === 'xai' ? 'base64' : undefined,
     )
+    const retryModelParams = useCurrentRuntime
+      ? { ...oldTask.modelParams, ...(node.data.modelParams ?? {}) }
+      : oldTask.modelParams
+    const retryProviderProfileId =
+      (useCurrentRuntime ? node.data.providerProfileId : oldTask.providerProfileId) ?? undefined
+    const retryManifestId =
+      (useCurrentRuntime ? node.data.manifestId : oldTask.manifestId) ?? undefined
+    const retryModelId = (useCurrentRuntime ? node.data.modelId : oldTask.modelId) ?? undefined
+    const retryAgentId = (useCurrentRuntime ? node.data.agentId : oldTask.agentId) ?? undefined
+    const retryReasoningEffort =
+      (useCurrentRuntime ? node.data.reasoningEffort : oldTask.reasoningEffort) ?? undefined
+    const retrySkillIds = (useCurrentRuntime ? node.data.skillIds : oldTask.skillIds) ?? []
+    const retryTaskPipelineRole = oldTask.taskPipelineRole ?? node.data.pipelineRole
+    const retryOutputPipelineRole = oldTask.outputPipelineRole ?? node.data.outputPipelineRole
+    const retryShotScriptConfig = oldTask.shotScriptConfig ?? node.data.shotScriptConfig
+    const retryPresetTargetId = resolveCanvasPresetTarget({
+      operation: oldTask.operation,
+      taskPipelineRole: retryTaskPipelineRole ?? null,
+      outputPipelineRole: retryOutputPipelineRole ?? null,
+      workflow: retryModelParams.workflow,
+    })
+    const retrySystemPrompt = normalizeCanvasFunctionalSystemPrompt(
+      oldTask.systemPrompt,
+      retryPresetTargetId,
+    )
     const request: CreateCanvasTaskRequest & { inputFiles?: CanvasMediaTaskInputFile[] } = {
       boardId: node.boardId,
       operation: oldTask.operation,
@@ -4590,16 +4762,19 @@ export const canvasApi = {
       ...(oldTask.inputAssetIds.length > 0 ? { inputAssetIds: oldTask.inputAssetIds } : {}),
       ...(retryInputFiles.length > 0 ? { inputFiles: retryInputFiles } : {}),
       outputPlacement: { x: baseX, y: baseY },
-      ...(oldTask.modelParams && Object.keys(oldTask.modelParams).length > 0
-        ? { modelParams: oldTask.modelParams }
-        : {}),
-      ...(oldTask.providerProfileId ? { providerProfileId: oldTask.providerProfileId } : {}),
-      ...(oldTask.manifestId ? { manifestId: oldTask.manifestId } : {}),
-      ...(oldTask.modelId ? { modelId: oldTask.modelId } : {}),
-      ...(oldTask.agentId ? { agentId: oldTask.agentId } : {}),
-      ...(oldTask.reasoningEffort ? { reasoningEffort: oldTask.reasoningEffort } : {}),
-      ...(oldTask.skillIds && oldTask.skillIds.length > 0 ? { skillIds: oldTask.skillIds } : {}),
+      ...(Object.keys(retryModelParams).length > 0 ? { modelParams: retryModelParams } : {}),
+      ...(retryProviderProfileId ? { providerProfileId: retryProviderProfileId } : {}),
+      ...(retryManifestId ? { manifestId: retryManifestId } : {}),
+      ...(retryModelId ? { modelId: retryModelId } : {}),
+      ...(retryAgentId ? { agentId: retryAgentId } : {}),
+      ...(retryReasoningEffort ? { reasoningEffort: retryReasoningEffort } : {}),
+      ...(retrySkillIds.length > 0 ? { skillIds: retrySkillIds } : {}),
+      ...(retryTaskPipelineRole ? { taskPipelineRole: retryTaskPipelineRole } : {}),
+      ...(retryOutputPipelineRole ? { outputPipelineRole: retryOutputPipelineRole } : {}),
+      ...(retryShotScriptConfig ? { shotScriptConfig: retryShotScriptConfig } : {}),
+      ...(oldTask.title ? { taskTitle: oldTask.title } : {}),
       ...pickCanvasPromptTaskFields(oldTask),
+      ...(retrySystemPrompt ? { systemPrompt: retrySystemPrompt } : {}),
     }
     // 重试：绑定到原操作节点，不新建节点
     return isTextModelOperation(request.operation)
@@ -4629,6 +4804,7 @@ export const canvasApi = {
       skipParameterValidation?: boolean
       skillIds?: string[]
       userPrompt?: string
+      shotScriptConfig?: ShotScriptConfig
     } & CanvasPromptTaskFields,
   ): Promise<CanvasSnapshot> {
     const db = readDb()
@@ -4690,6 +4866,7 @@ export const canvasApi = {
         ? { skipParameterValidation: true }
         : {}),
       ...(params.skillIds ? { skillIds: params.skillIds } : {}),
+      ...(params.shotScriptConfig ? { shotScriptConfig: params.shotScriptConfig } : {}),
       ...pickCanvasPromptTaskFields(params),
     }
     if (params.inputNodeIds) {
@@ -4761,6 +4938,12 @@ export const canvasApi = {
     task.errorDetail = '任务已由用户在画布任务队列中取消。'
     task.updatedAt = at
     task.completedAt = at
+    appendCanvasTaskRuntimeEvent(task, {
+      at,
+      kind: 'cancelled',
+      label: '任务已由用户取消',
+      detail: task.errorDetail,
+    })
     if (taskNode && patchTaskNode) {
       taskNode.data = {
         ...taskNode.data,
@@ -4850,6 +5033,7 @@ export const canvasApi = {
       progress: 24,
       message: '调用平台 adapter 中…',
     }
+    syncCanvasNodeRuntimeData(taskNodeData, request)
     const requestPromptWithContext = request.promptDocument
       ? request.prompt
       : mergeCanvasPromptWithInputTextContext(
@@ -4881,6 +5065,8 @@ export const canvasApi = {
     if (request.outputPipelineRole != null)
       taskNodeData.outputPipelineRole = request.outputPipelineRole
     if (request.outputTitle != null) taskNodeData.outputTitle = request.outputTitle
+    if (request.shotScriptConfig != null)
+      taskNodeData.shotScriptConfig = request.shotScriptConfig
     const defaultTaskTitle =
       request.taskTitle ??
       defaultCanvasNodeTitle(
@@ -4905,6 +5091,7 @@ export const canvasApi = {
         : null
     if (bindNode) {
       bindNode.data = { ...bindNode.data, ...taskNodeData }
+      syncCanvasNodeRuntimeData(bindNode.data, request)
       if (options != null && 'userPrompt' in options) {
         const userPrompt = options.userPrompt?.trim() ?? ''
         if (userPrompt) {
@@ -4945,6 +5132,7 @@ export const canvasApi = {
       status: 'running',
       progress: 24,
       title: defaultTaskTitle,
+      operationNodeId: taskNode.id,
       prompt: requestPrompt ?? null,
       negativePrompt: request.negativePrompt ?? null,
       inputNodeIds: request.inputNodeIds ?? [],
@@ -4960,6 +5148,10 @@ export const canvasApi = {
       modelId: request.modelId ?? null,
       reasoningEffort: request.reasoningEffort ?? null,
       modelParams: request.modelParams ?? {},
+      taskPipelineRole: request.taskPipelineRole ?? null,
+      outputPipelineRole: request.outputPipelineRole ?? null,
+      shotScriptConfig: request.shotScriptConfig ?? null,
+      runtimeEvents: initialCanvasTaskRuntimeEvents(at, '媒体任务创建并提交'),
       ...pickCanvasPromptTaskFields(request),
       createdAt: at,
       updatedAt: at,
@@ -5070,6 +5262,7 @@ export const canvasApi = {
       progress: 30,
       message: '调用文本模型中…',
     }
+    syncCanvasNodeRuntimeData(taskNodeData, request)
     const requestPrompt = request.promptDocument
       ? request.prompt
       : buildCanvasOperationPrompt(request.operation, request.prompt)
@@ -5087,6 +5280,8 @@ export const canvasApi = {
     if (request.outputPipelineRole != null)
       taskNodeData.outputPipelineRole = request.outputPipelineRole
     if (request.outputTitle != null) taskNodeData.outputTitle = request.outputTitle
+    if (request.shotScriptConfig != null)
+      taskNodeData.shotScriptConfig = request.shotScriptConfig
     if (request.skillIds != null) taskNodeData.skillIds = request.skillIds
     const defaultTaskTitle =
       request.taskTitle ??
@@ -5112,6 +5307,7 @@ export const canvasApi = {
         : null
     if (bindNode) {
       bindNode.data = { ...bindNode.data, ...taskNodeData }
+      syncCanvasNodeRuntimeData(bindNode.data, request)
       if (request.operation === 'text_generate' && request.taskPipelineRole === 'shot') {
         bindNode.width = Math.max(bindNode.width, taskNodeSize.width)
         bindNode.height = Math.max(bindNode.height, taskNodeSize.height)
@@ -5156,6 +5352,7 @@ export const canvasApi = {
       status: 'running',
       progress: 30,
       title: defaultTaskTitle,
+      operationNodeId: taskNode.id,
       prompt: request.prompt ?? null,
       negativePrompt: request.negativePrompt ?? null,
       inputNodeIds: request.inputNodeIds ?? [],
@@ -5172,6 +5369,10 @@ export const canvasApi = {
       modelId: request.modelId ?? null,
       reasoningEffort: request.reasoningEffort ?? null,
       modelParams: request.modelParams ?? {},
+      taskPipelineRole: request.taskPipelineRole ?? null,
+      outputPipelineRole: request.outputPipelineRole ?? null,
+      shotScriptConfig: request.shotScriptConfig ?? null,
+      runtimeEvents: initialCanvasTaskRuntimeEvents(at, '文本任务创建并提交'),
       ...pickCanvasPromptTaskFields(request),
       createdAt: at,
       updatedAt: at,
@@ -5252,6 +5453,7 @@ export const canvasApi = {
     }
 
     if (response.status === 'failed' || response.error || !response.text) {
+      const at = now()
       task.status = 'failed'
       task.progress = 100
       task.errorMsg = response.error?.code ?? 'text_generation_failed'
@@ -5263,8 +5465,19 @@ export const canvasApi = {
       task.provider = response.provider || task.provider || null
       task.modelId = response.model || task.modelId || null
       task.requestCall = response.requestCall ?? task.requestCall ?? null
+      if (response.text.trim()) {
+        task.modelOutputText = response.text
+        appendCanvasTaskModelOutputEvent(task, at, response.text)
+      }
       if (response.rawResponse !== undefined) task.rawResponse = response.rawResponse
-      task.updatedAt = now()
+      task.updatedAt = at
+      task.completedAt = at
+      appendCanvasTaskRuntimeEvent(task, {
+        at,
+        kind: 'failed',
+        label: '文本模型调用失败',
+        detail: task.errorDetail ?? undefined,
+      })
       if (patchTaskNode) {
         taskNode.data = {
           ...taskNode.data,
@@ -5272,16 +5485,18 @@ export const canvasApi = {
           progress: 100,
           message: `失败：${task.errorDetail}`,
         }
-        taskNode.updatedAt = now()
+        syncCanvasTaskRuntimeToNode(task, taskNode.data)
+        taskNode.updatedAt = at
       }
       updateProjectCounts(db, projectId)
       writeDb(db)
       return this.openSnapshot(projectId)
     }
 
-    const outputRole = taskNode.data.outputPipelineRole
+    const outputRole = task.outputPipelineRole ?? taskNode.data.outputPipelineRole
     const semanticValidation = validateCanvasSemanticTextOutput(outputRole, response.text)
     if (!semanticValidation.ok) {
+      const at = now()
       task.status = 'failed'
       task.progress = 100
       task.errorMsg = semanticValidation.code
@@ -5290,8 +5505,17 @@ export const canvasApi = {
       task.provider = response.provider || task.provider || null
       task.modelId = response.model || task.modelId || null
       task.requestCall = response.requestCall ?? task.requestCall ?? null
-      task.rawResponse = response.rawResponse ?? { text: response.text }
-      task.updatedAt = now()
+      task.modelOutputText = response.text
+      appendCanvasTaskModelOutputEvent(task, at, response.text)
+      if (response.rawResponse !== undefined) task.rawResponse = response.rawResponse
+      task.updatedAt = at
+      task.completedAt = at
+      appendCanvasTaskRuntimeEvent(task, {
+        at,
+        kind: 'validation',
+        label: '模型已返回文本，但业务结构解析失败',
+        detail: semanticValidation.message,
+      })
       if (patchTaskNode) {
         taskNode.data = {
           ...taskNode.data,
@@ -5299,7 +5523,8 @@ export const canvasApi = {
           progress: 100,
           message: `失败：${semanticValidation.message}`,
         }
-        taskNode.updatedAt = now()
+        syncCanvasTaskRuntimeToNode(task, taskNode.data)
+        taskNode.updatedAt = at
       }
       updateProjectCounts(db, projectId)
       writeDb(db)
@@ -5385,7 +5610,14 @@ export const canvasApi = {
     task.provider = response.provider || task.provider || null
     task.modelId = response.model || task.modelId || null
     task.requestCall = response.requestCall ?? task.requestCall ?? null
+    task.modelOutputText = response.text
+    appendCanvasTaskModelOutputEvent(task, at, response.text)
     if (response.rawResponse !== undefined) task.rawResponse = response.rawResponse
+    appendCanvasTaskRuntimeEvent(task, {
+      at,
+      kind: 'completed',
+      label: '文本生成与业务解析完成',
+    })
     task.outputAssetIds.push(asset.id)
     task.outputNodeIds.push(resultNode.id)
     if (patchTaskNode) {
@@ -5395,6 +5627,7 @@ export const canvasApi = {
         progress: 100,
         message: '文本已生成',
       }
+      syncCanvasTaskRuntimeToNode(task, taskNode.data)
       taskNode.updatedAt = at
     }
     db.assets.push(asset)
@@ -5437,7 +5670,14 @@ export const canvasApi = {
     task.modelId = response.model || task.modelId || null
     task.requestCall = response.requestCall ?? task.requestCall ?? null
     if (response.submitResponse !== undefined) task.submitResponse = response.submitResponse
-    task.updatedAt = now()
+    const at = now()
+    task.updatedAt = at
+    appendCanvasTaskRuntimeEvent(task, {
+      at,
+      kind: 'submitted',
+      label: 'Provider 已接受后台任务',
+      ...(task.requestId ? { detail: `Request ${task.requestId}` } : {}),
+    })
     if (patchTaskNode) {
       taskNode.data = {
         ...taskNode.data,
@@ -5445,7 +5685,8 @@ export const canvasApi = {
         progress: task.progress,
         message: '后台任务已提交，等待 provider 返回产物',
       }
-      taskNode.updatedAt = now()
+      syncCanvasTaskRuntimeToNode(task, taskNode.data)
+      taskNode.updatedAt = at
     }
     updateProjectCounts(db, projectId)
     writeDb(db)
@@ -5478,6 +5719,7 @@ export const canvasApi = {
     }
 
     if (response.error || response.status === 'failed' || response.status === 'cancelled') {
+      const at = now()
       const isCancelled = response.status === 'cancelled'
       task.status = isCancelled ? 'cancelled' : 'failed'
       task.progress = 100
@@ -5490,7 +5732,14 @@ export const canvasApi = {
       task.requestCall = response.requestCall ?? task.requestCall ?? null
       if (response.submitResponse !== undefined) task.submitResponse = response.submitResponse
       if (response.rawResponse !== undefined) task.rawResponse = response.rawResponse
-      task.updatedAt = now()
+      task.updatedAt = at
+      task.completedAt = at
+      appendCanvasTaskRuntimeEvent(task, {
+        at,
+        kind: isCancelled ? 'cancelled' : 'failed',
+        label: isCancelled ? 'Provider 任务已取消' : 'Provider 任务失败',
+        detail: task.errorDetail ?? undefined,
+      })
       if (patchTaskNode) {
         taskNode.data = {
           ...taskNode.data,
@@ -5498,7 +5747,8 @@ export const canvasApi = {
           progress: 100,
           message: isCancelled ? '任务已取消' : `失败：${task.errorDetail}`,
         }
-        taskNode.updatedAt = now()
+        syncCanvasTaskRuntimeToNode(task, taskNode.data)
+        taskNode.updatedAt = at
       }
       updateProjectCounts(db, projectId)
       writeDb(db)
@@ -5507,8 +5757,9 @@ export const canvasApi = {
 
     task.status = 'completed'
     task.progress = 100
-    task.completedAt = now()
-    task.updatedAt = now()
+    const at = now()
+    task.completedAt = at
+    task.updatedAt = at
     if (response.providerProfileId) task.providerProfileId = response.providerProfileId
     if (response.model) task.modelId = response.model
     task.provider = response.provider || null
@@ -5517,7 +5768,11 @@ export const canvasApi = {
     if (response.submitResponse !== undefined) task.submitResponse = response.submitResponse
     task.requestCall = response.requestCall ?? task.requestCall ?? null
 
-    const at = now()
+    appendCanvasTaskRuntimeEvent(task, {
+      at,
+      kind: 'completed',
+      label: 'Provider 任务完成并返回产物',
+    })
     const preparedOutputs: Array<{
       asset: CanvasAsset
       nodeType: CanvasNode['type']
@@ -5756,7 +6011,8 @@ export const canvasApi = {
         progress: 100,
         message: `${response.assets.length} 个产物已写回画布`,
       }
-      taskNode.updatedAt = now()
+      syncCanvasTaskRuntimeToNode(task, taskNode.data)
+      taskNode.updatedAt = at
     }
     updateProjectCounts(db, projectId)
     writeDb(db)

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.store.ts
@@ -865,8 +865,14 @@ export function useCanvasWorkspace(projectId: string) {
   )
 
   const retryOperationNode = useCallback(
-    async (nodeId: string) => {
-      await applyTaskSnapshot(canvasApi.retryOperationNode(projectId, nodeId))
+    async (
+      nodeId: string,
+      options?: {
+        sourceTaskId?: string
+        runtimeSource?: 'current-node' | 'original-task'
+      },
+    ) => {
+      await applyTaskSnapshot(canvasApi.retryOperationNode(projectId, nodeId, options))
     },
     [applyTaskSnapshot, projectId],
   )
@@ -888,6 +894,7 @@ export function useCanvasWorkspace(projectId: string) {
         skipParameterValidation?: boolean
         skillIds?: string[]
         userPrompt?: string
+        shotScriptConfig?: ShotScriptConfig
       } & CanvasPromptTaskFields,
     ) => {
       await applyTaskSnapshot(canvasApi.runOperationNode(projectId, nodeId, params))

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
@@ -112,6 +112,21 @@ export type CanvasPipelineRole =
 export type CanvasProductionState = 'empty' | 'drafting' | 'draft' | 'confirmed' | 'stale'
 
 export type CanvasTaskStatus = 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+
+export type CanvasTaskRuntimeEvent = {
+  at: string
+  kind:
+    | 'created'
+    | 'dispatched'
+    | 'submitted'
+    | 'provider_response'
+    | 'validation'
+    | 'completed'
+    | 'failed'
+    | 'cancelled'
+  label: string
+  detail?: string
+}
 export type CanvasEdgeType =
   | 'derived_from'
   | 'used_as_input'
@@ -344,6 +359,8 @@ export type CanvasTask = {
   status: CanvasTaskStatus
   progress: number
   title?: string | null
+  /** Stable owner operation node. Unlike node.taskId, this survives later retries. */
+  operationNodeId?: string | null
   prompt?: string | null
   negativePrompt?: string | null
   inputNodeIds: string[]
@@ -359,6 +376,8 @@ export type CanvasTask = {
   requestId?: string | null
   /** provider 原始响应摘要（不含敏感信息） */
   rawResponse?: unknown
+  /** Agent/model 原始文本；即使业务解析失败也必须保留。 */
+  modelOutputText?: string | null
   /** 轮询任务提交接口响应摘要，拿到渠道任务 ID 后立即写入。 */
   submitResponse?: unknown
   /** 提交时输入文件的诊断摘要，便于任务详情排查 url/base64/path 等传参方式。 */
@@ -372,6 +391,12 @@ export type CanvasTask = {
   /** Spark 统一推理强度；主进程会按目标 adapter 映射为 provider 合法枚举。 */
   reasoningEffort?: SessionReasoningEffort | null
   modelParams: Record<string, unknown>
+  taskPipelineRole?: CanvasPipelineRole | null
+  outputPipelineRole?: CanvasPipelineRole | null
+  /** Storyboard timing configuration captured when this task was submitted. */
+  shotScriptConfig?: ShotScriptConfig | null
+  /** Persisted lifecycle events with their actual write timestamps. */
+  runtimeEvents?: CanvasTaskRuntimeEvent[]
   errorMsg?: string | null
   errorDetail?: string | null
   createdAt: string
@@ -447,6 +472,8 @@ export type CreateCanvasTaskRequest = {
   taskPipelineRole?: CanvasPipelineRole
   /** 专用流水线节点：产物节点的流水线角色（如分镜脚本产物 = shot） */
   outputPipelineRole?: CanvasPipelineRole
+  /** 分镜任务提交时的时长配置快照。 */
+  shotScriptConfig?: ShotScriptConfig
   /** Contract V2 裁剪产物：被丢弃的字段及原因，供任务详情展示。 */
   droppedModelParams?: Array<{ name: string; reason: string; valuePreview?: string | undefined }>
   /** Contract V2 裁剪产物：非阻断性提示（如 missing_param_policy、compat_passthrough）。 */

--- a/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.test.ts
@@ -4,9 +4,18 @@ import {
   buildEntityExtractionPrompt,
   parseExtractedCharacters,
   parseExtractedScenes,
+  resolveExtractEntityKindFromWorkflow,
 } from './canvasEntityExtract'
 
 describe('canvasEntityExtract', () => {
+  it('maps every structured extraction workflow to its entity kind', () => {
+    expect(resolveExtractEntityKindFromWorkflow('extract_character')).toBe('character')
+    expect(resolveExtractEntityKindFromWorkflow('extract_scene')).toBe('scene')
+    expect(resolveExtractEntityKindFromWorkflow('extract_prop')).toBe('prop')
+    expect(resolveExtractEntityKindFromWorkflow('extract_effect')).toBe('effect')
+    expect(resolveExtractEntityKindFromWorkflow('shot_script')).toBeNull()
+  })
+
   describe('buildEntityExtractionPrompt', () => {
     it('角色抽取提示词含格式要求与剧本', () => {
       const prompt = buildEntityExtractionPrompt('character', '林岚推门进入。', '水墨写意')

--- a/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasEntityExtract.ts
@@ -1,5 +1,5 @@
 /**
- * 实体抽取（剧本 → 角色 / 场景，一对多）。
+ * 实体抽取（剧本 → 角色 / 场景 / 道具 / 特效，一对多）。
  *
  * 用于画布「文本节点右键 → 提取角色 / 提取场景」：让文本模型按**固定可解析格式**
  * 输出实体清单，再用这里的解析器还原为结构化实体，逐个落库 + 在画布生成专用节点。
@@ -7,6 +7,33 @@
  */
 
 export type ExtractEntityKind = 'character' | 'scene' | 'prop' | 'effect'
+
+export function extractEntityKindLabel(kind: ExtractEntityKind): string {
+  return kind === 'character'
+    ? '角色'
+    : kind === 'scene'
+      ? '场景'
+      : kind === 'prop'
+        ? '道具'
+        : '特效'
+}
+
+export function resolveExtractEntityKindFromWorkflow(
+  workflow: unknown,
+): ExtractEntityKind | null {
+  switch (workflow) {
+    case 'extract_character':
+      return 'character'
+    case 'extract_scene':
+      return 'scene'
+    case 'extract_prop':
+      return 'prop'
+    case 'extract_effect':
+      return 'effect'
+    default:
+      return null
+  }
+}
 
 /** 解析出的单个实体（字段已归一化为中文标准 key） */
 export type ParsedEntity = {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationInheritance.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationInheritance.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { canvasApi, __resetCanvasHotCache } from './canvas.api'
 import type { CanvasDb } from './canvas.api'
+import { writeCanvasOperationPreset } from './canvasOperationPresets'
 
 const STORAGE_KEY = 'spark-canvas:v1'
 
@@ -71,6 +72,181 @@ describe('canvas operation inheritance', () => {
     })
   })
 
+  it('backfills diagnostics for legacy failed tasks without changing their status', async () => {
+    seedCanvasDb({
+      projects: [
+        {
+          id: 'project-1',
+          userId: 0,
+          title: 'Project',
+          status: 'active',
+          nodeCount: 2,
+          assetCount: 0,
+          taskCount: 1,
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      boards: [
+        {
+          id: 'board-1',
+          projectId: 'project-1',
+          userId: 0,
+          name: 'Board',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          settings: {},
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      assets: [],
+      nodes: [
+        {
+          id: 'node-operation',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          userId: 0,
+          type: 'text_generate',
+          title: 'Storyboard',
+          x: 0,
+          y: 0,
+          width: 640,
+          height: 420,
+          rotation: 0,
+          zIndex: 1,
+          locked: false,
+          hidden: false,
+          taskId: 'task-newer',
+          data: {
+            pipelineRole: 'shot',
+            outputPipelineRole: 'shot',
+          },
+          createdAt: at,
+          updatedAt: at,
+        },
+        {
+          id: 'node-output',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          userId: 0,
+          type: 'text',
+          title: 'Legacy output',
+          x: 700,
+          y: 0,
+          width: 420,
+          height: 300,
+          rotation: 0,
+          zIndex: 2,
+          locked: false,
+          hidden: false,
+          data: { text: 'unparsed legacy model output', origin: 'task_output' },
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      edges: [
+        {
+          id: 'edge-generated',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          userId: 0,
+          sourceNodeId: 'node-operation',
+          targetNodeId: 'node-output',
+          type: 'generated',
+          taskId: 'task-legacy',
+          metadata: {},
+          createdAt: at,
+        },
+      ],
+      tasks: [
+        {
+          id: 'task-legacy',
+          projectId: 'project-1',
+          boardId: 'board-1',
+          userId: 0,
+          operation: 'text_generate',
+          status: 'failed',
+          progress: 100,
+          title: 'Legacy failed task',
+          prompt: 'Generate storyboard',
+          inputNodeIds: [],
+          inputAssetIds: [],
+          outputNodeIds: ['node-output'],
+          outputAssetIds: [],
+          modelParams: {},
+          rawResponse: { text: 'unparsed legacy model output' },
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+    })
+
+    const snapshot = await canvasApi.openSnapshot('project-1')
+    expect(snapshot.tasks[0]).toMatchObject({
+      id: 'task-legacy',
+      status: 'failed',
+      operationNodeId: 'node-operation',
+      taskPipelineRole: 'shot',
+      outputPipelineRole: 'shot',
+      completedAt: at,
+      modelOutputText: 'unparsed legacy model output',
+    })
+  })
+
+  it('does not prepend a generic text prompt to an explicit storyboard contract', async () => {
+    seedCanvasDb({
+      projects: [
+        {
+          id: 'project-1',
+          userId: 0,
+          title: 'Project',
+          status: 'active',
+          nodeCount: 0,
+          assetCount: 0,
+          taskCount: 0,
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      boards: [
+        {
+          id: 'board-1',
+          projectId: 'project-1',
+          userId: 0,
+          name: 'Board',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          settings: {},
+          createdAt: at,
+          updatedAt: at,
+        },
+      ],
+      assets: [],
+      nodes: [],
+      edges: [],
+      tasks: [],
+    })
+    writeCanvasOperationPreset('text_generate', {
+      prompt: '你是角色分析师，只输出 characters JSON。',
+    })
+
+    const snapshot = await canvasApi.createOperationNode({
+      projectId: 'project-1',
+      boardId: 'board-1',
+      operation: 'text_generate',
+      inputNodeIds: [],
+      x: 0,
+      y: 0,
+      taskPipelineRole: 'shot',
+      outputPipelineRole: 'shot',
+      modelParams: { workflow: 'shot_script', responseFormat: 'json' },
+      systemPrompt: '【任务】把下面的场次剧本拆成分镜。\nJSON 顶层结构必须为：{"shots":[]}',
+    })
+
+    const node = snapshot.nodes.find((candidate) => candidate.type === 'text_generate')
+    expect(node?.data.systemPrompt).toContain('"shots"')
+    expect(node?.data.systemPrompt).not.toContain('characters')
+  })
+
   it('creates storyboard tasks large and grows them to the completed shot table size', async () => {
     seedCanvasDb({
       projects: [
@@ -119,6 +295,9 @@ describe('canvas operation inheritance', () => {
     const taskNode = created.nodes.find((node) => node.type === 'text_generate')
     expect(taskNode).toMatchObject({ width: 960, height: 560 })
     if (!taskNode?.taskId) throw new Error('Storyboard task node was not created')
+    expect(created.tasks.find((task) => task.id === taskNode.taskId)?.shotScriptConfig).toEqual({
+      maxClipSec: 5,
+    })
 
     const shots = Array.from({ length: 5 }, (_, index) => ({
       index: index + 1,
@@ -414,6 +593,8 @@ describe('canvas operation inheritance', () => {
       systemPrompt: '隐藏的角色提取规则',
       providerProfileId: 'codex-cli-provider',
       modelId: 'codex cli',
+      taskPipelineRole: 'character',
+      outputPipelineRole: 'character',
     })
     const reboundNode = started.snapshot.nodes.find((node) => node.id === operationNode.id)
     const reboundTask = started.snapshot.tasks.find((task) => task.id === started.taskId)
@@ -427,6 +608,8 @@ describe('canvas operation inheritance', () => {
     expect(reboundTask?.prompt).toBe('[剧本 ref-1: 场次剧本]\n雨夜车站')
     expect(reboundTask?.promptDocument).toEqual(document)
     expect(reboundTask?.systemPrompt).toBe('隐藏的角色提取规则')
+    expect(reboundTask?.taskPipelineRole).toBe('character')
+    expect(reboundTask?.outputPipelineRole).toBe('character')
   })
 
   it('keeps compiled prompt documents out of the legacy operation prefix', async () => {
@@ -588,6 +771,154 @@ describe('canvas operation inheritance', () => {
         promptDocument: document,
         compiledUserText: '冻结文本',
         systemPrompt: '隐藏能力',
+      }),
+    )
+  })
+
+  it('distinguishes current-node runtime retries from original-task retries', async () => {
+    const seedRetryTask = () =>
+      seedCanvasDb({
+        projects: [
+          {
+            id: 'project-1',
+            userId: 0,
+            title: 'Project',
+            status: 'active',
+            nodeCount: 1,
+            assetCount: 0,
+            taskCount: 1,
+            createdAt: at,
+            updatedAt: at,
+          },
+        ],
+        boards: [
+          {
+            id: 'board-1',
+            projectId: 'project-1',
+            userId: 0,
+            name: 'Board',
+            viewport: { x: 0, y: 0, zoom: 1 },
+            settings: {},
+            createdAt: at,
+            updatedAt: at,
+          },
+        ],
+        assets: [],
+        nodes: [
+          {
+            id: 'node-op',
+            projectId: 'project-1',
+            boardId: 'board-1',
+            userId: 0,
+            type: 'text_generate',
+            title: '生成分镜脚本',
+            assetId: null,
+            taskId: 'task-old',
+            parentNodeId: null,
+            x: 0,
+            y: 0,
+            width: 240,
+            height: 160,
+            rotation: 0,
+            zIndex: 1,
+            locked: false,
+            hidden: false,
+            data: {
+              operation: 'text_generate',
+              modelId: 'new-model',
+              providerProfileId: 'new-provider',
+              agentId: 'new-agent',
+              pipelineRole: 'shot',
+              outputPipelineRole: 'shot',
+              modelParams: { workflow: 'shot_script', temperature: 0.2 },
+            },
+            createdAt: at,
+            updatedAt: at,
+          },
+        ],
+        edges: [],
+        tasks: [
+          {
+            id: 'task-old',
+            projectId: 'project-1',
+            boardId: 'board-1',
+            userId: 0,
+            operation: 'text_generate',
+            status: 'failed',
+            progress: 100,
+            title: '生成分镜脚本',
+            prompt: '冻结输入',
+            inputNodeIds: [],
+            inputAssetIds: [],
+            outputNodeIds: [],
+            outputAssetIds: [],
+            providerProfileId: 'old-provider',
+            modelId: 'old-model',
+            agentId: 'old-agent',
+            modelParams: { workflow: 'shot_script', temperature: 0.8 },
+            taskPipelineRole: 'shot',
+            outputPipelineRole: 'shot',
+            createdAt: at,
+            updatedAt: at,
+          },
+        ],
+      })
+
+    seedRetryTask()
+    const edited = await canvasApi.updateNodeData('project-1', 'node-op', {
+      modelId: 'edited-model',
+      providerProfileId: 'edited-provider',
+    })
+    expect(edited.nodes.find((node) => node.id === 'node-op')?.data).toMatchObject({
+      modelId: 'edited-model',
+      providerProfileId: 'edited-provider',
+    })
+    expect(edited.tasks.find((task) => task.id === 'task-old')).toMatchObject({
+      modelId: 'old-model',
+      providerProfileId: 'old-provider',
+    })
+    const currentInvoke = vi.fn().mockResolvedValue({
+      status: 'running',
+      providerProfileId: '',
+      provider: '',
+      model: '',
+      text: '',
+    })
+    Object.assign(window, { spark: { invoke: currentInvoke } })
+    await canvasApi.retryOperationNode('project-1', 'node-op', {
+      sourceTaskId: 'task-old',
+      runtimeSource: 'current-node',
+    })
+    expect(currentInvoke).toHaveBeenCalledWith(
+      'canvas:task:generate-text',
+      expect.objectContaining({
+        providerProfileId: 'edited-provider',
+        modelId: 'edited-model',
+        agentId: 'new-agent',
+        modelParams: { workflow: 'shot_script', temperature: 0.2 },
+      }),
+    )
+
+    seedRetryTask()
+    const originalInvoke = vi.fn().mockResolvedValue({
+      status: 'running',
+      providerProfileId: '',
+      provider: '',
+      model: '',
+      text: '',
+    })
+    Object.assign(window, { spark: { invoke: originalInvoke } })
+    await canvasApi.retryOperationNode('project-1', 'node-op', {
+      sourceTaskId: 'task-old',
+      runtimeSource: 'original-task',
+    })
+    expect(originalInvoke).toHaveBeenCalledWith(
+      'canvas:task:generate-text',
+      expect.objectContaining({
+        providerProfileId: 'old-provider',
+        modelId: 'old-model',
+        agentId: 'old-agent',
+        modelParams: { workflow: 'shot_script', temperature: 0.8 },
       }),
     )
   })
@@ -1364,6 +1695,7 @@ describe('canvas operation inheritance', () => {
       status: 'completed',
       outputNodeIds: [outputNode.id],
       message: '已展开 1 个分镜节点到画布',
+      modelOutputText: '{"shots":[{"index":1}]}',
       rawResponse: { workflow: 'script_breakdown', shotSegmentCount: 1 },
     })
 
@@ -1374,6 +1706,12 @@ describe('canvas operation inheritance', () => {
       workflow: 'script_breakdown',
       shotSegmentCount: 1,
     })
+    expect(completedTask?.modelOutputText).toBe('{"shots":[{"index":1}]}')
+    expect(completedTask?.runtimeEvents?.map((event) => event.kind)).toEqual([
+      'created',
+      'provider_response',
+      'completed',
+    ])
     expect(
       finished.edges.some(
         (edge) =>
@@ -1383,6 +1721,28 @@ describe('canvas operation inheritance', () => {
           edge.type === 'generated',
       ),
     ).toBe(true)
+
+    const failedRun = await canvasApi.startWorkflowTask('project-1', {
+      boardId: 'board-1',
+      title: '提取道具',
+      modelParams: { workflow: 'extract_prop', responseFormat: 'json' },
+      taskPipelineRole: 'prop',
+      outputPipelineRole: 'prop',
+    })
+    const failed = await canvasApi.finishWorkflowTask('project-1', failedRun.taskId, {
+      status: 'failed',
+      errorMsg: 'workflow_failed',
+      errorDetail: '无法解析道具实体',
+      modelOutputText: '{"episode":1,"characters":[]}',
+      rawResponse: { requestId: 'req-failed' },
+    })
+    expect(failed.tasks.find((task) => task.id === failedRun.taskId)).toMatchObject({
+      status: 'failed',
+      modelOutputText: '{"episode":1,"characters":[]}',
+      rawResponse: { requestId: 'req-failed' },
+      taskPipelineRole: 'prop',
+      outputPipelineRole: 'prop',
+    })
   })
 
   it('returns a running snapshot before slow text IPC completes', async () => {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.test.ts
@@ -190,6 +190,20 @@ describe('canvasOperationPresets', () => {
     })
   })
 
+  it('does not inherit a generic authored prompt into a dedicated pipeline contract', () => {
+    writeCanvasOperationPreset('text_generate', {
+      prompt: '你是角色分析师，只输出 characters JSON',
+      providerProfileId: 'provider:text',
+      modelId: 'gpt-5',
+    })
+
+    expect(readCanvasInheritedPresetTarget('screenplay.to_shot_script')).toMatchObject({
+      prompt: '',
+      providerProfileId: 'provider:text',
+      modelId: 'gpt-5',
+    })
+  })
+
   it('keeps the configured system prompt while reusing runtime selections', () => {
     writeCanvasPresetTarget('chapter.to_screenplay', {
       prompt: '预设版转剧本',
@@ -379,5 +393,12 @@ describe('canvasOperationPresets', () => {
         workflow: 'extract_character',
       }),
     ).toBe('screenplay.extract_characters')
+    expect(
+      resolveCanvasPresetTarget({
+        operation: 'text_generate',
+        taskPipelineRole: 'prop',
+        workflow: 'extract_prop',
+      }),
+    ).toBe('screenplay.extract_props')
   })
 })

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.ts
@@ -51,6 +51,24 @@ export const CANVAS_PIPELINE_PRESET_TARGETS = [
     label: '提取场景',
     description: '从剧本中提取场景信息',
   },
+  {
+    id: 'screenplay.extract_props',
+    operation: 'text_generate',
+    label: '提取道具',
+    description: '从剧本中提取道具信息',
+  },
+  {
+    id: 'screenplay.extract_effects',
+    operation: 'text_generate',
+    label: '提取特效',
+    description: '从剧本中提取特效信息',
+  },
+  {
+    id: 'screenplay.split_episodes',
+    operation: 'text_generate',
+    label: '按剧情分集',
+    description: '把长剧本拆分为结构化分集剧本',
+  },
 ] as const satisfies readonly {
   id: string
   operation: CanvasOperationType
@@ -318,6 +336,27 @@ export function resolveCanvasPresetTarget(input: {
   ) {
     return 'screenplay.extract_scenes'
   }
+  if (
+    input.operation === 'text_generate' &&
+    input.taskPipelineRole === 'prop' &&
+    workflow === 'extract_prop'
+  ) {
+    return 'screenplay.extract_props'
+  }
+  if (
+    input.operation === 'text_generate' &&
+    input.taskPipelineRole === 'effect' &&
+    workflow === 'extract_effect'
+  ) {
+    return 'screenplay.extract_effects'
+  }
+  if (
+    input.operation === 'text_generate' &&
+    input.taskPipelineRole === 'screenplay' &&
+    workflow === 'split_episodes'
+  ) {
+    return 'screenplay.split_episodes'
+  }
   return input.operation
 }
 
@@ -423,7 +462,11 @@ export function readCanvasInheritedPresetTarget(
   const taskDefaultKind = canvasTaskDefaultKindForOperation(target.operation, context)
   const taskDefault = taskDefaultKind ? readCanvasTaskDefault(taskDefaultKind) : { skillIds: [] }
   return {
-    prompt: operationOverrides.prompt ?? builtin.prompt,
+    // A dedicated pipeline contract owns its task identity and output schema.
+    // Reuse runtime/model defaults from the generic operation, but never inherit
+    // its authored prompt (for example a character extractor into a shot task).
+    prompt:
+      target.id === target.operation ? (operationOverrides.prompt ?? builtin.prompt) : '',
     negativePrompt: operationOverrides.negativePrompt ?? builtin.negativePrompt,
     ...((operationOverrides.providerProfileId ?? taskDefault.providerProfileId)
       ? {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipeline.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipeline.test.ts
@@ -24,11 +24,13 @@ describe('canvasPipeline', () => {
       expect(actions[0]!.produces).toBe('screenplay')
     })
 
-    it('剧本可生成分镜脚本 / 提取角色 / 提取场景 / 分镜关键帧图', () => {
+    it('剧本可生成分镜脚本 / 提取完整实体 / 分镜关键帧图', () => {
       expect(getPipelineActions('screenplay').map((a) => a.id)).toEqual([
         'screenplay.to_shot_script',
         'screenplay.extract_characters',
         'screenplay.extract_scenes',
+        'screenplay.extract_props',
+        'screenplay.extract_effects',
         'screenplay.storyboard_grid',
       ])
     })

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipelineActionContracts.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipelineActionContracts.ts
@@ -112,6 +112,7 @@ export function buildCanvasPipelineOperationDraft(
         message: '确认分集 Prompt、Agent 与模型后点击开始任务',
         taskPipelineRole: 'screenplay',
         outputPipelineRole: 'screenplay',
+        modelParams: { workflow: 'split_episodes' },
       }
     case 'shot.to_keyframes':
     case 'screenplay.storyboard_grid':

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.test.ts
@@ -13,11 +13,13 @@ describe('canvasPipelineOps', () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
-  it('剧本角色有四个专用 op', () => {
+  it('剧本角色有完整的专用 op', () => {
     expect(getOpsForRole('screenplay').map((op) => op.id)).toEqual([
       'screenplay.to_shot_script',
       'screenplay.extract_characters',
       'screenplay.extract_scenes',
+      'screenplay.extract_props',
+      'screenplay.extract_effects',
       'screenplay.storyboard_grid',
     ])
   })
@@ -35,6 +37,8 @@ describe('canvasPipelineOps', () => {
         'screenplay.to_shot_script',
         'screenplay.extract_characters',
         'screenplay.extract_scenes',
+        'screenplay.extract_props',
+        'screenplay.extract_effects',
         'screenplay.storyboard_grid',
       ])
     })
@@ -45,6 +49,8 @@ describe('canvasPipelineOps', () => {
         'screenplay.to_shot_script',
         'screenplay.extract_characters',
         'screenplay.extract_scenes',
+        'screenplay.extract_props',
+        'screenplay.extract_effects',
         'screenplay.storyboard_grid',
       ])
     })
@@ -55,6 +61,8 @@ describe('canvasPipelineOps', () => {
         'screenplay.to_shot_script',
         'screenplay.extract_characters',
         'screenplay.extract_scenes',
+        'screenplay.extract_props',
+        'screenplay.extract_effects',
         'screenplay.storyboard_grid',
       ])
     })
@@ -65,6 +73,8 @@ describe('canvasPipelineOps', () => {
         'screenplay.to_shot_script',
         'screenplay.extract_characters',
         'screenplay.extract_scenes',
+        'screenplay.extract_props',
+        'screenplay.extract_effects',
         'screenplay.storyboard_grid',
       ])
     })
@@ -119,6 +129,14 @@ describe('canvasPipelineOps', () => {
     it('提取场景委托抽取提示词', () => {
       const prompt = buildOpPrompt('screenplay.extract_scenes', { upstreamText: '车站' })
       expect(prompt).toContain('抽取其中出现的全部场景')
+    })
+    it('提取道具和特效委托各自的抽取提示词', () => {
+      expect(buildOpPrompt('screenplay.extract_props', { upstreamText: '银色手枪' })).toContain(
+        '抽取其中出现的全部道具',
+      )
+      expect(buildOpPrompt('screenplay.extract_effects', { upstreamText: '空间裂缝' })).toContain(
+        '抽取其中出现的全部特效',
+      )
     })
     it('图像类 op 返回空（由 workspace 用资产构建）', () => {
       expect(buildOpPrompt('character.three_view', {})).toBe('')

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPipelineOps.ts
@@ -88,6 +88,26 @@ export const CANVAS_PIPELINE_OPS: CanvasPipelineOp[] = [
     extractKind: 'scene',
   },
   {
+    id: 'screenplay.extract_props',
+    label: '提取道具',
+    icon: 'Box',
+    kind: 'extract',
+    produces: 'prop',
+    appliesTo: ['screenplay'],
+    appliesToText: true,
+    extractKind: 'prop',
+  },
+  {
+    id: 'screenplay.extract_effects',
+    label: '提取特效',
+    icon: 'Sparkles',
+    kind: 'extract',
+    produces: 'effect',
+    appliesTo: ['screenplay'],
+    appliesToText: true,
+    extractKind: 'effect',
+  },
+  {
     id: 'screenplay.storyboard_grid',
     label: '生成分镜关键帧图',
     icon: 'Image',
@@ -231,6 +251,10 @@ export function buildOpPrompt(
       return buildEntityExtractionPrompt('character', ctx.upstreamText ?? '', ctx.styleBible)
     case 'screenplay.extract_scenes':
       return buildEntityExtractionPrompt('scene', ctx.upstreamText ?? '', ctx.styleBible)
+    case 'screenplay.extract_props':
+      return buildEntityExtractionPrompt('prop', ctx.upstreamText ?? '', ctx.styleBible)
+    case 'screenplay.extract_effects':
+      return buildEntityExtractionPrompt('effect', ctx.upstreamText ?? '', ctx.styleBible)
     default:
       return ''
   }

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPromptInitialization.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPromptInitialization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeCanvasFunctionalSystemPrompt } from './canvasPromptInitialization'
+
+describe('canvas functional prompt initialization', () => {
+  it('removes a legacy character-extraction prefix from a storyboard contract', () => {
+    const prompt = [
+      '你是专业的影视角色分析师。只输出 characters JSON。',
+      '【任务】把下面的场次剧本拆成「精确到秒、超详细」的分镜表。',
+      'JSON 顶层结构必须为：{"shots":[]}',
+    ].join('\n\n')
+
+    expect(
+      normalizeCanvasFunctionalSystemPrompt(prompt, 'screenplay.to_shot_script'),
+    ).toBe(
+      '【任务】把下面的场次剧本拆成「精确到秒、超详细」的分镜表。\n\nJSON 顶层结构必须为：{"shots":[]}',
+    )
+  })
+
+  it('preserves authored prompts when no target contract marker is present', () => {
+    expect(normalizeCanvasFunctionalSystemPrompt('用户自定义要求', 'text_generate')).toBe(
+      '用户自定义要求',
+    )
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPromptInitialization.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPromptInitialization.ts
@@ -26,6 +26,46 @@ export function stripCanvasFunctionalPromptInput(prompt: string, presetTargetId:
   return markerIndex >= 0 ? prompt.slice(0, markerIndex).trim() : prompt.trim()
 }
 
+const FUNCTIONAL_PROMPT_START_MARKERS: Record<string, readonly string[]> = {
+  'screenplay.to_shot_script': ['【任务】把下面的场次剧本拆成'],
+  'chapter.to_screenplay': [
+    '请把下面的小说/长文稿章节改写为影视剧本',
+    '【任务】把下面的原文改写为规范的影视场次剧本',
+  ],
+  'screenplay.extract_characters': [
+    '【任务】你是资深影视美术/设定师。通读下面的剧本，抽取其中出现的全部角色',
+  ],
+  'screenplay.extract_scenes': [
+    '【任务】你是资深影视美术/设定师。通读下面的剧本，抽取其中出现的全部场景',
+  ],
+  'screenplay.extract_props': [
+    '【任务】你是资深影视美术/设定师。通读下面的剧本，抽取其中出现的全部道具',
+  ],
+  'screenplay.extract_effects': [
+    '【任务】你是资深影视美术/设定师。通读下面的剧本，抽取其中出现的全部特效',
+  ],
+  'screenplay.split_episodes': ['请把下面的长剧本按剧情冲突、悬念节奏和合理时长完成分集'],
+}
+
+/**
+ * Repair legacy functional nodes whose dedicated contract was prefixed by an unrelated
+ * generic operation preset. The target-specific marker is deliberately conservative:
+ * if it cannot be found, preserve the authored prompt unchanged.
+ */
+export function normalizeCanvasFunctionalSystemPrompt(
+  prompt: string | null | undefined,
+  presetTargetId: string,
+): string {
+  const value = prompt?.trim() ?? ''
+  if (!value) return ''
+  const markers = FUNCTIONAL_PROMPT_START_MARKERS[presetTargetId] ?? []
+  const markerIndexes = markers
+    .map((marker) => value.indexOf(marker))
+    .filter((index) => index >= 0)
+  if (markerIndexes.length === 0) return value
+  return value.slice(Math.min(...markerIndexes)).trim()
+}
+
 /**
  * Canonical editor initialization. Media inputs intentionally stay out of the
  * visible document: the media selector represents them, and the submission

--- a/apps/desktop/src/renderer/design/views/canvas/canvasSemanticTextTaskOutput.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasSemanticTextTaskOutput.test.ts
@@ -118,7 +118,26 @@ describe('semantic canvas text task output', () => {
       errorMsg: 'invalid_screenplay_output',
     })
     expect(snapshot.tasks[0]?.outputNodeIds).toEqual([])
+    expect(snapshot.tasks[0]?.modelOutputText).toBe('这是一个自由格式故事梗概。')
+    expect(snapshot.tasks[0]?.completedAt).toBeTruthy()
     expect(snapshot.nodes.some((node) => node.data.pipelineRole === 'screenplay')).toBe(false)
+  })
+
+  it('keeps model output separate when runtime diagnostics already exist', async () => {
+    seedSemanticTask('shot')
+    const modelText = JSON.stringify({ episode: 1, characters: [{ name: '苏烬' }] })
+
+    const snapshot = await canvasApi.applyTextTaskResult('project-1', 'task-1', {
+      ...responseBase,
+      text: modelText,
+      rawResponse: { executionPath: 'session-runtime', adapter: 'codex' },
+    })
+
+    expect(snapshot.tasks[0]).toMatchObject({
+      status: 'failed',
+      modelOutputText: modelText,
+      rawResponse: { executionPath: 'session-runtime', adapter: 'codex' },
+    })
   })
 
   it('normalizes valid storyboard JSON and writes shot groups before creating the result node', async () => {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasShotTableParse.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasShotTableParse.ts
@@ -195,7 +195,17 @@ function tryParseJsonObject(text: string): unknown | null {
     candidates.push(trimmed.slice(firstBrace, lastBrace + 1))
   for (const candidate of candidates) {
     try {
-      return JSON.parse(candidate)
+      const parsed = JSON.parse(candidate) as unknown
+      // Some adapters serialize the model's JSON one extra time. Accept that shape
+      // without making the task detail depend on provider-specific escaping.
+      if (typeof parsed === 'string') {
+        try {
+          return JSON.parse(parsed)
+        } catch {
+          return parsed
+        }
+      }
+      return parsed
     } catch {
       // try next candidate
     }

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTaskInputDiagnostics.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTaskInputDiagnostics.test.ts
@@ -48,6 +48,16 @@ describe('canvasTaskInputDiagnostics', () => {
   it('merges input diagnostics into task detail params', () => {
     expect(
       buildCanvasTaskDetailParams({
+        operation: 'text_to_image',
+        agentId: null,
+        skillIds: [],
+        providerProfileId: 'provider-1',
+        manifestId: 'manifest-1',
+        modelId: 'image-1',
+        reasoningEffort: null,
+        taskPipelineRole: 'design_card',
+        outputPipelineRole: 'design_card',
+        shotScriptConfig: { maxClipSec: 6 },
         modelParams: { size: '2:1', resolution: '2k' },
         inputFileDiagnostics: [
           {
@@ -61,9 +71,18 @@ describe('canvasTaskInputDiagnostics', () => {
         ],
       }),
     ).toEqual({
-      size: '2:1',
-      resolution: '2k',
-      _requestInputFiles: [
+      operation: 'text_to_image',
+      agentId: null,
+      skillIds: [],
+      providerProfileId: 'provider-1',
+      manifestId: 'manifest-1',
+      modelId: 'image-1',
+      reasoningEffort: null,
+      taskPipelineRole: 'design_card',
+      outputPipelineRole: 'design_card',
+      shotScriptConfig: { maxClipSec: 6 },
+      modelParams: { size: '2:1', resolution: '2k' },
+      requestInputFiles: [
         {
           type: 'image',
           payloadField: 'dataUrl',

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTaskInputDiagnostics.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTaskInputDiagnostics.ts
@@ -11,13 +11,35 @@ export function summarizeCanvasTaskInputFiles(
 }
 
 export function buildCanvasTaskDetailParams(
-  task: Pick<CanvasTask, 'modelParams' | 'inputFileDiagnostics'>,
+  task: Pick<
+    CanvasTask,
+    | 'operation'
+    | 'agentId'
+    | 'skillIds'
+    | 'providerProfileId'
+    | 'manifestId'
+    | 'modelId'
+    | 'reasoningEffort'
+    | 'modelParams'
+    | 'inputFileDiagnostics'
+    | 'taskPipelineRole'
+    | 'outputPipelineRole'
+    | 'shotScriptConfig'
+  >,
 ): Record<string, unknown> {
-  const modelParams = task.modelParams ?? {}
-  if (!task.inputFileDiagnostics || task.inputFileDiagnostics.length === 0) return modelParams
   return {
-    ...modelParams,
-    _requestInputFiles: task.inputFileDiagnostics,
+    operation: task.operation,
+    agentId: task.agentId ?? null,
+    skillIds: task.skillIds ?? [],
+    providerProfileId: task.providerProfileId ?? null,
+    manifestId: task.manifestId ?? null,
+    modelId: task.modelId ?? null,
+    reasoningEffort: task.reasoningEffort ?? null,
+    taskPipelineRole: task.taskPipelineRole ?? null,
+    outputPipelineRole: task.outputPipelineRole ?? null,
+    shotScriptConfig: task.shotScriptConfig ?? null,
+    modelParams: task.modelParams ?? {},
+    requestInputFiles: task.inputFileDiagnostics ?? [],
   }
 }
 

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTaskLifecycle.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTaskLifecycle.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendCanvasTaskRuntimeEvent,
+  appendCanvasTaskModelOutputEvent,
+  initialCanvasTaskRuntimeEvents,
+  syncCanvasNodeRuntimeData,
+  syncCanvasTaskRuntimeToNode,
+} from './canvasTaskLifecycle'
+import type { CanvasNodeData, CanvasTask } from './canvas.types'
+
+describe('canvas task lifecycle diagnostics', () => {
+  it('replaces stale node runtime fields when a new task is bound', () => {
+    const data: CanvasNodeData = {
+      modelId: 'old-model',
+      providerProfileId: 'old-provider',
+      agentId: 'old-agent',
+      modelParams: { temperature: 1 },
+      pipelineRole: 'character',
+    }
+
+    syncCanvasNodeRuntimeData(data, {
+      modelId: 'new-model',
+      providerProfileId: 'new-provider',
+      agentId: 'new-agent',
+      modelParams: { temperature: 0.2 },
+      taskPipelineRole: 'shot',
+      outputPipelineRole: 'shot',
+      skillIds: ['storyboard'],
+    })
+
+    expect(data).toMatchObject({
+      modelId: 'new-model',
+      providerProfileId: 'new-provider',
+      agentId: 'new-agent',
+      modelParams: { temperature: 0.2 },
+      pipelineRole: 'shot',
+      outputPipelineRole: 'shot',
+      skillIds: ['storyboard'],
+    })
+  })
+
+  it('clears runtime fields instead of retaining values from an older task', () => {
+    const data: CanvasNodeData = {
+      modelId: 'old-model',
+      providerProfileId: 'old-provider',
+      agentId: 'old-agent',
+      pipelineRole: 'shot',
+      outputPipelineRole: 'shot',
+    }
+
+    syncCanvasNodeRuntimeData(data, {})
+
+    expect(data.modelId).toBeUndefined()
+    expect(data.providerProfileId).toBeUndefined()
+    expect(data.agentId).toBeUndefined()
+    expect(data.pipelineRole).toBeUndefined()
+    expect(data.outputPipelineRole).toBeUndefined()
+  })
+
+  it('records lifecycle events in append order', () => {
+    const task = { runtimeEvents: initialCanvasTaskRuntimeEvents('2026-07-18T00:00:00.000Z') }
+    appendCanvasTaskRuntimeEvent(task, {
+      at: '2026-07-18T00:00:01.000Z',
+      kind: 'failed',
+      label: '结构解析失败',
+    })
+    expect(task.runtimeEvents.map((event) => event.kind)).toEqual(['created', 'failed'])
+  })
+
+  it('records the actual model output size as a provider response event', () => {
+    const task = { runtimeEvents: initialCanvasTaskRuntimeEvents('2026-07-18T00:00:00.000Z') }
+    appendCanvasTaskModelOutputEvent(task, '2026-07-18T00:00:01.000Z', '模型输出')
+    expect(task.runtimeEvents[1]).toMatchObject({
+      kind: 'provider_response',
+      detail: '4 字符',
+    })
+  })
+
+  it('preserves semantic roles when an older task has no persisted role fields', () => {
+    const data: CanvasNodeData = { pipelineRole: 'shot', outputPipelineRole: 'shot' }
+    const task = {
+      agentId: null,
+      providerProfileId: null,
+      manifestId: null,
+      modelId: null,
+      reasoningEffort: null,
+      skillIds: [],
+      modelParams: {},
+    } as unknown as CanvasTask
+
+    syncCanvasTaskRuntimeToNode(task, data)
+
+    expect(data.pipelineRole).toBe('shot')
+    expect(data.outputPipelineRole).toBe('shot')
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTaskLifecycle.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTaskLifecycle.ts
@@ -1,0 +1,95 @@
+import type {
+  CanvasNodeData,
+  CanvasPipelineRole,
+  CanvasTask,
+  CanvasTaskRuntimeEvent,
+} from './canvas.types'
+import type { SessionReasoningEffort } from '@spark/protocol'
+
+const MAX_TASK_RUNTIME_EVENTS = 100
+
+export function initialCanvasTaskRuntimeEvents(
+  at: string,
+  label = '任务创建',
+): CanvasTaskRuntimeEvent[] {
+  return [{ at, kind: 'created', label }]
+}
+
+export function appendCanvasTaskRuntimeEvent(
+  task: Pick<CanvasTask, 'runtimeEvents'>,
+  event: CanvasTaskRuntimeEvent,
+): void {
+  const events = [...(task.runtimeEvents ?? []), event]
+  task.runtimeEvents = events.slice(-MAX_TASK_RUNTIME_EVENTS)
+}
+
+export function appendCanvasTaskModelOutputEvent(
+  task: Pick<CanvasTask, 'runtimeEvents'>,
+  at: string,
+  text: string,
+): void {
+  appendCanvasTaskRuntimeEvent(task, {
+    at,
+    kind: 'provider_response',
+    label: '模型返回原始文本',
+    detail: `${text.length} 字符`,
+  })
+}
+
+export function syncCanvasNodeRuntimeData(
+  data: CanvasNodeData,
+  runtime: {
+    agentId?: string | null
+    providerProfileId?: string | null
+    manifestId?: string | null
+    modelId?: string | null
+    reasoningEffort?: SessionReasoningEffort | null
+    skillIds?: string[] | null
+    modelParams?: Record<string, unknown> | null
+    taskPipelineRole?: CanvasPipelineRole | null
+    outputPipelineRole?: CanvasPipelineRole | null
+  },
+): void {
+  syncOptionalString(data, 'agentId', runtime.agentId)
+  syncOptionalString(data, 'providerProfileId', runtime.providerProfileId)
+  syncOptionalString(data, 'manifestId', runtime.manifestId)
+  syncOptionalString(data, 'modelId', runtime.modelId)
+  if (runtime.reasoningEffort) data.reasoningEffort = runtime.reasoningEffort
+  else delete data.reasoningEffort
+  data.skillIds = [...(runtime.skillIds ?? [])]
+  data.modelParams = { ...(runtime.modelParams ?? {}) }
+  if (runtime.taskPipelineRole) data.pipelineRole = runtime.taskPipelineRole
+  else delete data.pipelineRole
+  if (runtime.outputPipelineRole) data.outputPipelineRole = runtime.outputPipelineRole
+  else delete data.outputPipelineRole
+}
+
+export function syncCanvasTaskRuntimeToNode(task: CanvasTask, data: CanvasNodeData): void {
+  syncCanvasNodeRuntimeData(data, {
+    agentId: task.agentId ?? null,
+    providerProfileId: task.providerProfileId ?? null,
+    manifestId: task.manifestId ?? null,
+    modelId: task.modelId ?? null,
+    reasoningEffort: task.reasoningEffort ?? null,
+    skillIds: task.skillIds ?? [],
+    modelParams: task.modelParams,
+    // Legacy tasks predate persisted role fields. Preserve the node's semantic roles
+    // for those records; new tasks explicitly store null when a role should be cleared.
+    taskPipelineRole:
+      task.taskPipelineRole === undefined ? (data.pipelineRole ?? null) : task.taskPipelineRole,
+    outputPipelineRole:
+      task.outputPipelineRole === undefined
+        ? (data.outputPipelineRole ?? null)
+        : task.outputPipelineRole,
+  })
+}
+
+function syncOptionalString(
+  data: CanvasNodeData,
+  key: 'agentId' | 'providerProfileId' | 'manifestId' | 'modelId',
+  value: string | null | undefined,
+): void {
+  const normalized = value?.trim() ?? ''
+  if (normalized) data[key] = normalized
+  else delete data[key]
+}

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTextOutputValidation.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTextOutputValidation.test.ts
@@ -54,11 +54,49 @@ describe('canvas semantic text output validation', () => {
     expect(validateCanvasSemanticTextOutput('shot', '{"shots":[]}')).toMatchObject({
       ok: false,
       code: 'invalid_storyboard_output',
+      message: expect.stringContaining('镜头数组为空'),
     })
     expect(validateCanvasSemanticTextOutput('shot', '普通段落')).toMatchObject({
       ok: false,
       code: 'invalid_storyboard_output',
     })
+  })
+
+  it('reports the received JSON schema when another functional task leaked into shots', () => {
+    expect(
+      validateCanvasSemanticTextOutput(
+        'shot',
+        JSON.stringify({ episode: 1, characters: [{ name: '苏烬' }] }),
+      ),
+    ).toMatchObject({
+      ok: false,
+      code: 'invalid_storyboard_output',
+      message: expect.stringContaining('episode、characters'),
+    })
+  })
+
+  it('accepts storyboard JSON serialized one extra time by an adapter', () => {
+    const serialized = JSON.stringify(
+      JSON.stringify({
+        shots: [{ index: 1, durationSec: 3, description: '苏烬抬头。' }],
+      }),
+    )
+    expect(validateCanvasSemanticTextOutput('shot', serialized)).toMatchObject({ ok: true })
+  })
+
+  it('validates every structured entity output role', () => {
+    for (const role of ['character', 'scene', 'prop', 'effect'] as const) {
+      expect(validateCanvasSemanticTextOutput(role, '无法按要求输出')).toMatchObject({
+        ok: false,
+        code: 'invalid_entity_output',
+      })
+      expect(
+        validateCanvasSemanticTextOutput(
+          role,
+          JSON.stringify({ entities: [{ name: `${role}-1`, description: '详细描述' }] }),
+        ),
+      ).toMatchObject({ ok: true })
+    }
   })
 
   it('leaves non-semantic text roles unchanged', () => {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTextOutputValidation.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTextOutputValidation.ts
@@ -1,12 +1,20 @@
 import type { CanvasPipelineRole } from './canvas.types'
 import { parseShotTable, type ParsedShotRow } from './canvasShotTableParse'
 import { formatStoryboardRowsAsMarkdown } from './canvasTextInputPresentation'
+import {
+  extractEntityKindLabel,
+  parseExtractedEntities,
+  type ExtractEntityKind,
+} from './canvasEntityExtract'
 
 export type CanvasSemanticTextValidation =
   | { ok: true; text: string; storyboardRows?: ParsedShotRow[] }
   | {
       ok: false
-      code: 'invalid_screenplay_output' | 'invalid_storyboard_output'
+      code:
+        | 'invalid_screenplay_output'
+        | 'invalid_storyboard_output'
+        | 'invalid_entity_output'
       message: string
     }
 
@@ -37,10 +45,12 @@ export function validateCanvasSemanticTextOutput(
   if (role === 'shot') {
     const storyboardRows = parseShotTable(value)
     if (storyboardRows.length === 0) {
+      const jsonShape = inspectJsonShape(value)
+      const message = storyboardValidationMessage(jsonShape)
       return {
         ok: false,
         code: 'invalid_storyboard_output',
-        message: '分镜结果不包含可解析的 shots JSON 或分镜表，未加载为分镜节点。',
+        message,
       }
     }
     return {
@@ -49,5 +59,61 @@ export function validateCanvasSemanticTextOutput(
       storyboardRows,
     }
   }
+  const entityKind = pipelineRoleToEntityKind(role)
+  if (entityKind) {
+    const entities = parseExtractedEntities(entityKind, value)
+    if (entities.length === 0) {
+      return {
+        ok: false,
+        code: 'invalid_entity_output',
+        message: `${extractEntityKindLabel(entityKind)}抽取结果不包含可解析的 entities JSON 或实体清单，未加载为实体节点。`,
+      }
+    }
+  }
   return { ok: true, text: value }
+}
+
+function pipelineRoleToEntityKind(role: CanvasPipelineRole | undefined): ExtractEntityKind | null {
+  return role === 'character' || role === 'scene' || role === 'prop' || role === 'effect'
+    ? role
+    : null
+}
+
+type JsonShape = { keys: string[]; shotsLength?: number } | null
+
+function inspectJsonShape(text: string): JsonShape {
+  const candidates = [text.trim()]
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i)
+  if (fenced?.[1]) candidates.push(fenced[1].trim())
+  const firstBrace = text.indexOf('{')
+  const lastBrace = text.lastIndexOf('}')
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    candidates.push(text.slice(firstBrace, lastBrace + 1))
+  }
+  for (const candidate of candidates) {
+    try {
+      let parsed = JSON.parse(candidate) as unknown
+      if (typeof parsed === 'string') parsed = JSON.parse(parsed) as unknown
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue
+      const record = parsed as Record<string, unknown>
+      return {
+        keys: Object.keys(record),
+        ...(Array.isArray(record.shots) ? { shotsLength: record.shots.length } : {}),
+      }
+    } catch {
+      // Try the next candidate.
+    }
+  }
+  return null
+}
+
+function storyboardValidationMessage(shape: JsonShape): string {
+  if (shape?.shotsLength === 0) {
+    return '分镜结果包含 shots，但镜头数组为空，未加载为分镜节点。请检查模型输出或任务输入。'
+  }
+  if (shape && shape.keys.length > 0) {
+    const keys = shape.keys.slice(0, 8).join('、')
+    return `分镜结果 JSON 顶层字段为 ${keys}；期望 shots（或可解析的分镜表）。该输出可能来自错误的节点功能提示词，未加载为分镜节点。`
+  }
+  return '分镜结果不包含可解析的 shots JSON 或分镜表，未加载为分镜节点。'
 }

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTrackedWorkflowDiagnostics.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTrackedWorkflowDiagnostics.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { mergeCanvasTrackedWorkflowDiagnostics } from './canvasTrackedWorkflowDiagnostics'
+
+describe('canvasTrackedWorkflowDiagnostics', () => {
+  it('preserves the model output while later diagnostics add an error response', () => {
+    expect(
+      mergeCanvasTrackedWorkflowDiagnostics(
+        { modelOutputText: '{"characters":[]}', modelId: 'model-a' },
+        { rawResponse: { requestId: 'req-1' } },
+      ),
+    ).toEqual({
+      modelOutputText: '{"characters":[]}',
+      modelId: 'model-a',
+      rawResponse: { requestId: 'req-1' },
+    })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTrackedWorkflowDiagnostics.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTrackedWorkflowDiagnostics.ts
@@ -1,0 +1,20 @@
+export type CanvasTrackedWorkflowDiagnostics = {
+  modelOutputText?: string | null
+  rawResponse?: unknown
+  agentId?: string | null
+  providerProfileId?: string | null
+  provider?: string | null
+  modelId?: string | null
+}
+
+export type CaptureCanvasTrackedWorkflowDiagnostics = (
+  diagnostics: CanvasTrackedWorkflowDiagnostics,
+) => void
+
+/** Keep the latest field values while a multi-step workflow progresses. */
+export function mergeCanvasTrackedWorkflowDiagnostics(
+  current: CanvasTrackedWorkflowDiagnostics,
+  next: CanvasTrackedWorkflowDiagnostics,
+): CanvasTrackedWorkflowDiagnostics {
+  return { ...current, ...next }
+}

--- a/docs/design/canvas-task-observability.md
+++ b/docs/design/canvas-task-observability.md
@@ -1,6 +1,6 @@
 # 画布节点任务可观测性与异步视频修复
 
-> 状态: 已落地 | 最后核对: 2026-07-17
+> 状态: 已落地 | 最后核对: 2026-07-18
 
 ## 背景
 
@@ -45,6 +45,30 @@ xAI 另有一处终态解析错误：官方成功契约是 `status=done` 且产�
 - `event=cancel-*`：媒体任务取消请求与结果。
 
 `projectId + clientTaskId` 是画布侧的主关联键；媒体任务还可以继续用 `runtimeTaskId + providerRequestId` 串联 `[canvas:media-task-runtime]`、`[media:adapter]` 和 `[media:task-poll]`。
+
+### 节点任务详情诊断
+
+任务记录同时保存 `operationNodeId` 与真实生命周期事件。操作节点后续重试并切换到新 task 时，历史任务仍可定位到原节点；任务详情不再使用同一个 `updatedAt` 伪造多条运行日志。
+
+文本任务把以下信息分开保存和展示：
+
+- `modelOutputText`：模型/Agent 原始文本，结构解析失败时也必须保留；
+- `rawResponse`：Session runtime 或 Provider 的非敏感诊断摘要，不再冒充模型正文；
+- `systemPrompt` 与 `compiledUserText`：最终提交的 System/User Prompt；
+- 完整运行配置：Agent、Provider Profile、Manifest、Model、推理强度、Skill、pipeline role、模型参数和输入文件传输摘要；
+- `completedAt`：成功、失败与取消三种终态都必须写入。
+
+结构化输出校验失败时，详情仍显示模型原文，并尽量报告实际收到的 JSON 顶层字段。例如分镜任务收到 `episode/characters` 时，应明确指出期望 `shots`，而不是只显示“无法解析”。
+
+重试提供两种明确语义：“使用当前节点模型重试”复用冻结的任务输入但采用节点当前 Agent/Provider/Model/参数；“按原任务模型重试”完整复用原运行时配置。
+
+任务一旦进入 `running` 或终态即成为不可变执行快照。后续在操作节点中切换模型、Provider、Agent、Skill 或参数，只修改节点的下一次运行配置，不得回写历史任务；分镜的 `shotScriptConfig` 也按任务独立保存，详情不能用节点当前值冒充历史值。
+
+角色、场景、道具和特效抽取共用完整实体解析链路。模型返回后先写入独立诊断快照，再开始解析和资产物化；即使解析器抛错，任务详情仍保存完整 `modelOutputText`、Provider 摘要和实际模型信息，而不是只保留截断的异常预览。
+
+文本执行路径按 Provider 的真实 wire protocol 选择：Anthropic-compatible 走 Messages；明确声明 `chat`/`responses` 的 OpenAI-compatible Profile 才可进入对应 Codex Session Runtime；缺少 `codexApiKind` 的旧 OpenAI-compatible Profile 保守回退直连 Chat Completions，避免被默认探测 `/responses`。
+
+旧任务迁移按边类型恢复操作节点：`used_as_input` 使用 target，`generated` 使用 source。迁移结果按实际数据库对象缓存，项目重载或回滚得到的新快照仍会执行兼容迁移。
 
 ### 异步轮询诊断
 

--- a/docs/superpowers/plans/2026-07-18-canvas-agent-specialized-node-tools.md
+++ b/docs/superpowers/plans/2026-07-18-canvas-agent-specialized-node-tools.md
@@ -326,3 +326,16 @@ git commit -m "feat(canvas): add specialized agent node tools"
 - `pnpm --filter @spark/desktop typecheck`、`pnpm --filter @spark/desktop lint` 和桌面生产构建通过。
 - 五轴审查补充了文本任务终态幂等、媒体类型/分镜回链前置校验和空语义名称校验。
 - GitNexus MCP 未暴露，按项目降级规则使用 `rg` 调用点、全量画布测试、类型检查、构建和 `git diff` 完成影响核对。
+
+### 2026-07-18 运行时与诊断维护补充
+
+- [x] Anthropic-compatible Provider 不再因 Agent adapter 为 Codex 而被错误路由到 Responses WebSocket；本地 Codex/Claude CLI 路由保持不变。
+- [x] 专用功能 Prompt 与通用操作 Prompt 隔离，空白画布入口补齐 task/output role 与 workflow。
+- [x] 历史污染的分镜、剧本和实体抽取 Prompt 在运行/重试时按专用契约标记修复。
+- [x] 结构解析失败独立保留模型原文，写入失败终态时间并输出 schema 诊断。
+- [x] 任务详情展示最终 System/User Prompt、完整运行配置、真实生命周期事件与独立运行时诊断。
+- [x] 节点卡片同步最新 Agent/Provider/Model；重试区分当前节点模型与原任务模型。
+- [x] 终态任务配置冻结，节点草稿不再覆盖原任务模型；分镜时长配置按任务快照保存。
+- [x] 角色、场景、道具、特效统一进入实体解析与资产物化路径，解析前先保存完整模型原文。
+- [x] 旧 OpenAI Chat Profile 缺少 wire protocol 时回退直连，不再默认探测 Responses。
+- [x] 旧任务按边语义恢复操作节点，生成边使用 source、输入边使用 target。

--- a/docs/superpowers/specs/2026-07-18-canvas-agent-specialized-node-tools-design.md
+++ b/docs/superpowers/specs/2026-07-18-canvas-agent-specialized-node-tools-design.md
@@ -87,7 +87,13 @@ UI 右键入口和 Agent 专用操作工具都调用同一个执行函数，不�
 - 实体抽取：使用现有实体解析器；没有合法实体时不创建影视资产。
 - 校验通过后，由代码生成现有 Markdown 展示文本，并一次性补齐节点角色、影视资产、生产状态和来源边。
 
-原始模型响应仍保存在任务诊断字段中，便于排查 Provider 截断、无效 JSON 或字段缺失。
+模型原始文本保存在独立的 `modelOutputText` 诊断字段中；Provider/Session runtime 摘要保存在 `rawResponse`。即使结构校验失败，二者也不能互相覆盖，便于排查 Provider 截断、无效 JSON、错误 schema 或字段缺失。
+
+该约束同时适用于普通文本任务和 renderer 侧跟踪的实体工作流。角色、场景、道具、特效在解析之前先记录完整模型输出；解析失败时沿失败终态写回，不得只保存错误摘要。四类实体 workflow 共用同一个类型解析入口和物化路径。
+
+任务记录是执行时快照：运行后不再随操作节点草稿变化。原任务重试读取任务快照，当前节点重试读取节点配置；分镜时长配置也必须写入任务。历史 `operationNodeId` 按 `used_as_input.target` 或 `generated.source` 恢复，不能关联到产物节点。
+
+专用功能 system prompt 是输出 schema 的唯一契约。通用 `text_generate`/`text_rewrite` 操作预设只能提供通用节点的默认 Prompt，不得拼接进分镜、剧本、分集或实体抽取契约；Agent 人设、Skill 和项目风格只能补充能力与风格，不能改变专用任务类型和输出 schema。历史节点若已经出现通用 Prompt 前缀污染，提交或重试时按专用契约标记剥离该前缀。
 
 ## 专用工具范围
 
@@ -255,7 +261,7 @@ UI 右键入口和 Agent 专用操作工具都调用同一个执行函数，不�
 
 - 已注册 13 个专用 Agent 工具，全部复用现有 `CanvasNode.type`、`pipelineRole`、影视资产 kind 和分镜 metadata，没有新增节点类型或持久化版本字段。
 - `canvas_get_available_actions` 只在 Agent 工具返回层把 `pipeline/recommended_flow` 配方改写为 `canvas_create_pipeline_operation_node`；UI 使用的原始能力目录和手动节点入口不变。
-- 剧本和分镜文本任务在创建语义产物前校验；无效结果保留原始响应并标记任务失败。分镜通过后由程序生成 Markdown 并写入 ShotGroup/ShotSegment。
+- 剧本和分镜文本任务在创建语义产物前校验；无效结果分别保留模型原文与运行时诊断并标记任务失败。分镜通过后由程序生成 Markdown 并写入 ShotGroup/ShotSegment。
 - 文本任务终态回调具备幂等保护，避免重复事件重复追加分镜；媒体语义工具会在写入前校验媒体类型和分镜回链。
 - 通用文本与通用操作工具仍然保留，但 Agent 指引明确禁止用它们伪装剧本、分镜或影视资产。
 

--- a/packages/agent-runtime/src/__tests__/sdk/codex-sdk-executor.test.ts
+++ b/packages/agent-runtime/src/__tests__/sdk/codex-sdk-executor.test.ts
@@ -508,6 +508,11 @@ describe('CodexSdkExecutor', () => {
             'Reconnecting... 2/5 (unexpected status 404 Not Found: endpoint not supported, url: ws://localhost:59538/v1/responses)',
         },
         {
+          type: 'error',
+          message:
+            'Reconnecting... 2/5 (unexpected status 404 Not Found: 404 page not found, url: wss://api.minimaxi.com/anthropic/responses)',
+        },
+        {
           type: 'item.completed',
           item: {
             id: 'transport-fallback-1',

--- a/packages/agent-runtime/src/sdk/codex-sdk-executor.ts
+++ b/packages/agent-runtime/src/sdk/codex-sdk-executor.ts
@@ -916,10 +916,13 @@ function computeDelta(next: string, prev: string): string {
 }
 
 function isBenignCodexSdkError(message: string): boolean {
+  const normalizedMessage = message.toLowerCase()
   const isUnsupportedResponsesWebSocket =
-    message.includes('unexpected status 404 Not Found: endpoint not supported') &&
-    message.includes('/v1/responses') &&
-    (message.includes('ws://') || message.includes('WebSockets') || message.includes('WebSocket'))
+    normalizedMessage.includes('unexpected status 404') &&
+    /wss?:\/\/\S+\/(?:v1\/)?responses\b/i.test(message) &&
+    (normalizedMessage.includes('reconnecting') ||
+      normalizedMessage.includes('falling back') ||
+      normalizedMessage.includes('websocket'))
   const isUnsupportedServiceTierWarning =
     message.includes('Configured service tier `') &&
     message.includes('` is not advertised as supported for model `') &&


### PR DESCRIPTION
## Summary

- fix provider routing so Anthropic-compatible MiniMax requests avoid the invalid Codex WebSocket endpoint, while legacy OpenAI chat profiles stay on direct HTTP chat
- preserve immutable task-time model/config/input/output snapshots and expose raw model output even when storyboard or entity parsing fails
- fix storyboard and character/scene/prop/effect structured-output parsing, retry semantics, model labels, and legacy task-to-operation migration

## Verification

- desktop canvas/IPC tests: 137 files, 930 tests passed
- agent runtime executor tests: 20 tests passed
- desktop and agent-runtime typechecks passed
- desktop production build passed
- targeted lint passed with no errors

## Notes

- full desktop lint still reports two pre-existing `no-require-imports` errors in `after-pack.test.ts` and `build-memory.test.ts`; neither file is changed by this PR
