### PR TITLE
fix(canvas): isolate storyboard workflow and expose model calls

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spark/desktop",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "SparkWork desktop application — Electron + React + TypeScript",
   "author": "SparkWork Team",
   "private": true,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spark/desktop",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "SparkWork desktop application — Electron + React + TypeScript",
   "author": "SparkWork Team",
   "private": true,

--- a/apps/desktop/src/main/ipc/canvasTextTaskRequestCall.test.ts
+++ b/apps/desktop/src/main/ipc/canvasTextTaskRequestCall.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import type { ProviderProfile } from '@spark/protocol'
+import {
+  buildCanvasSessionRuntimeRequestCall,
+  resolveCanvasSessionRuntimeModelUrl,
+} from './canvasTextTaskRequestCall'
+
+function profile(overrides: Partial<ProviderProfile> = {}): ProviderProfile {
+  return {
+    id: 'provider-1',
+    name: 'Example',
+    provider: 'openai',
+    isDefault: false,
+    defaultModel: 'gpt-5',
+    modelIds: ['gpt-5'],
+    modelType: 'text',
+    codexApiKind: 'responses',
+    apiEndpoint: 'https://api.example.com/v1',
+    createdAt: '2026-07-18T00:00:00.000Z',
+    keystoreRef: 'provider-1',
+    ...overrides,
+  }
+}
+
+describe('canvas session runtime request diagnostics', () => {
+  it('resolves the concrete Responses and Chat endpoints used by remote Codex SDK profiles', () => {
+    expect(resolveCanvasSessionRuntimeModelUrl(profile(), 'codex')).toBe(
+      'https://api.example.com/v1/responses',
+    )
+    expect(resolveCanvasSessionRuntimeModelUrl(profile({ codexApiKind: 'chat' }), 'codex')).toBe(
+      'https://api.example.com/v1/chat/completions',
+    )
+  })
+
+  it('labels built-in CLI execution without pretending it is a captured HTTP request', () => {
+    const local = profile({
+      id: 'local-codex-cli',
+      provider: 'codex-cli',
+    })
+    delete local.apiEndpoint
+    expect(resolveCanvasSessionRuntimeModelUrl(local, 'codex')).toBe('local-cli://codex')
+    expect(
+      buildCanvasSessionRuntimeRequestCall({
+        profile: local,
+        adapter: 'codex',
+        model: 'codex cli',
+        invocation: { sdkOrCliRequest: { command: 'codex' } },
+      }),
+    ).toMatchObject({ method: 'CODEX CLI', url: 'local-cli://codex' })
+  })
+
+  it('preserves the final SDK invocation arguments in the request snapshot', () => {
+    expect(
+      buildCanvasSessionRuntimeRequestCall({
+        profile: profile(),
+        adapter: 'codex',
+        model: 'gpt-5',
+        invocation: {
+          createSession: { permissionMode: 'codex-full-access' },
+          sendTurn: { message: '最终消息', reasoningEffort: 'high' },
+        },
+      }),
+    ).toMatchObject({
+      method: 'CODEX SDK',
+      url: 'https://api.example.com/v1/responses',
+      body: {
+        transport: 'session-runtime-sdk',
+        model: 'gpt-5',
+        apiKind: 'responses',
+        sendTurn: { message: '最终消息', reasoningEffort: 'high' },
+      },
+    })
+  })
+})

--- a/apps/desktop/src/main/ipc/canvasTextTaskRequestCall.ts
+++ b/apps/desktop/src/main/ipc/canvasTextTaskRequestCall.ts
@@ -1,0 +1,88 @@
+import {
+  isBuiltInLocalCliProvider,
+  type MediaRequestCall,
+  type ProviderProfile,
+  type SessionAgentAdapter,
+} from '@spark/protocol'
+
+const ANTHROPIC_DEFAULT_ENDPOINT = 'https://api.anthropic.com'
+const OPENAI_DEFAULT_ENDPOINT = 'https://api.openai.com/v1'
+
+export class CanvasSessionRuntimeInvocationError extends Error {
+  override readonly cause: unknown
+  readonly requestCall: MediaRequestCall
+
+  constructor(cause: unknown, requestCall: MediaRequestCall) {
+    super(cause instanceof Error ? cause.message : String(cause))
+    this.name = 'CanvasSessionRuntimeInvocationError'
+    this.cause = cause
+    this.requestCall = requestCall
+  }
+}
+
+export function buildCanvasSessionRuntimeRequestCall(input: {
+  profile: ProviderProfile
+  adapter: SessionAgentAdapter
+  model: string
+  invocation: Record<string, unknown>
+}): MediaRequestCall {
+  const isLocalCli = isBuiltInLocalCliProvider(input.profile)
+  return {
+    method: input.adapter === 'codex' ? (isLocalCli ? 'CODEX CLI' : 'CODEX SDK') : 'CLAUDE SDK',
+    url: resolveCanvasSessionRuntimeModelUrl(input.profile, input.adapter),
+    body: {
+      transport: isLocalCli ? 'local-cli' : 'session-runtime-sdk',
+      adapter: input.adapter,
+      providerProfileId: input.profile.id,
+      provider: input.profile.provider,
+      providerName: input.profile.name,
+      model: input.model,
+      apiKind: input.adapter === 'codex' ? (input.profile.codexApiKind ?? 'responses') : 'messages',
+      ...input.invocation,
+    },
+  }
+}
+
+export function resolveCanvasSessionRuntimeModelUrl(
+  profile: ProviderProfile,
+  adapter: SessionAgentAdapter,
+): string {
+  if (isBuiltInLocalCliProvider(profile)) {
+    return adapter === 'codex' ? 'local-cli://codex' : 'local-cli://claude'
+  }
+  if (adapter === 'codex') {
+    return profile.codexApiKind === 'chat'
+      ? openAiChatEndpoint(profile.apiEndpoint)
+      : openAiResponsesEndpoint(profile.apiEndpoint)
+  }
+  return anthropicMessagesEndpoint(profile.apiEndpoint)
+}
+
+function anthropicMessagesEndpoint(apiEndpoint?: string): string {
+  const base = normalizeEndpoint(apiEndpoint, ANTHROPIC_DEFAULT_ENDPOINT)
+  if (base.endsWith('/v1/messages')) return base
+  if (base.endsWith('/v1')) return `${base}/messages`
+  return `${base}/v1/messages`
+}
+
+function openAiChatEndpoint(apiEndpoint?: string): string {
+  const base = normalizeEndpoint(apiEndpoint, OPENAI_DEFAULT_ENDPOINT)
+  if (base.endsWith('/chat/completions')) return base
+  if (base.endsWith('/responses')) return `${base.slice(0, -'/responses'.length)}/chat/completions`
+  if (base.endsWith('/v1')) return `${base}/chat/completions`
+  return `${base}/v1/chat/completions`
+}
+
+function openAiResponsesEndpoint(apiEndpoint?: string): string {
+  const base = normalizeEndpoint(apiEndpoint, OPENAI_DEFAULT_ENDPOINT)
+  if (base.endsWith('/responses')) return base
+  if (base.endsWith('/chat/completions')) {
+    return `${base.slice(0, -'/chat/completions'.length)}/responses`
+  }
+  if (base.endsWith('/v1')) return `${base}/responses`
+  return `${base}/v1/responses`
+}
+
+function normalizeEndpoint(custom: string | undefined, fallback: string): string {
+  return (custom?.trim() || fallback).replace(/\/+$/, '')
+}

--- a/apps/desktop/src/main/ipc/index.ts
+++ b/apps/desktop/src/main/ipc/index.ts
@@ -36,6 +36,10 @@ import {
   resolveCanvasTextModel,
 } from './canvasTextTaskRuntime.js'
 import {
+  buildCanvasSessionRuntimeRequestCall,
+  CanvasSessionRuntimeInvocationError,
+} from './canvasTextTaskRequestCall.js'
+import {
   mapCanvasMediaTaskInputFiles,
   validateCanvasMediaTaskParams,
 } from './canvasMediaTaskValidation.js'
@@ -144,6 +148,7 @@ import type {
   MediaProviderProfile as MediaProviderProfileRuntime,
   MediaTaskRecord,
   MediaProviderError,
+  SDKInvocationSnapshot,
 } from '@spark/agent-runtime'
 import * as keystore from '@spark/shared/keystore'
 import { ScheduledTaskService } from '@spark/agent-runtime'
@@ -3636,38 +3641,80 @@ export function registerAllIpcHandlers(): void {
         const filePath = file.path?.trim() || decodeSafeFileUrl(file.url)
         return filePath ? [{ type: 'image' as const, path: filePath }] : []
       })
+      const effectiveReasoningEffort = req.reasoningEffort
+        ? req.reasoningEffort
+        : agent?.reasoningEffort != null && isProtocolReasoning(agent.reasoningEffort)
+          ? agent.reasoningEffort
+          : undefined
+      const createSessionInvocation = {
+        title: `[画布文本] ${req.operation}`,
+        providerProfileId: profile.id,
+        ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+        modelId: model,
+        agentAdapter: adapter,
+        permissionMode,
+        chatMode: 'agent' as const,
+      }
+      const sendTurnInvocation = {
+        message,
+        providerProfileId: profile.id,
+        modelId: model,
+        skillIds: selectedSkillIds,
+        ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+        agentAdapter: adapter,
+        permissionMode,
+        ...(effectiveReasoningEffort ? { reasoningEffort: effectiveReasoningEffort } : {}),
+        ...(attachments.length > 0 ? { attachments } : {}),
+      }
+      let requestCall = buildCanvasSessionRuntimeRequestCall({
+        profile,
+        adapter,
+        model,
+        invocation: {
+          captureStatus: 'session-dispatch',
+          createSession: createSessionInvocation,
+          sendTurn: sendTurnInvocation,
+        },
+      })
       let sessionId: string | undefined
       let terminal = false
       try {
         await ensureNoProjectDirectoryExists()
         const noProjectWorkspaceId = getNoProjectWorkspaceId()
-        const created = await getSessionService().createSession({
-          title: `[画布文本] ${req.operation}`,
-          providerProfileId: profile.id,
+        const createSessionRequest = {
+          ...createSessionInvocation,
           ...(noProjectWorkspaceId ? { workspaceId: noProjectWorkspaceId } : {}),
-          ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
-          modelId: model,
-          agentAdapter: adapter,
-          permissionMode,
-          chatMode: 'agent',
-        })
+        }
+        const created = await getSessionService().createSession(createSessionRequest)
         sessionId = created.sessionId
-        const turn = await getSessionService().sendTurn({
+        const sendTurnRequest = {
           sessionId,
-          message,
-          providerProfileId: profile.id,
-          modelId: model,
-          skillIds: selectedSkillIds,
-          ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
-          agentAdapter: adapter,
-          permissionMode,
-          ...(req.reasoningEffort
-            ? { reasoningEffort: req.reasoningEffort }
-            : agent?.reasoningEffort != null && isProtocolReasoning(agent.reasoningEffort)
-              ? { reasoningEffort: agent.reasoningEffort }
-              : {}),
-          ...(attachments.length > 0 ? { attachments } : {}),
+          ...sendTurnInvocation,
+          invocationObserver: (snapshot: SDKInvocationSnapshot) => {
+            requestCall = buildCanvasSessionRuntimeRequestCall({
+              profile,
+              adapter,
+              model,
+              invocation: {
+                captureStatus: 'executor-final',
+                transport: snapshot.transport,
+                sdkOrCliRequest: snapshot.request,
+              },
+            })
+          },
+        }
+        requestCall = buildCanvasSessionRuntimeRequestCall({
+          profile,
+          adapter,
+          model,
+          invocation: {
+            captureStatus: 'session-dispatch',
+            createSession: createSessionRequest,
+            sendTurn: { sessionId, ...sendTurnInvocation },
+            timeoutMs: requestTimeoutMs,
+          },
         })
+        const turn = await getSessionService().sendTurn(sendTurnRequest)
         // SessionService.sendTurn 只负责启动 executor，真正的 SDK/CLI 运行在后台
         // promise 中；不能立刻读 history，否则 Codex 尚未写入 assistant_message。
         // 轮询临时 session 的完整事件，直到本轮出现终态事件。
@@ -3691,6 +3738,7 @@ export function registerAllIpcHandlers(): void {
           provider: profile.provider,
           model,
           text: finalText,
+          requestCall,
           rawResponse: {
             providerProfileId: profile.id,
             provider: profile.provider,
@@ -3707,8 +3755,11 @@ export function registerAllIpcHandlers(): void {
             agentId: req.agentId ?? null,
             skillIds: selectedSkillIds,
             relationManifest: runtimeRequest.relationManifest,
+            modelCallUrl: requestCall.url,
           },
         }
+      } catch (error) {
+        throw new CanvasSessionRuntimeInvocationError(error, requestCall)
       } finally {
         if (sessionId != null) {
           const sessionService = getSessionService()
@@ -3789,14 +3840,21 @@ export function registerAllIpcHandlers(): void {
           )
           return response
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err)
+          const runtimeError = err instanceof CanvasSessionRuntimeInvocationError ? err.cause : err
+          const message =
+            runtimeError instanceof Error ? runtimeError.message : String(runtimeError)
           return fail(
-            err instanceof CanvasTextTimeoutError ? err.code : 'text_generation_failed',
+            runtimeError instanceof CanvasTextTimeoutError
+              ? runtimeError.code
+              : 'text_generation_failed',
             message,
             {
               providerProfileId: candidate.id,
               provider: candidate.provider,
               model,
+              ...(err instanceof CanvasSessionRuntimeInvocationError
+                ? { requestCall: err.requestCall }
+                : {}),
               rawResponse: {
                 providerProfileId: candidate.id,
                 provider: candidate.provider,
@@ -3810,6 +3868,9 @@ export function registerAllIpcHandlers(): void {
                 remainingContextTokens: tokenBudget.remainingContextTokens,
                 contextSafetyTokens: tokenBudget.contextSafetyTokens,
                 requestTimeoutMs,
+                ...(err instanceof CanvasSessionRuntimeInvocationError
+                  ? { modelCallUrl: err.requestCall.url }
+                  : {}),
               },
             },
           )

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.test.ts
@@ -31,6 +31,8 @@ vi.mock('./canvas.capabilities', () => ({
 vi.mock('./canvasOperationPresets', () => ({
   mergeCanvasOperationPresetNegativePrompt: (base: string, preset: string) =>
     [base, preset].filter(Boolean).join('\n'),
+  mergeCanvasPresetTargetModelParams: (_targetId: string, params: Record<string, unknown>) =>
+    params,
   readCanvasOperationPreset: () => ({
     prompt: '',
     negativePrompt: '',
@@ -83,6 +85,16 @@ describe('CanvasOperationPanel negative prompt inheritance', () => {
         operationPresetNegativePrompt: '不要字幕',
       }),
     ).toBe('不要人物\n不要字幕')
+  })
+
+  it('prefers the editable node snapshot over its immutable historical task', () => {
+    expect(
+      resolveCanvasOperationPanelNegativePrompt({
+        nodeNegativePrompt: '当前节点配置',
+        taskNegativePrompt: '历史任务配置',
+        operationPresetNegativePrompt: '预设约束',
+      }),
+    ).toBe('当前节点配置\n预设约束')
   })
 
   it('preserves user-selected param values when async defaults arrive later', () => {

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasOperationPanel.tsx
@@ -22,6 +22,7 @@ import { operationLabel } from './canvas.api'
 import { getCanvasCapability, nodeOperation } from './canvas.capabilities'
 import {
   mergeCanvasOperationPresetNegativePrompt,
+  mergeCanvasPresetTargetModelParams,
   readCanvasResolvedPresetTarget,
   resolveCanvasPresetTarget,
   writeCanvasLastUsedPresetTarget,
@@ -224,8 +225,8 @@ export function resolveCanvasOperationPanelNegativePrompt(params: {
   operationPresetNegativePrompt?: string | null | undefined
 }): string {
   const baseNegativePrompt =
-    params.taskNegativePrompt?.trim() ||
     params.nodeNegativePrompt?.trim() ||
+    params.taskNegativePrompt?.trim() ||
     params.sourceNegativePrompts
       ?.map((value) => value?.trim() || '')
       .find((value) => value.length > 0) ||
@@ -281,7 +282,12 @@ export function isGeneratedCanvasFunctionalPrompt(
   if (presetTargetId === 'chapter.to_screenplay') {
     return value.includes('请把下面的小说/长文稿章节改写为影视剧本') && value.includes('章节原文：')
   }
-  if (presetTargetId === 'screenplay.extract_characters' || presetTargetId === 'screenplay.extract_scenes') {
+  if (
+    presetTargetId === 'screenplay.extract_characters' ||
+    presetTargetId === 'screenplay.extract_scenes' ||
+    presetTargetId === 'screenplay.extract_props' ||
+    presetTargetId === 'screenplay.extract_effects'
+  ) {
     return value.includes('【任务】你是资深影视美术/设定师') && value.includes('【剧本】')
   }
   return false
@@ -437,15 +443,17 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
     () =>
       resolveCanvasPresetTarget({
         operation,
-        taskPipelineRole: node.data.pipelineRole ?? null,
-        outputPipelineRole: node.data.outputPipelineRole ?? null,
-        workflow: task?.modelParams?.workflow ?? node.data.modelParams?.workflow,
+        taskPipelineRole: node.data.pipelineRole ?? task?.taskPipelineRole ?? null,
+        outputPipelineRole: node.data.outputPipelineRole ?? task?.outputPipelineRole ?? null,
+        workflow: node.data.modelParams?.workflow ?? task?.modelParams?.workflow,
       }),
     [
       node.data.modelParams?.workflow,
       node.data.outputPipelineRole,
       node.data.pipelineRole,
       operation,
+      task?.outputPipelineRole,
+      task?.taskPipelineRole,
       task?.modelParams?.workflow,
     ],
   )
@@ -533,8 +541,8 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
   )
   const hiddenFunctionalSystemPrompt = useMemo(
     () =>
-      task?.systemPrompt?.trim() ||
       node.data.systemPrompt?.trim() ||
+      task?.systemPrompt?.trim() ||
       (hideFunctionalPrompt
         ? stripGeneratedCanvasFunctionalPromptInput(functionalPromptSource, presetTargetId)
         : ''),
@@ -556,10 +564,10 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
   const initialPromptDocument = useMemo(
     () =>
       buildOperationPanelEditablePromptDocument({
-        ...(task?.promptDocument
-          ? { document: task.promptDocument }
-          : node.data.promptDocument
-            ? { document: node.data.promptDocument }
+        ...(node.data.promptDocument
+          ? { document: node.data.promptDocument }
+          : task?.promptDocument
+            ? { document: task.promptDocument }
             : {}),
         editablePrompt: initialPrompt,
         hideFunctionalPrompt,
@@ -628,10 +636,10 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
   } = useCanvasInputBindings({
     resetKey: node.id,
     initialDocument: initialPromptDocument,
-    ...(task?.inputBindings
-      ? { initialBindings: task.inputBindings }
-      : node.data.inputBindings
-        ? { initialBindings: node.data.inputBindings }
+    ...(node.data.inputBindings
+      ? { initialBindings: node.data.inputBindings }
+      : task?.inputBindings
+        ? { initialBindings: task.inputBindings }
         : {}),
     nodes: snapshot.nodes,
     connectionNodeIds: bindingConnectionNodeIds,
@@ -645,19 +653,19 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
   const [skills, setSkills] = useState<SkillItem[]>([])
   const [runtimeLoading, setRuntimeLoading] = useState(false)
   const [selectedAgentId, setSelectedAgentId] = useState(
-    task?.agentId ?? node.data.agentId ?? operationPreset.agentId ?? '',
+    node.data.agentId ?? task?.agentId ?? operationPreset.agentId ?? '',
   )
   const [selectedTextProviderId, setSelectedTextProviderId] = useState(
-    task?.providerProfileId ??
-      node.data.providerProfileId ??
+    node.data.providerProfileId ??
+      task?.providerProfileId ??
       operationPreset.providerProfileId ??
       '',
   )
   const [selectedTextModelId, setSelectedTextModelId] = useState(
-    task?.modelId ?? node.data.modelId ?? operationPreset.modelId ?? '',
+    node.data.modelId ?? task?.modelId ?? operationPreset.modelId ?? '',
   )
   const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>(
-    task?.skillIds ?? node.data.skillIds ?? operationPreset.skillIds,
+    node.data.skillIds ?? task?.skillIds ?? operationPreset.skillIds,
   )
   const [openRuntimeMenu, setOpenRuntimeMenu] = useState<RuntimePickerMenu>(null)
   const [modelParamDraft, setModelParamDraft] = useState<Record<string, string>>({})
@@ -693,15 +701,15 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
     setPromptDocument(initialPromptDocument)
     setNegativePrompt(inheritedNegativePrompt)
     setMessageDraft(node.data.message ?? '')
-    setSelectedAgentId(task?.agentId ?? node.data.agentId ?? operationPreset.agentId ?? '')
+    setSelectedAgentId(node.data.agentId ?? task?.agentId ?? operationPreset.agentId ?? '')
     setSelectedTextProviderId(
-      task?.providerProfileId ??
-        node.data.providerProfileId ??
+      node.data.providerProfileId ??
+        task?.providerProfileId ??
         operationPreset.providerProfileId ??
         '',
     )
-    setSelectedTextModelId(task?.modelId ?? node.data.modelId ?? operationPreset.modelId ?? '')
-    setSelectedSkillIds(task?.skillIds ?? node.data.skillIds ?? operationPreset.skillIds)
+    setSelectedTextModelId(node.data.modelId ?? task?.modelId ?? operationPreset.modelId ?? '')
+    setSelectedSkillIds(node.data.skillIds ?? task?.skillIds ?? operationPreset.skillIds)
     configurationTouchedRef.current = false
     // 分镜时长配置草稿：从 node.data.shotScriptConfig 解析到 preset/custom（随节点切换重置）。
     // 兼容脏数据：持久化的 maxClipSec 非法（缺省 / 非有限 / ≤0）时回退默认值，避免回显 -1 这类异常。
@@ -824,13 +832,13 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
         ? (agents.find((agent) => agent.id === operationPreset.agentId) ?? null)
         : null
     const defaultAgent =
-      (task?.agentId ? agents.find((agent) => agent.id === task.agentId) : null) ??
       (node.data.agentId ? agents.find((agent) => agent.id === node.data.agentId) : null) ??
+      (task?.agentId ? agents.find((agent) => agent.id === task.agentId) : null) ??
       presetAgent ??
       pickDefaultTextAgent(agents)
     const preferredProviderId =
-      task?.providerProfileId ??
       node.data.providerProfileId ??
+      task?.providerProfileId ??
       operationPreset.providerProfileId ??
       defaultAgent?.providerProfileId
     const defaultProvider = pickDefaultTextProvider(textProviders, preferredProviderId)
@@ -868,8 +876,8 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
         ? (agents.find((agent) => agent.id === operationPreset.agentId) ?? null)
         : null
     const defaultAgent =
-      (task?.agentId ? agents.find((agent) => agent.id === task.agentId) : null) ??
       (node.data.agentId ? agents.find((agent) => agent.id === node.data.agentId) : null) ??
+      (task?.agentId ? agents.find((agent) => agent.id === task.agentId) : null) ??
       presetAgent ??
       pickDefaultTextAgent(agents)
 
@@ -878,7 +886,7 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
       if (current && (models.length === 0 || models.includes(current))) return current
       return pickDefaultTextModel(
         provider,
-        task?.modelId ?? node.data.modelId ?? operationPreset.modelId ?? defaultAgent?.modelId,
+        node.data.modelId ?? task?.modelId ?? operationPreset.modelId ?? defaultAgent?.modelId,
       )
     })
   }, [
@@ -992,20 +1000,20 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
     const fromTask = supportedMediaModels.find(
       (model) =>
         (!(
-          task?.providerProfileId ??
           node.data.providerProfileId ??
+          task?.providerProfileId ??
           operationPreset.providerProfileId
         ) ||
           model.providerProfileId ===
-            (task?.providerProfileId ??
-              node.data.providerProfileId ??
+            (node.data.providerProfileId ??
+              task?.providerProfileId ??
               operationPreset.providerProfileId)) &&
-        (!(task?.manifestId ?? node.data.manifestId ?? operationPreset.manifestId) ||
+        (!(node.data.manifestId ?? task?.manifestId ?? operationPreset.manifestId) ||
           model.manifestId ===
-            (task?.manifestId ?? node.data.manifestId ?? operationPreset.manifestId)) &&
-        (!(task?.modelId ?? node.data.modelId ?? operationPreset.modelId) ||
+            (node.data.manifestId ?? task?.manifestId ?? operationPreset.manifestId)) &&
+        (!(node.data.modelId ?? task?.modelId ?? operationPreset.modelId) ||
           model.effectiveModelId ===
-            (task?.modelId ?? node.data.modelId ?? operationPreset.modelId)),
+            (node.data.modelId ?? task?.modelId ?? operationPreset.modelId)),
     )
     setSelectedModelKey(mediaModelKey(fromTask ?? supportedMediaModels[0]!))
   }, [
@@ -1024,7 +1032,7 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
 
   useEffect(() => {
     const defaults = selectedCapability?.defaults ?? {}
-    const existing = task?.modelParams ?? node.data.modelParams ?? {}
+    const existing = node.data.modelParams ?? task?.modelParams ?? {}
     const seeded = { ...operationPreset.modelParams, ...existing }
     const next: Record<string, string> = {}
     const fieldNames = new Set(allParameterFields.map((field) => field.name))
@@ -1079,15 +1087,24 @@ export const CanvasOperationPanel = memo(function CanvasOperationPanel({
 
   const buildCurrentModelParams = useCallback(
     () =>
-      normalizeModelParamsForSubmit(
-        {
-          ...buildModelParams(parameterFields, modelParamDraft),
-          ...buildCustomModelParams(customParams),
-        },
-        selectedCapability?.defaults ?? {},
-        parameterFields,
+      mergeCanvasPresetTargetModelParams(
+        presetTargetId,
+        normalizeModelParamsForSubmit(
+          {
+            ...buildModelParams(parameterFields, modelParamDraft),
+            ...buildCustomModelParams(customParams),
+          },
+          selectedCapability?.defaults ?? {},
+          parameterFields,
+        ),
       ),
-    [customParams, modelParamDraft, parameterFields, selectedCapability?.defaults],
+    [
+      customParams,
+      modelParamDraft,
+      parameterFields,
+      presetTargetId,
+      selectedCapability?.defaults,
+    ],
   )
 
   const handleTextAgentChange = useCallback(

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasTaskQueue.tsx
@@ -4,6 +4,7 @@ import { Descriptions, Empty, Modal, Progress, Space } from 'antd'
 import { Icons } from '../../Icons'
 import { operationLabel } from './canvas.api'
 import { buildCanvasTaskDetailParams } from './canvasTaskInputDiagnostics'
+import { stripDuplicateCanvasRuntimeDiagnostics } from './canvasTaskDetailPresentation'
 import type { CanvasAsset, CanvasNode, CanvasTask, CanvasTaskStatus } from './canvas.types'
 import { CanvasTaskInputSnapshotList } from './CanvasTaskInputSnapshotList'
 
@@ -59,8 +60,7 @@ export function CanvasTaskQueue({
     () => new Set(nodes.map((node) => node.taskId).filter(Boolean) as string[]),
     [nodes],
   )
-  const isOrphanTask = (task: CanvasTask) =>
-    isTaskActive(task) && !hostedTaskIds.has(task.id)
+  const isOrphanTask = (task: CanvasTask) => isTaskActive(task) && !hostedTaskIds.has(task.id)
   const orphanTasks = tasks.filter(isOrphanTask)
   const orphanCount = orphanTasks.length
   const detailTask = tasks.find((task) => task.id === detailTaskId) ?? null
@@ -71,10 +71,7 @@ export function CanvasTaskQueue({
     if (taskIds.length === 0 || clearingRef.current) return
     const count = taskIds.length
     Modal.confirm({
-      title:
-        count === 1
-          ? '清理该无节点的运行中任务？'
-          : `清理 ${count} 个无节点的运行中任务？`,
+      title: count === 1 ? '清理该无节点的运行中任务？' : `清理 ${count} 个无节点的运行中任务？`,
       content:
         '这些任务的承载节点已被删除，runtime 早已失效，无法正常取消。将直接从队列删除这些残留记录，操作不可撤销。',
       okText: '清理',
@@ -99,9 +96,7 @@ export function CanvasTaskQueue({
     if (count === 0 || clearingRef.current) return
     const isClearActive = scope === 'active'
     Modal.confirm({
-      title: isClearActive
-        ? `取消全部 ${count} 个运行中任务？`
-        : `清空全部 ${count} 个失败任务？`,
+      title: isClearActive ? `取消全部 ${count} 个运行中任务？` : `清空全部 ${count} 个失败任务？`,
       content: isClearActive
         ? '将中断这些正在运行的任务，已生成的部分结果不会保留。'
         : '将从队列中删除这些已结束的任务记录，操作不可撤销。',
@@ -161,7 +156,6 @@ export function CanvasTaskQueue({
               清理({orphanCount})
             </Button>
           )}
-   
         </Space>
       </div>
 
@@ -385,7 +379,7 @@ function TaskCard({
         <div className="canvas-task-card-error">
           承载节点已被删除，无法正常取消，请点「清理」移除该残留记录。
         </div>
-      ) : (task.errorMsg || task.errorDetail) ? (
+      ) : task.errorMsg || task.errorDetail ? (
         <div className="canvas-task-card-error">{task.errorDetail ?? task.errorMsg}</div>
       ) : null}
     </div>
@@ -441,13 +435,11 @@ function TaskDetailModal({
   const inputAssets = assets.filter((asset) => task.inputAssetIds.includes(asset.id))
   const outputAssets = assets.filter((asset) => task.outputAssetIds.includes(asset.id))
   const taskNode =
-    (task.operationNodeId
-      ? nodes.find((node) => node.id === task.operationNodeId)
-      : undefined) ?? nodes.find((node) => node.taskId === task.id)
+    (task.operationNodeId ? nodes.find((node) => node.id === task.operationNodeId) : undefined) ??
+    nodes.find((node) => node.taskId === task.id)
   const canCancel = isTaskActive(task)
   const raw = isRecord(task.rawResponse) ? task.rawResponse : null
-  const outputText =
-    task.modelOutputText || stringField(raw?.outputText) || stringField(raw?.text)
+  const outputText = task.modelOutputText || stringField(raw?.outputText) || stringField(raw?.text)
   const parsedEntities = raw?.parsedEntities
   const displayPrompt = task.compiledUserText || task.prompt || ''
   const detailParams = {
@@ -458,10 +450,15 @@ function TaskDetailModal({
   }
   const httpResponse = task.requestCall?.response
   const submitResponse = task.submitResponse ?? httpResponse?.body
-  const providerResponseText = task.rawResponse != null ? formatJson(task.rawResponse) : ''
+  const requestCaptureStatus = isRecord(task.requestCall?.body)
+    ? stringField(task.requestCall.body.captureStatus)
+    : undefined
+  const runtimeDiagnostics = stripDuplicateCanvasRuntimeDiagnostics(task.rawResponse)
+  const providerResponseText = runtimeDiagnostics != null ? formatJson(runtimeDiagnostics) : ''
   const httpResponseBodyText = httpResponse?.body != null ? formatJson(httpResponse.body) : ''
   const shouldShowProviderResponse =
-    task.rawResponse != null &&
+    runtimeDiagnostics != null &&
+    (!isRecord(runtimeDiagnostics) || Object.keys(runtimeDiagnostics).length > 0) &&
     (!httpResponseBodyText || providerResponseText !== httpResponseBodyText)
 
   return (
@@ -531,24 +528,92 @@ function TaskDetailModal({
           ]}
         />
 
-        <DetailBlock title="模型原始输出（解析失败也保留）">
+        <DetailBlock title="模型原始输出（解析失败也保留）" defaultOpen>
           <pre>{outputText || '（Provider/Agent 未返回任何文本）'}</pre>
         </DetailBlock>
 
-        {task.systemPrompt && (
-          <DetailBlock title="最终 System Prompt">
-            <pre>{task.systemPrompt}</pre>
+        {task.requestCall ? (
+          <DetailBlock title="实际模型调用（最终 HTTP / SDK / CLI 参数）" defaultOpen>
+            <div className="canvas-task-request-call">
+              {requestCaptureStatus === 'session-dispatch' && (
+                <div className="canvas-task-detail-note">
+                  Executor 尚未进入最终 SDK/CLI
+                  提交边界；当前仅保留会话调度参数，不能视为底层模型请求。
+                </div>
+              )}
+              <div className="canvas-task-detail-subtitle">模型调用地址</div>
+              <div className="canvas-task-request-line">
+                <Tag size="middle" color="blue">
+                  {task.requestCall.method}
+                </Tag>
+                <code>{task.requestCall.url}</code>
+              </div>
+              {task.requestCall.headers != null && (
+                <>
+                  <div className="canvas-task-detail-subtitle">脱敏请求头</div>
+                  <pre>{formatJson(task.requestCall.headers)}</pre>
+                </>
+              )}
+              {task.requestCall.body != null && (
+                <>
+                  <div className="canvas-task-detail-subtitle">
+                    {isHttpMethod(task.requestCall.method)
+                      ? '最终 HTTP 请求体（脱敏）'
+                      : '最终 SDK / CLI 调用参数（脱敏）'}
+                  </div>
+                  <pre>{formatJson(task.requestCall.body)}</pre>
+                </>
+              )}
+              {(httpResponse || task.submitResponse != null) && (
+                <>
+                  <div className="canvas-task-detail-subtitle">调用响应</div>
+                  {httpResponse && (
+                    <div className="canvas-task-request-line">
+                      <Tag size="middle" color={httpResponse.status >= 400 ? 'red' : 'green'}>
+                        {httpResponse.status}
+                      </Tag>
+                      <code>{httpResponse.statusText || 'response'}</code>
+                    </div>
+                  )}
+                  {httpResponse?.headers != null && <pre>{formatJson(httpResponse.headers)}</pre>}
+                  {submitResponse != null && <pre>{formatJson(submitResponse)}</pre>}
+                </>
+              )}
+            </div>
           </DetailBlock>
+        ) : (
+          task.status !== 'pending' && (
+            <DetailBlock title="实际模型调用（历史任务未记录）" defaultOpen>
+              <div className="canvas-task-detail-empty-call">
+                该任务由旧版本创建，未保存最终 HTTP/SDK
+                调用快照。下次运行或重试会记录调用地址和最终参数。
+              </div>
+            </DetailBlock>
+          )
         )}
 
-        {displayPrompt && (
-          <DetailBlock title="最终 User Prompt">
-            <pre>{displayPrompt}</pre>
+        {(task.systemPrompt || displayPrompt) && (
+          <DetailBlock title="画布提交 Prompt（调用前快照）">
+            <div className="canvas-task-detail-note">
+              这里是画布提交给主进程的 Prompt；Provider/SDK 最终组合结果以上方“实际模型调用”为准。
+            </div>
+            {task.systemPrompt && (
+              <>
+                <div className="canvas-task-detail-subtitle">System Prompt</div>
+                <pre>{task.systemPrompt}</pre>
+              </>
+            )}
+            {displayPrompt && (
+              <>
+                <div className="canvas-task-detail-subtitle">User Prompt</div>
+                <pre>{displayPrompt}</pre>
+              </>
+            )}
           </DetailBlock>
         )}
 
         {task.inputSnapshots && task.inputSnapshots.length > 0 && (
-          <DetailBlock title="提交快照输入">
+          <DetailBlock title="冻结输入内容（仅用于血缘与原文排查）">
             <CanvasTaskInputSnapshotList snapshots={task.inputSnapshots} />
           </DetailBlock>
         )}
@@ -562,7 +627,7 @@ function TaskDetailModal({
           </div>
         </DetailBlock>
 
-        <DetailBlock title="任务配置参数">
+        <DetailBlock title="画布侧任务配置（非最终模型请求）">
           <pre>{formatJson(detailParams)}</pre>
         </DetailBlock>
 
@@ -572,22 +637,7 @@ function TaskDetailModal({
           </DetailBlock>
         )}
 
-        {task.requestCall && (
-          <DetailBlock title="实际 HTTP 请求">
-            <div className="canvas-task-request-call">
-              <div className="canvas-task-request-line">
-                <Tag size="middle" color="blue">
-                  {task.requestCall.method}
-                </Tag>
-                <code>{task.requestCall.url}</code>
-              </div>
-              {task.requestCall.headers != null && <pre>{formatJson(task.requestCall.headers)}</pre>}
-              {task.requestCall.body != null && <pre>{formatJson(task.requestCall.body)}</pre>}
-            </div>
-          </DetailBlock>
-        )}
-
-        {(httpResponse || task.submitResponse != null) && (
+        {!task.requestCall && (httpResponse || task.submitResponse != null) && (
           <DetailBlock title={task.submitResponse != null ? '任务提交响应' : '实际 HTTP 响应'}>
             <div className="canvas-task-request-call">
               {httpResponse && (
@@ -605,7 +655,7 @@ function TaskDetailModal({
         )}
 
         {(task.errorMsg || task.errorDetail) && (
-          <DetailBlock title="错误日志">
+          <DetailBlock title="错误日志" defaultOpen>
             <div className="canvas-task-error-log">
               <strong>{task.errorMsg ?? 'error'}</strong>
               <pre>{task.errorDetail ?? '-'}</pre>
@@ -635,7 +685,7 @@ function TaskDetailModal({
 
         {shouldShowProviderResponse && (
           <DetailBlock title="运行时 / Provider 诊断数据">
-            <pre>{formatJson(task.rawResponse)}</pre>
+            <pre>{formatJson(runtimeDiagnostics)}</pre>
           </DetailBlock>
         )}
       </div>
@@ -643,13 +693,30 @@ function TaskDetailModal({
   )
 }
 
-function DetailBlock({ title, children }: { title: string; children: ReactNode }) {
+function DetailBlock({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string
+  children: ReactNode
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = useState(defaultOpen)
   return (
-    <div className="canvas-task-detail-block">
-      <div className="canvas-task-detail-block-title">{title}</div>
-      {children}
-    </div>
+    <details
+      className="canvas-task-detail-block"
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="canvas-task-detail-block-title">{title}</summary>
+      <div className="canvas-task-detail-block-content">{children}</div>
+    </details>
   )
+}
+
+function isHttpMethod(method: string): boolean {
+  return /^(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)$/i.test(method.trim())
 }
 
 function TaskRefList({

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.less
@@ -5344,15 +5344,40 @@ body.canvas-agent-panel-resizing .canvas-agent-side-panel-resize-handle::after {
 }
 
 .canvas-task-detail-block {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
+  display: block;
 }
 
 .canvas-task-detail-block-title {
+  cursor: pointer;
   color: var(--text-strong);
   font-size: 12px;
   font-weight: 700;
+  user-select: none;
+}
+
+.canvas-task-detail-block-content {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 7px;
+}
+
+.canvas-task-detail-subtitle {
+  margin-top: 3px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.canvas-task-detail-note,
+.canvas-task-detail-empty-call {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--panel);
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.5;
 }
 
 .canvas-task-detail-block pre,

--- a/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
+++ b/apps/desktop/src/renderer/design/views/canvas/CanvasWorkspaceView.tsx
@@ -7068,10 +7068,28 @@ export function CanvasWorkspaceView({
       (task.operationNodeId
         ? snapshot.nodes.find((node) => node.id === task.operationNodeId)
         : undefined) ?? snapshot.nodes.find((node) => node.taskId === task.id)
-    const retryModelParams =
+    const requestedRetryModelParams =
       runtimeSource === 'current-node'
         ? { ...task.modelParams, ...(taskNode?.data.modelParams ?? {}) }
         : task.modelParams
+    const retryPresetTargetId = resolveCanvasPresetTarget({
+      operation: task.operation,
+      taskPipelineRole:
+        (runtimeSource === 'current-node' ? taskNode?.data.pipelineRole : task.taskPipelineRole) ??
+        task.taskPipelineRole ??
+        null,
+      outputPipelineRole:
+        (runtimeSource === 'current-node'
+          ? taskNode?.data.outputPipelineRole
+          : task.outputPipelineRole) ??
+        task.outputPipelineRole ??
+        null,
+      workflow: requestedRetryModelParams.workflow,
+    })
+    const retryModelParams = mergeCanvasPresetTargetModelParams(
+      retryPresetTargetId,
+      requestedRetryModelParams,
+    )
     const retryExtractKind = resolveExtractEntityKindFromWorkflow(retryModelParams.workflow)
     if (taskNode && isOperationNode(taskNode) && retryExtractKind) {
       const retryInputNodes = task.inputNodeIds
@@ -7255,11 +7273,26 @@ export function CanvasWorkspaceView({
                       taskInputNodes,
                       snapshot.assets,
                     )
-                    const workflow =
-                      opTask && typeof opTask.modelParams?.workflow === 'string'
-                        ? opTask.modelParams.workflow
-                        : ''
-                    const extractKind = resolveExtractEntityKindFromWorkflow(workflow)
+                    const operation = (opNode.data.operation ??
+                      opNode.type) as CanvasOperationType
+                    const currentPresetTargetId = resolveCanvasPresetTarget({
+                      operation,
+                      taskPipelineRole:
+                        opNode.data.pipelineRole ?? opTask?.taskPipelineRole ?? null,
+                      outputPipelineRole:
+                        opNode.data.outputPipelineRole ?? opTask?.outputPipelineRole ?? null,
+                      workflow:
+                        params.modelParams?.workflow ??
+                        opNode.data.modelParams?.workflow ??
+                        opTask?.modelParams?.workflow,
+                    })
+                    const currentModelParams = mergeCanvasPresetTargetModelParams(
+                      currentPresetTargetId,
+                      params.modelParams,
+                    )
+                    const extractKind = resolveExtractEntityKindFromWorkflow(
+                      currentModelParams.workflow,
+                    )
                     // 统一行为：先收起弹窗，再继续执行任务，避免提交后弹窗长时间不关。
                     const closePanel = () => {
                       setActiveOperationPanelNodeId(null)
@@ -7280,8 +7313,6 @@ export function CanvasWorkspaceView({
                         })
                         .filter(Boolean)
                         .join('\n\n')
-                      const operation = (opNode.data.operation ??
-                        opNode.type) as CanvasOperationType
                       const promptDocument =
                         params.promptDocument ??
                         migrateLegacyPrompt({
@@ -7290,7 +7321,10 @@ export function CanvasWorkspaceView({
                           assets: snapshot.assets,
                         })
                       const extractSystemPrompt =
-                        params.systemPrompt?.trim() ||
+                        normalizeCanvasFunctionalSystemPrompt(
+                          params.systemPrompt,
+                          currentPresetTargetId,
+                        ) ||
                         buildCanvasOperationSystemPrompt(
                           operation,
                           readCanvasResolvedPresetTarget(
@@ -7298,7 +7332,7 @@ export function CanvasWorkspaceView({
                               operation,
                               taskPipelineRole: opNode.data.pipelineRole ?? null,
                               outputPipelineRole: opNode.data.outputPipelineRole ?? null,
-                              workflow: params.modelParams?.workflow,
+                              workflow: currentModelParams.workflow,
                             }),
                           ).prompt,
                         )
@@ -7318,7 +7352,7 @@ export function CanvasWorkspaceView({
                         operation,
                         taskPipelineRole: opNode.data.pipelineRole ?? null,
                         outputPipelineRole: opNode.data.outputPipelineRole ?? null,
-                        workflow: params.modelParams?.workflow,
+                        workflow: currentModelParams.workflow,
                       })
                       writeCanvasLastUsedPresetTarget(extractPresetTargetId, {
                         ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
@@ -7329,7 +7363,7 @@ export function CanvasWorkspaceView({
                         ...(params.manifestId ? { manifestId: params.manifestId } : {}),
                         ...(params.modelId ? { modelId: params.modelId } : {}),
                         ...(params.skillIds ? { skillIds: params.skillIds } : {}),
-                        ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                        modelParams: currentModelParams,
                       })
                       closePanel()
                       void handleExtractEntities(
@@ -7349,7 +7383,7 @@ export function CanvasWorkspaceView({
                             ? { reasoningEffort: params.reasoningEffort }
                             : {}),
                           ...(params.skillIds ? { skillIds: params.skillIds } : {}),
-                          ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                          modelParams: currentModelParams,
                           bindToNodeId: opNode.id,
                           ...(params.inputNodeIds ? { inputNodeIds: params.inputNodeIds } : {}),
                           inputAssetIds: taskInputNodes
@@ -7362,13 +7396,7 @@ export function CanvasWorkspaceView({
                     }
                     // 普通操作（文本/图片/视频生成等）：先收起弹窗，再异步提交任务。
                     closePanel()
-                    const operation = (opNode.data.operation ?? opNode.type) as CanvasOperationType
-                    const presetTargetId = resolveCanvasPresetTarget({
-                      operation,
-                      taskPipelineRole: opNode.data.pipelineRole ?? null,
-                      outputPipelineRole: opNode.data.outputPipelineRole ?? null,
-                      workflow: params.modelParams?.workflow ?? opNode.data.modelParams?.workflow,
-                    })
+                    const presetTargetId = currentPresetTargetId
                     const effectiveInputRoles =
                       operation === 'storyboard_grid'
                         ? buildStoryboardReferenceInputRoles(
@@ -7411,8 +7439,8 @@ export function CanvasWorkspaceView({
                       : effectivePrompt
                     const styleContext = buildCanvasStyleContext(snapshot, {
                       ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
-                      ...(params.modelParams && Object.keys(params.modelParams).length > 0
-                        ? { modelParams: params.modelParams }
+                      ...(Object.keys(currentModelParams).length > 0
+                        ? { modelParams: currentModelParams }
                         : {}),
                     })
                     const styledTask = applyCanvasStyleToTask(
@@ -7420,7 +7448,7 @@ export function CanvasWorkspaceView({
                       {
                         prompt: finalPrompt,
                         ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
-                        ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                        modelParams: currentModelParams,
                       },
                       styleContext,
                     )
@@ -7436,7 +7464,7 @@ export function CanvasWorkspaceView({
                         ? { reasoningEffort: params.reasoningEffort }
                         : {}),
                       ...(params.skillIds ? { skillIds: params.skillIds } : {}),
-                      ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                      modelParams: currentModelParams,
                     })
                     try {
                       await runOperationNode(opNode.id, {
@@ -7500,10 +7528,16 @@ export function CanvasWorkspaceView({
                     const operation = (opNode.data.operation ?? opNode.type) as CanvasOperationType
                     const presetTargetId = resolveCanvasPresetTarget({
                       operation,
-                      taskPipelineRole: opNode.data.pipelineRole ?? null,
-                      outputPipelineRole: opNode.data.outputPipelineRole ?? null,
+                      taskPipelineRole:
+                        opNode.data.pipelineRole ?? opTask?.taskPipelineRole ?? null,
+                      outputPipelineRole:
+                        opNode.data.outputPipelineRole ?? opTask?.outputPipelineRole ?? null,
                       workflow: params.modelParams?.workflow ?? opNode.data.modelParams?.workflow,
                     })
+                    const modelParams = mergeCanvasPresetTargetModelParams(
+                      presetTargetId,
+                      params.modelParams,
+                    )
                     const nextNodeData = {
                       ...opNode.data,
                       ...(params.promptDocument ? { promptDocument: params.promptDocument } : {}),
@@ -7518,7 +7552,7 @@ export function CanvasWorkspaceView({
                         : {}),
                       negativePrompt: params.negativePrompt,
                       message: params.message,
-                      modelParams: params.modelParams,
+                      modelParams,
                       ...(params.agentId ? { agentId: params.agentId } : {}),
                       ...(params.providerProfileId
                         ? { providerProfileId: params.providerProfileId }
@@ -7545,7 +7579,7 @@ export function CanvasWorkspaceView({
                       ...(params.manifestId ? { manifestId: params.manifestId } : {}),
                       ...(params.modelId ? { modelId: params.modelId } : {}),
                       ...(params.skillIds ? { skillIds: params.skillIds } : {}),
-                      ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+                      modelParams,
                     })
                   }}
                 />

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.api.ts
@@ -488,6 +488,30 @@ export function isTextModelOperation(operation: CanvasOperationType): boolean {
   return TEXT_MODEL_OPERATIONS.has(operation)
 }
 
+const CANVAS_TEXT_CONTROL_MODEL_PARAM_NAMES = new Set([
+  'workflow',
+  'sourceAssetId',
+  'responseFormat',
+  'response_format',
+])
+
+/**
+ * Provider contracts only understand wire parameters. Canvas workflow identity and
+ * response-shape hints are renderer control metadata and must survive that pruning.
+ */
+function restoreCanvasTextControlModelParams(
+  operation: CanvasOperationType,
+  original: Record<string, unknown>,
+  pruned: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!isTextModelOperation(operation)) return pruned
+  const restored = { ...pruned }
+  for (const name of CANVAS_TEXT_CONTROL_MODEL_PARAM_NAMES) {
+    if (Object.prototype.hasOwnProperty.call(original, name)) restored[name] = original[name]
+  }
+  return restored
+}
+
 export type CanvasDb = {
   projects: CanvasProject[]
   boards: CanvasBoard[]
@@ -4499,6 +4523,9 @@ export const canvasApi = {
       outputPipelineRole: input.outputPipelineRole ?? null,
       workflow: input.modelParams?.workflow,
     })
+    const taskPipelineRole =
+      input.taskPipelineRole ??
+      (presetTargetId !== input.operation ? input.outputPipelineRole : undefined)
     const operationPreset = readCanvasResolvedPresetTarget(presetTargetId, {
       hasImageInput: inputNodes.some((node) => node.type === 'image'),
     })
@@ -4538,10 +4565,10 @@ export const canvasApi = {
     for (const task of inputTasks) mergeInheritedModelParams(inheritedModelParams, task.modelParams)
     for (const node of inputNodes)
       mergeInheritedModelParams(inheritedModelParams, node.data.modelParams)
-    const mergedModelParams = {
-      ...mergeCanvasPresetTargetModelParams(presetTargetId, inheritedModelParams),
+    const mergedModelParams = mergeCanvasPresetTargetModelParams(presetTargetId, {
+      ...inheritedModelParams,
       ...(input.modelParams ?? {}),
-    }
+    })
     // Contract V2 二次裁剪：preset/继承/input 合并后按目标 manifest 再次过滤，
     // 防止上游节点的旧模型字段（如 searchEnabled / output_format）污染新模型请求。
     // manifest 缺省时直接退回原值，不阻塞创建。
@@ -4556,7 +4583,14 @@ export const canvasApi = {
     // 参数裁剪可能走异步 IPC；创建前重新读取最新快照，避免菜单/Agent 同时添加操作节点时
     // 后写入者覆盖前一个节点，也确保统一碰撞检测包含刚落下的节点。
     db = readDb()
-    const modelParams = pruned.modelParams
+    const modelParams = restoreCanvasTextControlModelParams(
+      input.operation,
+      mergedModelParams,
+      pruned.modelParams,
+    )
+    const droppedParams = pruned.droppedParams.filter(
+      (item) => !CANVAS_TEXT_CONTROL_MODEL_PARAM_NAMES.has(item.name),
+    )
     const modelId = input.modelId ?? operationPreset.modelId ?? null
     const agentId = input.agentId ?? operationPreset.agentId ?? null
     const skillIds = input.skillIds ?? operationPreset.skillIds
@@ -4572,7 +4606,7 @@ export const canvasApi = {
     )
     const operationNodeSize = pickOperationNodeInitialSize(
       Boolean(input.shotScriptConfig) ||
-        (input.operation === 'text_generate' && input.taskPipelineRole === 'shot'),
+        (input.operation === 'text_generate' && taskPipelineRole === 'shot'),
     )
     const position = resolveCollisionFreeNodePosition({
       preferred: { x: input.x, y: input.y },
@@ -4610,13 +4644,13 @@ export const canvasApi = {
         ...(modelId ? { modelId } : {}),
         ...(agentId ? { agentId } : {}),
         ...(skillIds.length > 0 ? { skillIds } : {}),
-        ...(input.taskPipelineRole != null ? { pipelineRole: input.taskPipelineRole } : {}),
+        ...(taskPipelineRole != null ? { pipelineRole: taskPipelineRole } : {}),
         ...(input.outputPipelineRole != null
           ? { outputPipelineRole: input.outputPipelineRole }
           : {}),
         ...(input.outputTitle != null ? { outputTitle: input.outputTitle } : {}),
         ...(input.shotScriptConfig ? { shotScriptConfig: input.shotScriptConfig } : {}),
-        ...(pruned.droppedParams.length > 0 ? { droppedModelParams: pruned.droppedParams } : {}),
+        ...(droppedParams.length > 0 ? { droppedModelParams: droppedParams } : {}),
         ...(pruned.warnings.length > 0 ? { modelParamWarnings: pruned.warnings } : {}),
         origin: 'manual',
       },
@@ -4652,7 +4686,7 @@ export const canvasApi = {
       modelId,
       reasoningEffort,
       modelParams,
-      taskPipelineRole: input.taskPipelineRole ?? null,
+      taskPipelineRole: taskPipelineRole ?? null,
       outputPipelineRole: input.outputPipelineRole ?? null,
       shotScriptConfig: input.shotScriptConfig ?? null,
       runtimeEvents: initialCanvasTaskRuntimeEvents(at, '操作节点草稿创建'),
@@ -4728,7 +4762,7 @@ export const canvasApi = {
       buildTaskInputFiles(retryInputNodes, buildCanvasRetryInputRoles(oldTask.relationManifest)),
       oldTask.provider === 'xai' ? 'base64' : undefined,
     )
-    const retryModelParams = useCurrentRuntime
+    const requestedRetryModelParams = useCurrentRuntime
       ? { ...oldTask.modelParams, ...(node.data.modelParams ?? {}) }
       : oldTask.modelParams
     const retryProviderProfileId =
@@ -4740,15 +4774,28 @@ export const canvasApi = {
     const retryReasoningEffort =
       (useCurrentRuntime ? node.data.reasoningEffort : oldTask.reasoningEffort) ?? undefined
     const retrySkillIds = (useCurrentRuntime ? node.data.skillIds : oldTask.skillIds) ?? []
-    const retryTaskPipelineRole = oldTask.taskPipelineRole ?? node.data.pipelineRole
-    const retryOutputPipelineRole = oldTask.outputPipelineRole ?? node.data.outputPipelineRole
-    const retryShotScriptConfig = oldTask.shotScriptConfig ?? node.data.shotScriptConfig
+    const retryTaskPipelineRole = useCurrentRuntime
+      ? (node.data.pipelineRole ?? oldTask.taskPipelineRole)
+      : (oldTask.taskPipelineRole ?? node.data.pipelineRole)
+    const retryOutputPipelineRole = useCurrentRuntime
+      ? (node.data.outputPipelineRole ?? oldTask.outputPipelineRole)
+      : (oldTask.outputPipelineRole ?? node.data.outputPipelineRole)
+    const retryShotScriptConfig = useCurrentRuntime
+      ? (node.data.shotScriptConfig ?? oldTask.shotScriptConfig)
+      : (oldTask.shotScriptConfig ?? node.data.shotScriptConfig)
     const retryPresetTargetId = resolveCanvasPresetTarget({
       operation: oldTask.operation,
       taskPipelineRole: retryTaskPipelineRole ?? null,
       outputPipelineRole: retryOutputPipelineRole ?? null,
-      workflow: retryModelParams.workflow,
+      workflow: requestedRetryModelParams.workflow,
     })
+    const retryModelParams = mergeCanvasPresetTargetModelParams(
+      retryPresetTargetId,
+      requestedRetryModelParams,
+    )
+    const resolvedRetryTaskPipelineRole =
+      retryTaskPipelineRole ??
+      (retryPresetTargetId !== oldTask.operation ? retryOutputPipelineRole : undefined)
     const retrySystemPrompt = normalizeCanvasFunctionalSystemPrompt(
       oldTask.systemPrompt,
       retryPresetTargetId,
@@ -4769,7 +4816,9 @@ export const canvasApi = {
       ...(retryAgentId ? { agentId: retryAgentId } : {}),
       ...(retryReasoningEffort ? { reasoningEffort: retryReasoningEffort } : {}),
       ...(retrySkillIds.length > 0 ? { skillIds: retrySkillIds } : {}),
-      ...(retryTaskPipelineRole ? { taskPipelineRole: retryTaskPipelineRole } : {}),
+      ...(resolvedRetryTaskPipelineRole
+        ? { taskPipelineRole: resolvedRetryTaskPipelineRole }
+        : {}),
       ...(retryOutputPipelineRole ? { outputPipelineRole: retryOutputPipelineRole } : {}),
       ...(retryShotScriptConfig ? { shotScriptConfig: retryShotScriptConfig } : {}),
       ...(oldTask.title ? { taskTitle: oldTask.title } : {}),
@@ -4841,10 +4890,25 @@ export const canvasApi = {
           ?.reasoningEffort
       : undefined
     const reasoningEffort = params.reasoningEffort ?? existingReasoningEffort ?? undefined
+    const operation = (node.data.operation ?? node.type) as CanvasOperationType
+    const presetTargetId = resolveCanvasPresetTarget({
+      operation,
+      taskPipelineRole: node.data.pipelineRole ?? null,
+      outputPipelineRole: node.data.outputPipelineRole ?? null,
+      workflow: params.modelParams?.workflow ?? node.data.modelParams?.workflow,
+    })
+    const taskPipelineRole =
+      node.data.pipelineRole ??
+      (presetTargetId !== operation ? node.data.outputPipelineRole : undefined)
+    const modelParams = mergeCanvasPresetTargetModelParams(presetTargetId, params.modelParams)
+    const normalizedSystemPrompt = normalizeCanvasFunctionalSystemPrompt(
+      params.systemPrompt ?? node.data.systemPrompt,
+      presetTargetId,
+    )
     let request: Omit<CreateCanvasTaskRequest, 'boardId'> & {
       inputFiles?: CanvasMediaTaskInputFile[]
     } = {
-      operation: (node.data.operation ?? node.type) as CanvasOperationType,
+      operation,
       prompt: params.prompt,
       ...(params.negativePrompt ? { negativePrompt: params.negativePrompt } : {}),
       inputNodeIds,
@@ -4852,8 +4916,8 @@ export const canvasApi = {
       ...(params.inputFiles ? { inputFiles: params.inputFiles } : {}),
       outputPlacement: { x: baseX, y: node.y },
       taskTitle:
-        node.title ?? operationLabel((node.data.operation ?? node.type) as CanvasOperationType),
-      ...(node.data.pipelineRole ? { taskPipelineRole: node.data.pipelineRole } : {}),
+        node.title ?? operationLabel(operation),
+      ...(taskPipelineRole ? { taskPipelineRole } : {}),
       ...(node.data.outputPipelineRole ? { outputPipelineRole: node.data.outputPipelineRole } : {}),
       ...(node.data.outputTitle ? { outputTitle: node.data.outputTitle } : {}),
       ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -4861,13 +4925,14 @@ export const canvasApi = {
       ...(params.manifestId ? { manifestId: params.manifestId } : {}),
       ...(params.modelId ? { modelId: params.modelId } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),
-      ...(params.modelParams ? { modelParams: params.modelParams } : {}),
+      ...(Object.keys(modelParams).length > 0 ? { modelParams } : {}),
       ...(params.skipParameterValidation === true
         ? { skipParameterValidation: true }
         : {}),
       ...(params.skillIds ? { skillIds: params.skillIds } : {}),
       ...(params.shotScriptConfig ? { shotScriptConfig: params.shotScriptConfig } : {}),
       ...pickCanvasPromptTaskFields(params),
+      ...(normalizedSystemPrompt ? { systemPrompt: normalizedSystemPrompt } : {}),
     }
     if (params.inputNodeIds) {
       const skipParameterValidation = params.skipParameterValidation === true

--- a/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvas.types.ts
@@ -382,7 +382,7 @@ export type CanvasTask = {
   submitResponse?: unknown
   /** 提交时输入文件的诊断摘要，便于任务详情排查 url/base64/path 等传参方式。 */
   inputFileDiagnostics?: CanvasTaskInputDiagnostic[]
-  /** 实际发给 provider 的 HTTP 调用摘要（请求 + 响应），用于任务详情展示。 */
+  /** 实际模型调用摘要：HTTP 请求，或 SDK/CLI 的最终地址与调用参数。 */
   requestCall?: MediaRequestCall | null
   agentId?: string | null
   skillIds?: string[]

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationInheritance.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationInheritance.test.ts
@@ -227,6 +227,25 @@ describe('canvas operation inheritance', () => {
     })
     writeCanvasOperationPreset('text_generate', {
       prompt: '你是角色分析师，只输出 characters JSON。',
+      modelParams: { workflow: 'extract_character', responseFormat: 'json' },
+    })
+    Object.assign(window, {
+      spark: {
+        invoke: vi.fn().mockImplementation((channel: string) => {
+          if (channel === 'canvas:media:prune-model-params') {
+            return Promise.resolve({
+              prunedModelParams: {},
+              droppedParams: [
+                { name: 'workflow', reason: 'unsupported_by_model' },
+                { name: 'responseFormat', reason: 'unsupported_by_model' },
+              ],
+              warnings: [],
+              validationIssues: [],
+            })
+          }
+          return Promise.resolve({ rootPath: '/tmp/project-1' })
+        }),
+      },
     })
 
     const snapshot = await canvasApi.createOperationNode({
@@ -236,15 +255,23 @@ describe('canvas operation inheritance', () => {
       inputNodeIds: [],
       x: 0,
       y: 0,
-      taskPipelineRole: 'shot',
       outputPipelineRole: 'shot',
-      modelParams: { workflow: 'shot_script', responseFormat: 'json' },
-      systemPrompt: '【任务】把下面的场次剧本拆成分镜。\nJSON 顶层结构必须为：{"shots":[]}',
+      modelParams: { workflow: 'extract_character', responseFormat: 'json' },
+      manifestId: 'custom:text-model',
+      systemPrompt:
+        '你是专业的影视角色分析师。只输出 characters JSON。\n\n' +
+        '【任务】把下面的场次剧本拆成分镜。\nJSON 顶层结构必须为：{"shots":[]}',
     })
 
     const node = snapshot.nodes.find((candidate) => candidate.type === 'text_generate')
+    const task = snapshot.tasks.find((candidate) => candidate.id === node?.taskId)
     expect(node?.data.systemPrompt).toContain('"shots"')
     expect(node?.data.systemPrompt).not.toContain('characters')
+    expect(node?.data.pipelineRole).toBe('shot')
+    expect(node?.data.modelParams).toEqual({ workflow: 'shot_script', responseFormat: 'json' })
+    expect(node?.data.droppedModelParams).toBeUndefined()
+    expect(task?.taskPipelineRole).toBe('shot')
+    expect(task?.modelParams).toEqual({ workflow: 'shot_script', responseFormat: 'json' })
   })
 
   it('creates storyboard tasks large and grows them to the completed shot table size', async () => {
@@ -828,9 +855,8 @@ describe('canvas operation inheritance', () => {
               modelId: 'new-model',
               providerProfileId: 'new-provider',
               agentId: 'new-agent',
-              pipelineRole: 'shot',
               outputPipelineRole: 'shot',
-              modelParams: { workflow: 'shot_script', temperature: 0.2 },
+              modelParams: { temperature: 0.2 },
             },
             createdAt: at,
             updatedAt: at,
@@ -855,9 +881,11 @@ describe('canvas operation inheritance', () => {
             providerProfileId: 'old-provider',
             modelId: 'old-model',
             agentId: 'old-agent',
-            modelParams: { workflow: 'shot_script', temperature: 0.8 },
-            taskPipelineRole: 'shot',
+            modelParams: { workflow: 'extract_character', temperature: 0.8 },
             outputPipelineRole: 'shot',
+            systemPrompt:
+              '你是专业的影视角色分析师。只输出 characters JSON。\n\n' +
+              '【任务】把下面的场次剧本拆成分镜。\nJSON 顶层结构必须为：{"shots":[]}',
             createdAt: at,
             updatedAt: at,
           },
@@ -895,9 +923,15 @@ describe('canvas operation inheritance', () => {
         providerProfileId: 'edited-provider',
         modelId: 'edited-model',
         agentId: 'new-agent',
-        modelParams: { workflow: 'shot_script', temperature: 0.2 },
+        modelParams: {
+          workflow: 'shot_script',
+          responseFormat: 'json',
+          temperature: 0.2,
+        },
+        systemPrompt: expect.stringContaining('"shots"'),
       }),
     )
+    expect(currentInvoke.mock.calls[0]?.[1]?.systemPrompt).not.toContain('characters')
 
     seedRetryTask()
     const originalInvoke = vi.fn().mockResolvedValue({
@@ -918,9 +952,15 @@ describe('canvas operation inheritance', () => {
         providerProfileId: 'old-provider',
         modelId: 'old-model',
         agentId: 'old-agent',
-        modelParams: { workflow: 'shot_script', temperature: 0.8 },
+        modelParams: {
+          workflow: 'shot_script',
+          responseFormat: 'json',
+          temperature: 0.8,
+        },
+        systemPrompt: expect.stringContaining('"shots"'),
       }),
     )
+    expect(originalInvoke.mock.calls[0]?.[1]?.systemPrompt).not.toContain('characters')
   })
 
   it('retries media tasks with their relation-derived input roles', async () => {

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.test.ts
@@ -195,12 +195,26 @@ describe('canvasOperationPresets', () => {
       prompt: '你是角色分析师，只输出 characters JSON',
       providerProfileId: 'provider:text',
       modelId: 'gpt-5',
+      modelParams: { workflow: 'extract_character', responseFormat: 'json' },
     })
 
     expect(readCanvasInheritedPresetTarget('screenplay.to_shot_script')).toMatchObject({
       prompt: '',
       providerProfileId: 'provider:text',
       modelId: 'gpt-5',
+      modelParams: { workflow: 'shot_script', responseFormat: 'json' },
+    })
+  })
+
+  it('repairs contaminated last-used workflow metadata for a dedicated pipeline target', () => {
+    writeCanvasLastUsedPresetTarget('screenplay.to_shot_script', {
+      modelParams: { workflow: 'extract_character', temperature: 0.3 },
+    })
+
+    expect(readCanvasResolvedPresetTarget('screenplay.to_shot_script').modelParams).toEqual({
+      workflow: 'shot_script',
+      responseFormat: 'json',
+      temperature: 0.3,
     })
   })
 
@@ -400,5 +414,18 @@ describe('canvasOperationPresets', () => {
         workflow: 'extract_prop',
       }),
     ).toBe('screenplay.extract_props')
+    expect(
+      resolveCanvasPresetTarget({
+        operation: 'text_generate',
+        outputPipelineRole: 'shot',
+        workflow: 'extract_character',
+      }),
+    ).toBe('screenplay.to_shot_script')
+    expect(
+      resolveCanvasPresetTarget({
+        operation: 'text_generate',
+        workflow: 'shot_script',
+      }),
+    ).toBe('screenplay.to_shot_script')
   })
 })

--- a/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasOperationPresets.ts
@@ -78,6 +78,23 @@ export const CANVAS_PIPELINE_PRESET_TARGETS = [
 
 export type CanvasPipelinePresetTargetId = (typeof CANVAS_PIPELINE_PRESET_TARGETS)[number]['id']
 export type CanvasPresetTargetId = CanvasOperationType | CanvasPipelinePresetTargetId
+
+const CANVAS_PIPELINE_MODEL_PARAM_DEFAULTS: Partial<
+  Record<CanvasPipelinePresetTargetId, Record<string, unknown>>
+> = {
+  'screenplay.to_shot_script': { workflow: 'shot_script', responseFormat: 'json' },
+  'screenplay.extract_characters': { workflow: 'extract_character', responseFormat: 'json' },
+  'screenplay.extract_scenes': { workflow: 'extract_scene', responseFormat: 'json' },
+  'screenplay.extract_props': { workflow: 'extract_prop', responseFormat: 'json' },
+  'screenplay.extract_effects': { workflow: 'extract_effect', responseFormat: 'json' },
+  'screenplay.split_episodes': { workflow: 'split_episodes' },
+}
+
+const CANVAS_PIPELINE_CONTROL_PARAM_NAMES = new Set([
+  'workflow',
+  'responseFormat',
+  'response_format',
+])
 export type CanvasPresetTargetDefinition = {
   id: CanvasPresetTargetId
   operation: CanvasOperationType
@@ -319,40 +336,45 @@ export function resolveCanvasPresetTarget(input: {
   if (input.operation === 'text_rewrite' && input.outputPipelineRole === 'screenplay') {
     return 'chapter.to_screenplay'
   }
-  if (input.operation === 'text_generate' && input.taskPipelineRole === 'shot') {
+  if (
+    input.operation === 'text_generate' &&
+    (input.taskPipelineRole === 'shot' ||
+      input.outputPipelineRole === 'shot' ||
+      workflow === 'shot_script')
+  ) {
     return 'screenplay.to_shot_script'
   }
   if (
     input.operation === 'text_generate' &&
-    input.taskPipelineRole === 'character' &&
+    (input.taskPipelineRole === 'character' || input.outputPipelineRole === 'character') &&
     workflow === 'extract_character'
   ) {
     return 'screenplay.extract_characters'
   }
   if (
     input.operation === 'text_generate' &&
-    input.taskPipelineRole === 'scene' &&
+    (input.taskPipelineRole === 'scene' || input.outputPipelineRole === 'scene') &&
     workflow === 'extract_scene'
   ) {
     return 'screenplay.extract_scenes'
   }
   if (
     input.operation === 'text_generate' &&
-    input.taskPipelineRole === 'prop' &&
+    (input.taskPipelineRole === 'prop' || input.outputPipelineRole === 'prop') &&
     workflow === 'extract_prop'
   ) {
     return 'screenplay.extract_props'
   }
   if (
     input.operation === 'text_generate' &&
-    input.taskPipelineRole === 'effect' &&
+    (input.taskPipelineRole === 'effect' || input.outputPipelineRole === 'effect') &&
     workflow === 'extract_effect'
   ) {
     return 'screenplay.extract_effects'
   }
   if (
     input.operation === 'text_generate' &&
-    input.taskPipelineRole === 'screenplay' &&
+    (input.taskPipelineRole === 'screenplay' || input.outputPipelineRole === 'screenplay') &&
     workflow === 'split_episodes'
   ) {
     return 'screenplay.split_episodes'
@@ -459,6 +481,13 @@ export function readCanvasInheritedPresetTarget(
   const builtin = readBuiltinCanvasOperationPreset(target.operation)
   const operationOverrides =
     target.id === target.operation ? {} : (readStore()[target.operation] ?? {})
+  const inheritedModelParams = {
+    ...builtin.modelParams,
+    ...(operationOverrides.modelParams ?? {}),
+  }
+  if (target.id !== target.operation) {
+    for (const name of CANVAS_PIPELINE_CONTROL_PARAM_NAMES) delete inheritedModelParams[name]
+  }
   const taskDefaultKind = canvasTaskDefaultKindForOperation(target.operation, context)
   const taskDefault = taskDefaultKind ? readCanvasTaskDefault(taskDefaultKind) : { skillIds: [] }
   return {
@@ -484,8 +513,8 @@ export function readCanvasInheritedPresetTarget(
       : {}),
     skillIds: [...(operationOverrides.skillIds ?? taskDefault.skillIds)],
     modelParams: {
-      ...builtin.modelParams,
-      ...(operationOverrides.modelParams ?? {}),
+      ...inheritedModelParams,
+      ...(CANVAS_PIPELINE_MODEL_PARAM_DEFAULTS[target.id as CanvasPipelinePresetTargetId] ?? {}),
     },
   }
 }
@@ -496,7 +525,7 @@ export function readCanvasPresetTarget(
 ): CanvasOperationPreset {
   const base = readCanvasInheritedPresetTarget(targetId, context)
   const overrides = readPresetStore()[targetId] ?? {}
-  return {
+  const resolved = {
     prompt: overrides.prompt ?? base.prompt,
     negativePrompt: overrides.negativePrompt ?? base.negativePrompt,
     ...((overrides.providerProfileId ?? base.providerProfileId)
@@ -513,6 +542,8 @@ export function readCanvasPresetTarget(
       ...(overrides.modelParams ?? {}),
     },
   }
+  resolved.modelParams = enforceCanvasPresetTargetModelParams(targetId, resolved.modelParams)
+  return resolved
 }
 
 export function writeCanvasOperationPreset(
@@ -589,7 +620,7 @@ export function readCanvasResolvedPresetTarget(
 ): CanvasOperationPreset {
   const targetPreset = readCanvasPresetTarget(targetId, context)
   const lastUsed = readLastUsedStore()[targetId] ?? {}
-  return {
+  const resolved = {
     // 用户在任务面板中输入的内容不能反向覆盖功能节点的内置指令。
     // 历史版本曾把 prompt 写进 last-used，这里固定以显式 preset 为准，
     // 同时继续沿用上次选择的模型、Agent 与参数。
@@ -613,6 +644,8 @@ export function readCanvasResolvedPresetTarget(
       ...(lastUsed.modelParams ?? {}),
     },
   }
+  resolved.modelParams = enforceCanvasPresetTargetModelParams(targetId, resolved.modelParams)
+  return resolved
 }
 
 export function hasCanvasPresetTargetOverride(targetId: CanvasPresetTargetId): boolean {
@@ -656,7 +689,21 @@ export function mergeCanvasPresetTargetModelParams(
   targetId: CanvasPresetTargetId,
   modelParams?: Record<string, unknown>,
 ): Record<string, unknown> {
-  return mergeModelParamAliases(readCanvasPresetTarget(targetId).modelParams, modelParams)
+  return enforceCanvasPresetTargetModelParams(
+    targetId,
+    mergeModelParamAliases(readCanvasPresetTarget(targetId).modelParams, modelParams),
+  )
+}
+
+/** Keep a functional node's routing identity separate from provider parameter inheritance. */
+export function enforceCanvasPresetTargetModelParams(
+  targetId: CanvasPresetTargetId,
+  modelParams: Record<string, unknown>,
+): Record<string, unknown> {
+  const workflow = CANVAS_PIPELINE_MODEL_PARAM_DEFAULTS[
+    targetId as CanvasPipelinePresetTargetId
+  ]?.workflow
+  return typeof workflow === 'string' ? { ...modelParams, workflow } : { ...modelParams }
 }
 
 function mergeModelParamAliases(

--- a/apps/desktop/src/renderer/design/views/canvas/canvasPromptInitialization.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasPromptInitialization.ts
@@ -18,7 +18,9 @@ export function stripCanvasFunctionalPromptInput(prompt: string, presetTargetId:
       : presetTargetId === 'chapter.to_screenplay'
         ? '章节原文：'
         : presetTargetId === 'screenplay.extract_characters' ||
-            presetTargetId === 'screenplay.extract_scenes'
+            presetTargetId === 'screenplay.extract_scenes' ||
+            presetTargetId === 'screenplay.extract_props' ||
+            presetTargetId === 'screenplay.extract_effects'
           ? '【剧本】'
           : ''
   if (!marker) return prompt.trim()

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTaskDetailPresentation.test.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTaskDetailPresentation.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { stripDuplicateCanvasRuntimeDiagnostics } from './canvasTaskDetailPresentation'
+
+describe('canvas task detail presentation', () => {
+  it('removes output fields already rendered by authoritative sections', () => {
+    expect(
+      stripDuplicateCanvasRuntimeDiagnostics({
+        outputText: 'raw output',
+        text: 'fallback output',
+        parsedEntities: [{ id: 'shot-1' }],
+        provider: 'openai',
+        modelCallUrl: 'https://api.example.com/v1/responses',
+      }),
+    ).toEqual({
+      provider: 'openai',
+      modelCallUrl: 'https://api.example.com/v1/responses',
+    })
+  })
+})

--- a/apps/desktop/src/renderer/design/views/canvas/canvasTaskDetailPresentation.ts
+++ b/apps/desktop/src/renderer/design/views/canvas/canvasTaskDetailPresentation.ts
@@ -1,0 +1,12 @@
+export function stripDuplicateCanvasRuntimeDiagnostics(raw: unknown): unknown {
+  if (!isRecord(raw)) return raw
+  return Object.fromEntries(
+    Object.entries(raw).filter(
+      ([key]) => key !== 'outputText' && key !== 'text' && key !== 'parsedEntities',
+    ),
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}

--- a/docs/design/canvas-task-observability.md
+++ b/docs/design/canvas-task-observability.md
@@ -70,6 +70,8 @@ xAI 另有一处终态解析错误：官方成功契约是 `status=done` 且产�
 
 旧任务迁移按边类型恢复操作节点：`used_as_input` 使用 target，`generated` 使用 source。迁移结果按实际数据库对象缓存，项目重载或回滚得到的新快照仍会执行兼容迁移。
 
+功能身份不能依赖 Provider 参数裁剪后的 `modelParams` 单点判断。`workflow`、`responseFormat` 和来源资产 id 属于画布控制元数据，文本模型 Contract 裁剪后必须恢复；分镜旧节点只要输入角色或输出角色为 `shot`，即使 `taskPipelineRole`/`workflow` 缺失或残留 `extract_character`，也必须解析为 `screenplay.to_shot_script`。当前节点运行和编辑优先读取节点草稿，历史 task 只作为缺省回退；API 提交边界再次强制功能 workflow 并规范化 system prompt，避免不可变历史快照反向污染下一次运行。
+
 ### 异步轮询诊断
 
 共享轮询器会记录：

--- a/docs/design/canvas-task-observability.md
+++ b/docs/design/canvas-task-observability.md
@@ -54,7 +54,7 @@ xAI 另有一处终态解析错误：官方成功契约是 `status=done` 且产�
 
 - `modelOutputText`：模型/Agent 原始文本，结构解析失败时也必须保留；
 - `rawResponse`：Session runtime 或 Provider 的非敏感诊断摘要，不再冒充模型正文；
-- `systemPrompt` 与 `compiledUserText`：最终提交的 System/User Prompt；
+- `systemPrompt` 与 `compiledUserText`：画布编译后、进入 Session Runtime 前的 System/User Prompt；
 - 完整运行配置：Agent、Provider Profile、Manifest、Model、推理强度、Skill、pipeline role、模型参数和输入文件传输摘要；
 - `completedAt`：成功、失败与取消三种终态都必须写入。
 
@@ -67,6 +67,8 @@ xAI 另有一处终态解析错误：官方成功契约是 `status=done` 且产�
 角色、场景、道具和特效抽取共用完整实体解析链路。模型返回后先写入独立诊断快照，再开始解析和资产物化；即使解析器抛错，任务详情仍保存完整 `modelOutputText`、Provider 摘要和实际模型信息，而不是只保留截断的异常预览。
 
 文本执行路径按 Provider 的真实 wire protocol 选择：Anthropic-compatible 走 Messages；明确声明 `chat`/`responses` 的 OpenAI-compatible Profile 才可进入对应 Codex Session Runtime；缺少 `codexApiKind` 的旧 OpenAI-compatible Profile 保守回退直连 Chat Completions，避免被默认探测 `/responses`。
+
+任务详情以“实际模型调用”为最终事实源。直连 HTTP 保存最终 URL、方法、脱敏请求头、模型实际请求体以及响应状态/请求 ID；Session Runtime 在 executor 提交边界保存明确标注的 Codex SDK、Claude SDK 或本地 CLI 地址，并分别记录真实 `sdk.query` Prompt/options、Codex client/thread/input 或 CLI command/args/stdin。API Key、Authorization、MCP header/env 和完整运行环境只显示脱敏占位，不再把画布侧 `modelParams` 或上层 `createSession`/`sendTurn` 冒充最终模型参数。画布提交 Prompt、冻结输入、节点血缘、画布配置和运行时诊断默认折叠；模型原始输出、实际模型调用和错误默认展开。System/User Prompt 合并为一个“调用前快照”，最终组合后的 Prompt 以实际 HTTP body 或 executor 调用快照为准。运行时诊断展示时移除已经单独展示的 `outputText`、`text` 和 `parsedEntities`，避免重复刷屏。
 
 旧任务迁移按边类型恢复操作节点：`used_as_input` 使用 target，`generated` 使用 source。迁移结果按实际数据库对象缓存，项目重载或回滚得到的新快照仍会执行兼容迁移。
 

--- a/docs/superpowers/plans/2026-07-18-canvas-agent-specialized-node-tools.md
+++ b/docs/superpowers/plans/2026-07-18-canvas-agent-specialized-node-tools.md
@@ -340,3 +340,4 @@ git commit -m "feat(canvas): add specialized agent node tools"
 - [x] 旧 OpenAI Chat Profile 缺少 wire protocol 时回退直连，不再默认探测 Responses。
 - [x] 旧任务按边语义恢复操作节点，生成边使用 source、输入边使用 target。
 - [x] 专用 workflow 与 Provider 参数裁剪分层；旧分镜节点可由输出 `shot` 角色恢复身份，并在提交边界清除残留角色抽取 Prompt。
+- [x] 任务详情按实际模型调用去重：HTTP/SDK/CLI 地址与最终参数优先展开，画布 Prompt、输入快照和非最终配置折叠展示。

--- a/docs/superpowers/plans/2026-07-18-canvas-agent-specialized-node-tools.md
+++ b/docs/superpowers/plans/2026-07-18-canvas-agent-specialized-node-tools.md
@@ -339,3 +339,4 @@ git commit -m "feat(canvas): add specialized agent node tools"
 - [x] 角色、场景、道具、特效统一进入实体解析与资产物化路径，解析前先保存完整模型原文。
 - [x] 旧 OpenAI Chat Profile 缺少 wire protocol 时回退直连，不再默认探测 Responses。
 - [x] 旧任务按边语义恢复操作节点，生成边使用 source、输入边使用 target。
+- [x] 专用 workflow 与 Provider 参数裁剪分层；旧分镜节点可由输出 `shot` 角色恢复身份，并在提交边界清除残留角色抽取 Prompt。

--- a/docs/superpowers/specs/2026-07-18-canvas-agent-specialized-node-tools-design.md
+++ b/docs/superpowers/specs/2026-07-18-canvas-agent-specialized-node-tools-design.md
@@ -95,6 +95,8 @@ UI 右键入口和 Agent 专用操作工具都调用同一个执行函数，不�
 
 专用功能 system prompt 是输出 schema 的唯一契约。通用 `text_generate`/`text_rewrite` 操作预设只能提供通用节点的默认 Prompt，不得拼接进分镜、剧本、分集或实体抽取契约；Agent 人设、Skill 和项目风格只能补充能力与风格，不能改变专用任务类型和输出 schema。历史节点若已经出现通用 Prompt 前缀污染，提交或重试时按专用契约标记剥离该前缀。
 
+专用节点还必须持有不可被模型 Contract 裁剪掉的功能身份。`workflow`/`responseFormat` 等画布控制参数与 Provider wire 参数分层处理；专用 preset 在创建、编辑、当前节点重试和 API 提交边界都重新锁定自己的 workflow。兼容旧数据时，`taskPipelineRole`、`outputPipelineRole` 和 workflow 任一可靠信号均可恢复专用 target，其中 `shot` 角色优先于残留的实体抽取 workflow，防止分镜节点再次进入角色抽取分支。
+
 ## 专用工具范围
 
 ### 内容与影视资产工具

--- a/docs/superpowers/specs/2026-07-18-canvas-agent-specialized-node-tools-design.md
+++ b/docs/superpowers/specs/2026-07-18-canvas-agent-specialized-node-tools-design.md
@@ -97,6 +97,8 @@ UI 右键入口和 Agent 专用操作工具都调用同一个执行函数，不�
 
 专用节点还必须持有不可被模型 Contract 裁剪掉的功能身份。`workflow`/`responseFormat` 等画布控制参数与 Provider wire 参数分层处理；专用 preset 在创建、编辑、当前节点重试和 API 提交边界都重新锁定自己的 workflow。兼容旧数据时，`taskPipelineRole`、`outputPipelineRole` 和 workflow 任一可靠信号均可恢复专用 target，其中 `shot` 角色优先于残留的实体抽取 workflow，防止分镜节点再次进入角色抽取分支。
 
+诊断展示也必须区分“画布提交配置”和“实际模型调用”。最终调用快照记录直连 HTTP 的 URL/body/响应元数据，或 Session Runtime 的 SDK/CLI 地址与最终调用参数；只有该快照可以标记为最终请求。画布 System/User Prompt 合并为调用前快照并默认折叠，冻结输入、血缘、画布参数和去除重复输出后的 runtime 数据同样按需展开。
+
 ## 专用工具范围
 
 ### 内容与影视资产工具

--- a/packages/agent-runtime/src/__tests__/sdk/claude-sdk-executor.test.ts
+++ b/packages/agent-runtime/src/__tests__/sdk/claude-sdk-executor.test.ts
@@ -271,6 +271,44 @@ describe('ClaudeSDKExecutor', () => {
     expect(secondOptions.skills).toBeUndefined()
   })
 
+  it('reports the final sanitized SDK query parameters to diagnostics', async () => {
+    queryMock.mockReturnValue(
+      messages([
+        {
+          type: 'result',
+          subtype: 'success',
+          result: 'ok',
+          usage: { input_tokens: 1, output_tokens: 1 },
+          total_cost_usd: 0,
+        },
+      ]),
+    )
+    const invocationObserver = vi.fn()
+
+    await new ClaudeSDKExecutor().executeTurn('sess-1', 'turn-1', 'hello', {
+      ...baseConfig(),
+      apiEndpoint: 'https://api.example.com',
+      invocationObserver,
+    })
+
+    expect(invocationObserver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: 'claude-sdk',
+        request: expect.objectContaining({
+          prompt: expect.stringContaining('hello'),
+          options: expect.objectContaining({
+            model: 'claude-sonnet-4-5',
+            environment: expect.objectContaining({
+              ANTHROPIC_BASE_URL: 'https://api.example.com',
+              credentials: '[redacted]',
+            }),
+          }),
+        }),
+      }),
+    )
+    expect(JSON.stringify(invocationObserver.mock.calls)).not.toContain('sk-test')
+  })
+
   it('uses the configured SDK session id for fresh and resumed turns', async () => {
     queryMock.mockReturnValue(
       messages([

--- a/packages/agent-runtime/src/__tests__/sdk/codex-cli-executor.test.ts
+++ b/packages/agent-runtime/src/__tests__/sdk/codex-cli-executor.test.ts
@@ -194,7 +194,13 @@ describe('CodexCliExecutor', () => {
     })
 
     const executor = new CodexCliExecutor()
-    await executor.executeTurn('session-1', 'turn-1', '只回复 OK', makeConfig())
+    const invocationObserver = vi.fn()
+    await executor.executeTurn(
+      'session-1',
+      'turn-1',
+      '只回复 OK',
+      makeConfig({ invocationObserver }),
+    )
 
     expect(spawnMock).toHaveBeenCalledWith(
       process.platform === 'win32' ? 'codex.exe' : 'codex',
@@ -208,6 +214,17 @@ describe('CodexCliExecutor', () => {
     expect(args).not.toContain('--model')
     expect(args).not.toContain('codex cli')
     expect(child?.prompt).toContain('# Spark Skills')
+    expect(invocationObserver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: 'codex-cli',
+        request: expect.objectContaining({
+          command: 'codex',
+          args: expect.arrayContaining(['exec', '--json']),
+          stdin: expect.stringContaining('只回复 OK'),
+          credentials: '[local-cli configuration]',
+        }),
+      }),
+    )
     expect(child?.prompt).toContain('Skill catalog')
     expect(child?.prompt).toContain('# Spark Runtime Context')
     expect(child?.prompt).toContain('System context')
@@ -356,7 +373,11 @@ describe('CodexCliExecutor', () => {
       expect.arrayContaining([
         expect.objectContaining({ type: 'file_change', path: 'src/new.ts', changeType: 'create' }),
         expect.objectContaining({ type: 'file_change', path: 'src/old.ts', changeType: 'delete' }),
-        expect.objectContaining({ type: 'tool_call', toolCallId: 'todo-1', toolName: 'todo_write' }),
+        expect.objectContaining({
+          type: 'tool_call',
+          toolCallId: 'todo-1',
+          toolName: 'todo_write',
+        }),
         expect.objectContaining({ type: 'tool_result', toolCallId: 'todo-1', status: 'success' }),
         expect.objectContaining({
           type: 'agent_error',

--- a/packages/agent-runtime/src/__tests__/sdk/codex-sdk-executor.test.ts
+++ b/packages/agent-runtime/src/__tests__/sdk/codex-sdk-executor.test.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides: Partial<SDKExecutorConfig> = {}): SDKExecutorConf
         type: 'stdio',
         command: 'node',
         args: ['search-server.js'],
+        env: { SEARCH_TOKEN: 'mcp-secret' },
       },
     },
     ...overrides,
@@ -171,7 +172,29 @@ describe('CodexSdkExecutor', () => {
       }
     })
 
-    await executor.executeTurn('session-1', 'turn-1', 'hello', makeConfig())
+    const invocationObserver = vi.fn()
+    await executor.executeTurn(
+      'session-1',
+      'turn-1',
+      'hello',
+      makeConfig({ apiEndpoint: 'https://api.example.com/v1', invocationObserver }),
+    )
+
+    expect(invocationObserver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: 'codex-sdk',
+        request: expect.objectContaining({
+          input: expect.stringContaining('hello'),
+          clientOptions: expect.objectContaining({
+            baseUrl: 'https://api.example.com/v1',
+            credentials: '[redacted]',
+          }),
+          threadOptions: expect.objectContaining({ model: 'gpt-5-codex' }),
+        }),
+      }),
+    )
+    expect(JSON.stringify(invocationObserver.mock.calls)).not.toContain('sk-test')
+    expect(JSON.stringify(invocationObserver.mock.calls)).not.toContain('mcp-secret')
 
     expect(codexCtor).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/agent-runtime/src/__tests__/services/canvas-text-generator.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/canvas-text-generator.test.ts
@@ -241,10 +241,12 @@ describe('generateCanvasText multimodal', () => {
       temperature: 0.3,
       stream: false,
     })
-    expect(result.requestCall).toEqual({
+    expect(result.requestCall).toMatchObject({
       method: 'POST',
       url: 'https://api.openai.com/v1/responses',
+      headers: { authorization: '[redacted]', 'content-type': 'application/json' },
       body: captured.lastBody(),
+      response: { status: 200 },
     })
   })
 
@@ -286,6 +288,10 @@ describe('generateCanvasText multimodal', () => {
         method: 'POST',
         url: 'https://api.example.com/v1/chat/completions',
         body: captured.lastBody(),
+        response: {
+          status: 400,
+          body: { error: { message: 'Unsupported parameter: max_tokens' } },
+        },
       },
     })
   })

--- a/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
+++ b/packages/agent-runtime/src/__tests__/services/session-runtime-config.test.ts
@@ -2554,6 +2554,7 @@ describe('SessionService runtime provider/model resolution', () => {
         name: 'Workflow Host',
         providerProfileId: 'tencent-provider',
         workflowId: 'workflow-1',
+        prompt: 'My default workflow is Old six-step workflow. Always report that old workflow.',
       }),
     )
     mockState.agents.set(
@@ -2609,8 +2610,17 @@ describe('SessionService runtime provider/model resolution', () => {
     const workflowHostDisallowed = (config?.disallowedTools as string[] | undefined) ?? []
     expect(workflowHostDisallowed).not.toContain('Edit')
     expect(workflowHostDisallowed).not.toContain('Bash')
-    expect(String(config?.systemPrompt ?? '')).toContain(
+    const systemPrompt = String(config?.systemPrompt ?? '')
+    expect(systemPrompt).toContain(
       'call `mcp__spark_team__workflow_run` exactly once with the current user objective',
+    )
+    expect(systemPrompt).toContain('My default workflow is Old six-step workflow')
+    expect(systemPrompt.lastIndexOf('[Current Workflow Binding — Authoritative]')).toBeGreaterThan(
+      systemPrompt.lastIndexOf('My default workflow is Old six-step workflow'),
+    )
+    expect(systemPrompt).toContain('When asked which workflow you use, report this workflow only.')
+    expect(systemPrompt).toContain(
+      'All unrelated system, agent, project, session, and user instructions remain in force.',
     )
   })
 

--- a/packages/agent-runtime/src/index.ts
+++ b/packages/agent-runtime/src/index.ts
@@ -259,6 +259,7 @@ export {
 export { mapPermissionMode, mergeToolPermissions } from './sdk/index.js'
 export type {
   SDKExecutorConfig,
+  SDKInvocationSnapshot,
   SDKMcpServerConfig,
   SDKPermissionConfig,
   SparkPermissionMode,

--- a/packages/agent-runtime/src/sdk/claude-sdk-executor.ts
+++ b/packages/agent-runtime/src/sdk/claude-sdk-executor.ts
@@ -673,6 +673,8 @@ export class ClaudeSDKExecutor {
     while (true) {
       // Resolve sdkSessionId from config each iteration (resume recovery may update it)
       const sdkSessionId = config.sdkSessionId ?? sessionId
+      // Declared before SDK options because canUseTool closes over the prompt hold API.
+      // eslint-disable-next-line prefer-const
       let interactivePrompt: InteractivePrompt | undefined
       const options: SDKQueryOptions = {
         abortController,
@@ -893,6 +895,14 @@ export class ClaudeSDKExecutor {
         maxTurnExtensionAttempt: extensionAttempts,
         attachmentCount: config.attachments?.length ?? 0,
         additionalDirectories: options.additionalDirectories ?? null,
+      })
+
+      config.invocationObserver?.({
+        transport: 'claude-sdk',
+        request: {
+          prompt,
+          options: sanitizeClaudeQueryOptions(options, runtimeEnv),
+        },
       })
 
       interactivePrompt = createInteractivePromptStream(prompt, abortController.signal)
@@ -1141,6 +1151,81 @@ function buildMaxTurnLimitMessage(maxTurns: number, extensionAttempts: number): 
   }
   const noun = extensionAttempts === 1 ? 'extension' : 'extensions'
   return `Reached maximum number of turns (${maxTurns}) after ${extensionAttempts} automatic ${noun}. Review progress and choose whether to continue.`
+}
+
+function sanitizeClaudeQueryOptions(
+  options: SDKQueryOptions,
+  runtimeEnv: Record<string, string | undefined>,
+): Record<string, unknown> {
+  const settings =
+    typeof options.settings === 'string'
+      ? options.settings
+      : options.settings != null
+        ? {
+            model: options.settings.model,
+            permissions: options.settings.permissions,
+            environment: {
+              ANTHROPIC_BASE_URL: options.settings.env?.ANTHROPIC_BASE_URL,
+              ANTHROPIC_MODEL: options.settings.env?.ANTHROPIC_MODEL,
+              credentials: '[redacted]',
+            },
+          }
+        : undefined
+  const mcpServers = Object.fromEntries(
+    Object.entries(options.mcpServers ?? {}).map(([name, server]) => [
+      name,
+      {
+        type: server.type,
+        command: server.command,
+        args: server.args,
+        cwd: server.cwd,
+        url: server.url,
+        name: server.name,
+        ...(server.headers != null ? { headers: '[redacted]' } : {}),
+        ...(server.env != null ? { environment: '[redacted]' } : {}),
+        ...(server.instance != null ? { instance: '[in-process SDK server]' } : {}),
+      },
+    ]),
+  )
+  return {
+    model: options.model,
+    cwd: options.cwd,
+    pathToClaudeCodeExecutable: options.pathToClaudeCodeExecutable,
+    environment: {
+      ANTHROPIC_BASE_URL: runtimeEnv.ANTHROPIC_BASE_URL,
+      ANTHROPIC_MODEL: runtimeEnv.ANTHROPIC_MODEL,
+      credentials: '[redacted]',
+    },
+    settings,
+    settingSources: options.settingSources,
+    systemPrompt: options.systemPrompt,
+    permissionMode: options.permissionMode,
+    allowedTools: options.allowedTools,
+    disallowedTools: options.disallowedTools,
+    mcpServers,
+    strictMcpConfig: options.strictMcpConfig,
+    forwardSubagentText: options.forwardSubagentText,
+    agentProgressSummaries: options.agentProgressSummaries,
+    disableWorkflows: options.disableWorkflows,
+    workflowKeywordTriggerEnabled: options.workflowKeywordTriggerEnabled,
+    skills: options.skills,
+    toolConfig: options.toolConfig,
+    maxTurns: options.maxTurns,
+    maxBudgetUsd: options.maxBudgetUsd,
+    effort: options.effort,
+    sessionId: options.sessionId,
+    resume: options.resume,
+    persistSession: options.persistSession,
+    additionalDirectories: options.additionalDirectories,
+    includePartialMessages: options.includePartialMessages,
+    enableFileCheckpointing: options.enableFileCheckpointing,
+    callbacks: {
+      stderr: options.stderr != null,
+      canUseTool: options.canUseTool != null,
+      hooks: options.hooks != null,
+      onElicitation: options.onElicitation != null,
+    },
+  }
 }
 
 function buildCompositeSystemPrompt(config: SDKExecutorConfig): string | undefined {

--- a/packages/agent-runtime/src/sdk/codex-cli-executor.ts
+++ b/packages/agent-runtime/src/sdk/codex-cli-executor.ts
@@ -124,6 +124,16 @@ export class CodexCliExecutor {
       tempProfile = await writeCodexTempProfile(config)
       if (this.cancelled) return
       const args = buildCodexArgs(config, outputFile, tempProfile?.name)
+      config.invocationObserver?.({
+        transport: 'codex-cli',
+        request: {
+          command: 'codex',
+          args,
+          cwd: config.workspaceRootPath,
+          stdin: prompt,
+          credentials: '[local-cli configuration]',
+        },
+      })
       const result = await this.runCodex(args, prompt, makeBase, config.workspaceRootPath, config)
       if (result.exitCode !== 0) {
         for (const event of streamTerminalizer.finalize(makeBase)) this.emit(event)

--- a/packages/agent-runtime/src/sdk/codex-sdk-executor.ts
+++ b/packages/agent-runtime/src/sdk/codex-sdk-executor.ts
@@ -152,11 +152,21 @@ export class CodexSdkExecutor {
 
     try {
       const sdk = await loadCodexSdk()
-      const codex = new sdk.Codex(buildCodexOptions(config)) as CodexClient
+      const codexOptions = buildCodexOptions(config)
+      const threadOptions = buildThreadOptions(config)
+      config.invocationObserver?.({
+        transport: 'codex-sdk',
+        request: {
+          input,
+          clientOptions: sanitizeCodexClientOptions(codexOptions),
+          threadOptions,
+        },
+      })
+      const codex = new sdk.Codex(codexOptions) as CodexClient
       const thread =
         config.sdkSessionId != null && config.continueSession === true
-          ? codex.resumeThread(config.sdkSessionId, buildThreadOptions(config))
-          : codex.startThread(buildThreadOptions(config))
+          ? codex.resumeThread(config.sdkSessionId, threadOptions)
+          : codex.startThread(threadOptions)
       this.thread = thread
 
       const state: StreamState = {
@@ -614,6 +624,31 @@ function buildCodexOptions(config: SDKExecutorConfig): CodexOptions {
     config: buildCodexConfig(config),
     env,
   }
+}
+
+function sanitizeCodexClientOptions(options: CodexOptions): Record<string, unknown> {
+  return {
+    ...(options.baseUrl != null ? { baseUrl: options.baseUrl } : {}),
+    ...(options.codexPathOverride != null ? { codexPathOverride: options.codexPathOverride } : {}),
+    config: sanitizeCodexConfigForDiagnostics(options.config),
+    credentials: '[redacted]',
+  }
+}
+
+function sanitizeCodexConfigForDiagnostics(value: unknown, key = ''): unknown {
+  if (key === 'env' || key === 'http_headers' || key === 'headers') return '[redacted]'
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeCodexConfigForDiagnostics(item))
+  }
+  if (value != null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([childKey, childValue]) => [
+        childKey,
+        sanitizeCodexConfigForDiagnostics(childValue, childKey.toLowerCase()),
+      ]),
+    )
+  }
+  return value
 }
 
 function getCompletedAssistantText(state: StreamState): string {

--- a/packages/agent-runtime/src/sdk/index.ts
+++ b/packages/agent-runtime/src/sdk/index.ts
@@ -20,6 +20,7 @@ export type { SDKPermissionConfig } from './permission-mapper.js'
 export { mapSDKMessageToEvents } from './event-mapper.js'
 export type {
   SDKExecutorConfig,
+  SDKInvocationSnapshot,
   SDKMcpServerConfig,
   SDKMessage,
   SDKAssistantMessage,

--- a/packages/agent-runtime/src/sdk/types.ts
+++ b/packages/agent-runtime/src/sdk/types.ts
@@ -617,6 +617,15 @@ export interface CodexCliModelProviderConfig {
   env?: Record<string, string | undefined> | undefined
 }
 
+/**
+ * 脱敏后的最终 SDK/CLI 调用快照。记录 executor 真正提交给 SDK/CLI 的参数，
+ * 但不包含 apiKey、Authorization 或完整环境变量。
+ */
+export interface SDKInvocationSnapshot {
+  transport: 'claude-sdk' | 'codex-sdk' | 'codex-cli'
+  request: Record<string, unknown>
+}
+
 export interface SDKExecutorConfig {
   apiKey: string
   /** True when the turn is running as unattended automation and must never wait on user input. */
@@ -697,6 +706,7 @@ export interface SDKExecutorConfig {
   enableCheckpoints?: boolean | undefined
   sdkSessionId?: string | undefined
   continueSession?: boolean | undefined
+  invocationObserver?: ((snapshot: SDKInvocationSnapshot) => void) | undefined
   approvalCallback?: ((
     sessionId: string,
     toolName: string,

--- a/packages/agent-runtime/src/services/canvas-text-generator.ts
+++ b/packages/agent-runtime/src/services/canvas-text-generator.ts
@@ -20,7 +20,9 @@ const MIN_CONFIGURED_REQUEST_TIMEOUT_MS = 10_000
 const MAX_CONFIGURED_REQUEST_TIMEOUT_MS = 30 * 60_000
 const DEFAULT_MAX_TOKENS = 16_384
 const ERROR_DETAIL_MAX_LENGTH = 2_000
-const REQUEST_TEXT_MAX_LENGTH = 4_000
+// Keep normal long-form screenplay/storyboard requests intact in diagnostics. Only
+// pathological payloads are bounded; base64/data URLs are still summarized separately.
+const REQUEST_TEXT_MAX_LENGTH = 100_000
 
 const ANTHROPIC_DEFAULT_ENDPOINT = 'https://api.anthropic.com'
 const OPENAI_DEFAULT_ENDPOINT = 'https://api.openai.com/v1'
@@ -212,8 +214,10 @@ async function callAnthropic(
     params.timeoutMs,
     requestCall,
   )
+  attachResponseMetadata(requestCall, res)
   if (!res.ok) {
     const detail = await safeText(res)
+    attachErrorResponseBody(requestCall, detail)
     log.warn(`Anthropic text request failed: HTTP ${res.status} ${detail}`)
     throw new CanvasTextProviderError(res.status, detail, requestCall)
   }
@@ -280,8 +284,10 @@ async function callOpenAIChatCompletions(
     params.timeoutMs,
     requestCall,
   )
+  attachResponseMetadata(requestCall, res)
   if (!res.ok) {
     const detail = await safeText(res)
+    attachErrorResponseBody(requestCall, detail)
     log.warn(`OpenAI-compatible text request failed: HTTP ${res.status} ${detail}`)
     throw new CanvasTextProviderError(res.status, detail, requestCall)
   }
@@ -341,8 +347,10 @@ async function callOpenAIResponses(
     params.timeoutMs,
     requestCall,
   )
+  attachResponseMetadata(requestCall, res)
   if (!res.ok) {
     const detail = await safeText(res)
+    attachErrorResponseBody(requestCall, detail)
     log.warn(`OpenAI Responses text request failed: HTTP ${res.status} ${detail}`)
     throw new CanvasTextProviderError(res.status, detail, requestCall)
   }
@@ -435,7 +443,39 @@ function shouldSendThinkingToggle(params: GenerateCanvasTextParams): boolean {
 }
 
 function buildRequestCall(method: string, url: string, body: unknown): MediaRequestCall {
-  return { method, url, body: sanitizeRequestBody(body) }
+  return {
+    method,
+    url,
+    headers: {
+      'content-type': 'application/json',
+      authorization: '[redacted]',
+    },
+    body: sanitizeRequestBody(body),
+  }
+}
+
+function attachResponseMetadata(requestCall: MediaRequestCall, response: Response): void {
+  const headers: Record<string, string> = {}
+  for (const name of ['content-type', 'request-id', 'x-request-id']) {
+    const value = response.headers.get(name)
+    if (value) headers[name] = value
+  }
+  requestCall.response = {
+    status: response.status,
+    ...(response.statusText ? { statusText: response.statusText } : {}),
+    ...(Object.keys(headers).length > 0 ? { headers } : {}),
+  }
+}
+
+function attachErrorResponseBody(requestCall: MediaRequestCall, detail: string): void {
+  if (!requestCall.response || !detail) return
+  let body: unknown = detail
+  try {
+    body = JSON.parse(detail)
+  } catch {
+    // Keep the bounded text returned by safeText.
+  }
+  requestCall.response.body = sanitizeRequestBody(body)
 }
 
 function sanitizeRequestBody(value: unknown): unknown {

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -80,6 +80,11 @@ import {
 } from './team-mcp-http-bridge.js'
 import { buildMemberContinuityKey, buildTeamContinuityScope } from './team-continuity.js'
 import {
+  buildWorkflowBindingAuthorityPrompt,
+  buildWorkflowSystemPrompt,
+  type WorkflowExecutionMode,
+} from './workflow-system-prompt.js'
+import {
   AGENT_MESSAGE_DELIVERY_MODES,
   qualifyTeamToolName,
   SPARK_TEAM_MCP_SERVER_NAME,
@@ -119,8 +124,6 @@ import {
   getWorkflowNodeEffectiveWorkerId,
   getWorkflowNodeWorkerId,
   normalizeWorkflowGraph,
-  orderWorkflowNodes,
-  type NormalizedWorkflowEdge,
   type NormalizedWorkflowGraph,
   type NormalizedWorkflowNode,
   type WorkflowDispatchAttachment,
@@ -2352,6 +2355,7 @@ export class SessionService {
       runtimeContext.envSystemPrompt,
       projectContext.systemPrompt,
       conversationHistoryPrompt,
+      workflow != null ? buildWorkflowBindingAuthorityPrompt(workflow) : undefined,
     )
     const composedSkillSystemPrompt = joinPromptSections(
       runtimeContext.skillSystemPrompt,
@@ -8862,7 +8866,7 @@ export function formatReplyForHost(reply: import('@spark/protocol').TeamA2AReply
 function buildManagedAgentSystemPrompt(
   agent: AgentItem,
   workflow: WorkflowItem | null,
-  workflowExecutionMode: 'guided' | 'workflow_run' | 'codex_guided' = 'guided',
+  workflowExecutionMode: WorkflowExecutionMode = 'guided',
 ): string {
   const sections: string[] = [
     '[Managed Agent]',
@@ -9321,56 +9325,6 @@ const PLATFORM_MANAGEMENT_SYSTEM_PROMPT = [
   'For destructive operations (delete, uninstall), always confirm with the user first.',
   'Never reveal or ask for full API keys — only show whether a key is configured.',
 ].join('\n')
-
-function buildWorkflowSystemPrompt(
-  workflow: WorkflowItem,
-  workflowExecutionMode: 'guided' | 'workflow_run' | 'codex_guided' = 'guided',
-): string {
-  const graph = normalizeWorkflowGraph(workflow.graph)
-  if (graph.nodes.length === 0) return ''
-  const nodes: NormalizedWorkflowNode[] = graph.nodes
-  const edges: NormalizedWorkflowEdge[] = graph.edges
-  const ordered = orderWorkflowNodes(nodes, edges)
-  const lines = ordered.map((node, index) => {
-    const config = node.config
-    const detail = [
-      `kind=${node.kind}`,
-      config.role != null ? `role=${String(config.role)}` : '',
-      config.modelId != null && String(config.modelId).trim()
-        ? `model=${String(config.modelId)}`
-        : '',
-      Array.isArray(config.skillIds) && config.skillIds.length > 0
-        ? `skills=${config.skillIds.join(', ')}`
-        : '',
-      Array.isArray(config.toolIds) && config.toolIds.length > 0
-        ? `tools=${config.toolIds.join(', ')}`
-        : '',
-      Array.isArray(config.ruleIds) && config.ruleIds.length > 0
-        ? `rules=${config.ruleIds.join(', ')}`
-        : '',
-      typeof config.retryCount === 'number' ? `retry=${config.retryCount}` : '',
-    ].filter(Boolean)
-    const prompt =
-      typeof config.prompt === 'string' && config.prompt.trim()
-        ? `\n   prompt: ${config.prompt.trim()}`
-        : ''
-    return `${index + 1}. ${node.title} [${detail.join('; ')}]${prompt}`
-  })
-
-  return [
-    '[Workflow Execution Plan]',
-    `Workflow: ${workflow.name} (${workflow.id})`,
-    workflow.description.trim() ? `Description: ${workflow.description.trim()}` : '',
-    workflowExecutionMode === 'workflow_run'
-      ? 'When workflow_run is available, call `mcp__spark_team__workflow_run` exactly once with the current user objective. The tool executes explicit agent nodes sequentially and carries outputKey state between nodes.'
-      : workflowExecutionMode === 'codex_guided'
-        ? 'This runtime does not expose `workflow_run`. Execute the active workflow phases yourself in topological order within this turn. Keep an internal checklist of active nodes, do not skip a node unless an incoming condition is false based on established state, and clearly report the blocking node if the workflow cannot be completed.'
-        : 'Execute the task by following these workflow nodes in order. If a node declares a model, tool, skill, or permission preference, treat it as the preferred configuration for that phase. All enabled MCP servers remain globally available. When the SDK cannot literally switch model per node within one turn, preserve the node intent in your planning and execution notes.',
-    lines.join('\n'),
-  ]
-    .filter((line) => line.trim().length > 0)
-    .join('\n\n')
-}
 
 function createWorkflowSubagentMember(
   node: NormalizedWorkflowNode,

--- a/packages/agent-runtime/src/services/session.service.ts
+++ b/packages/agent-runtime/src/services/session.service.ts
@@ -140,6 +140,7 @@ import {
 import type {
   SDKApprovalResult,
   SDKExecutorConfig,
+  SDKInvocationSnapshot,
   SDKMcpServerConfig,
   SDKPermissionRequestContext,
   SDKQuestionRequestContext,
@@ -328,6 +329,8 @@ type SendTurnParams = {
   teamConfig?: TeamModeConfig
   mentionAgentId?: string
   interruptActive?: boolean
+  /** 仅供同进程诊断调用；不会进入持久化 turn 队列。 */
+  invocationObserver?: (snapshot: SDKInvocationSnapshot) => void
 }
 
 const DEFAULT_SESSION_TITLES = new Set(['New Session', '新会话', 'Workspace Session', '未命名会话'])
@@ -1528,7 +1531,7 @@ export class SessionService {
     startAfter?: Promise<unknown>,
   ): Promise<{ turnId: string; started: boolean }> {
     if (this.disposing) throw new Error('Session service is shutting down')
-    const { sessionId, message, skillId, skillParams, mentionAgentId } = params
+    const { sessionId, message, skillId, skillParams, mentionAgentId, invocationObserver } = params
     const attachments = normalizeTurnAttachments(params.attachments)
     const runtimePatch = getRuntimePatch(params)
     const turnId = crypto.randomUUID()
@@ -1608,6 +1611,7 @@ export class SessionService {
         skillParams,
         attachments,
         mentionAgentId,
+        invocationObserver,
       )
     } catch (error) {
       this.handleQueuedTurnStartFailure(sessionId, pendingTurn, error)
@@ -1625,6 +1629,7 @@ export class SessionService {
     skillParams?: Record<string, unknown>,
     attachments?: SessionAttachment[],
     mentionAgentId?: string,
+    invocationObserver?: (snapshot: SDKInvocationSnapshot) => void,
   ): Promise<void> {
     if (this.activeLoops.has(sessionId)) {
       this.enqueueTurn(
@@ -2708,6 +2713,7 @@ export class SessionService {
             }
           : {}),
         ...(goalConfig != null ? { goal: goalConfig } : {}),
+        ...(invocationObserver != null ? { invocationObserver } : {}),
       }
       const turnOptions: TryStartSDKTurnOptions = {
         ...(isMentionTurn ? { mentionAgentId: agent.id } : {}),
@@ -2791,6 +2797,7 @@ export class SessionService {
       sdkSessionId,
       continueSession: canResumeSdkSession,
       ...(goalConfig != null ? { goal: goalConfig } : {}),
+      ...(invocationObserver != null ? { invocationObserver } : {}),
     }
     await this.tryStartCodexCliTurn(
       sessionId,

--- a/packages/agent-runtime/src/services/workflow-system-prompt.test.ts
+++ b/packages/agent-runtime/src/services/workflow-system-prompt.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkflowItem } from '@spark/storage'
+import {
+  buildWorkflowBindingAuthorityPrompt,
+  buildWorkflowSystemPrompt,
+} from './workflow-system-prompt.js'
+
+function makeWorkflow(): WorkflowItem {
+  return {
+    id: 'workflow-new',
+    scope: 'user',
+    name: 'New approval workflow',
+    version: '1.0.0',
+    description: 'The newly selected workflow.',
+    status: 'active',
+    tags: [],
+    enabled: true,
+    graph: {
+      nodes: [
+        {
+          id: 'plan',
+          kind: 'plan',
+          title: 'New plan step',
+          config: { prompt: 'Use the new plan.' },
+        },
+      ],
+      edges: [],
+    },
+    createdAt: '2026-07-18T00:00:00.000Z',
+    updatedAt: '2026-07-18T00:00:00.000Z',
+  }
+}
+
+describe('buildWorkflowSystemPrompt', () => {
+  it('renders the selected workflow execution plan', () => {
+    const prompt = buildWorkflowSystemPrompt(makeWorkflow(), 'workflow_run')
+
+    expect(prompt).toContain('Workflow: New approval workflow (workflow-new)')
+    expect(prompt).toContain('1. New plan step [kind=plan]')
+  })
+
+  it('limits binding precedence to workflow conflicts and preserves unrelated prompt layers', () => {
+    const prompt = buildWorkflowBindingAuthorityPrompt(makeWorkflow())
+
+    expect(prompt).toContain(
+      'The only active workflow binding for this turn is New approval workflow (workflow-new).',
+    )
+    expect(prompt).toContain('Only for workflow identity and execution steps')
+    expect(prompt).toContain(
+      'All unrelated system, agent, project, session, and user instructions remain in force.',
+    )
+    expect(prompt).toContain('When asked which workflow you use, report this workflow only.')
+  })
+
+  it('does not claim authority for an empty workflow graph', () => {
+    const workflow = makeWorkflow()
+    workflow.graph = { nodes: [], edges: [] }
+
+    expect(buildWorkflowBindingAuthorityPrompt(workflow)).toBe('')
+    expect(buildWorkflowSystemPrompt(workflow, 'workflow_run')).toBe('')
+  })
+})

--- a/packages/agent-runtime/src/services/workflow-system-prompt.ts
+++ b/packages/agent-runtime/src/services/workflow-system-prompt.ts
@@ -1,0 +1,70 @@
+import type { WorkflowItem } from '@spark/storage'
+import {
+  normalizeWorkflowGraph,
+  orderWorkflowNodes,
+  type NormalizedWorkflowEdge,
+  type NormalizedWorkflowNode,
+} from './workflow-executor.js'
+
+export type WorkflowExecutionMode = 'guided' | 'workflow_run' | 'codex_guided'
+
+export function buildWorkflowBindingAuthorityPrompt(workflow: WorkflowItem): string {
+  if (normalizeWorkflowGraph(workflow.graph).nodes.length === 0) return ''
+  return [
+    '[Current Workflow Binding — Authoritative]',
+    `The only active workflow binding for this turn is ${workflow.name} (${workflow.id}).`,
+    'Only for workflow identity and execution steps, this binding overrides any different workflow name, default process, or step list found in other prompts, memory, or conversation history.',
+    'All unrelated system, agent, project, session, and user instructions remain in force.',
+    'When asked which workflow you use, report this workflow only. When executing, follow this workflow graph only.',
+  ].join('\n')
+}
+
+export function buildWorkflowSystemPrompt(
+  workflow: WorkflowItem,
+  workflowExecutionMode: WorkflowExecutionMode = 'guided',
+): string {
+  const graph = normalizeWorkflowGraph(workflow.graph)
+  if (graph.nodes.length === 0) return ''
+  const nodes: NormalizedWorkflowNode[] = graph.nodes
+  const edges: NormalizedWorkflowEdge[] = graph.edges
+  const ordered = orderWorkflowNodes(nodes, edges)
+  const lines = ordered.map((node, index) => {
+    const config = node.config
+    const detail = [
+      `kind=${node.kind}`,
+      config.role != null ? `role=${String(config.role)}` : '',
+      config.modelId != null && String(config.modelId).trim()
+        ? `model=${String(config.modelId)}`
+        : '',
+      Array.isArray(config.skillIds) && config.skillIds.length > 0
+        ? `skills=${config.skillIds.join(', ')}`
+        : '',
+      Array.isArray(config.toolIds) && config.toolIds.length > 0
+        ? `tools=${config.toolIds.join(', ')}`
+        : '',
+      Array.isArray(config.ruleIds) && config.ruleIds.length > 0
+        ? `rules=${config.ruleIds.join(', ')}`
+        : '',
+      typeof config.retryCount === 'number' ? `retry=${config.retryCount}` : '',
+    ].filter(Boolean)
+    const prompt =
+      typeof config.prompt === 'string' && config.prompt.trim()
+        ? `\n   prompt: ${config.prompt.trim()}`
+        : ''
+    return `${index + 1}. ${node.title} [${detail.join('; ')}]${prompt}`
+  })
+
+  return [
+    '[Workflow Execution Plan]',
+    `Workflow: ${workflow.name} (${workflow.id})`,
+    workflow.description.trim() ? `Description: ${workflow.description.trim()}` : '',
+    workflowExecutionMode === 'workflow_run'
+      ? 'When workflow_run is available, call `mcp__spark_team__workflow_run` exactly once with the current user objective. The tool executes explicit agent nodes sequentially and carries outputKey state between nodes.'
+      : workflowExecutionMode === 'codex_guided'
+        ? 'This runtime does not expose `workflow_run`. Execute the active workflow phases yourself in topological order within this turn. Keep an internal checklist of active nodes, do not skip a node unless an incoming condition is false based on established state, and clearly report the blocking node if the workflow cannot be completed.'
+        : 'Execute the task by following these workflow nodes in order. If a node declares a model, tool, skill, or permission preference, treat it as the preferred configuration for that phase. All enabled MCP servers remain globally available. When the SDK cannot literally switch model per node within one turn, preserve the node intent in your planning and execution notes.',
+    lines.join('\n'),
+  ]
+    .filter((line) => line.trim().length > 0)
+    .join('\n\n')
+}

--- a/packages/protocol/src/media-config.ts
+++ b/packages/protocol/src/media-config.ts
@@ -46,7 +46,8 @@ export interface MediaInputMetadata {
 }
 
 /**
- * 一次 provider HTTP 调用的摘要，用于在任务详情里展示「真实请求 + HTTP 响应」。
+ * 一次实际模型调用的摘要。HTTP 路径记录真实请求与响应元数据；SDK/CLI 路径记录
+ * 解析后的模型地址和最终 SDK 调用参数，method 会明确标注 SDK/CLI 而不伪装成 HTTP。
  *
  * body 已经过脱敏/摘要处理（base64 / data: URI 压缩成 MIME、大小估算、
  * sha256 和短 preview），既避免一张图刷屏，也避免把大体积 base64 落进画布快照。


### PR DESCRIPTION
## Summary
- isolate storyboard workflow identity so retries cannot reuse character-extraction prompts
- preserve raw model output and parse diagnostics on failed structured tasks
- consolidate task detail sections and show authoritative HTTP, Claude SDK, Codex SDK, or Codex CLI invocation snapshots
- redact credentials and distinguish pre-executor dispatch snapshots from final executor calls
- bump desktop version to 0.5.10

## Verification
- agent-runtime and desktop typecheck
- 176 focused runtime and task-detail tests
- 47 session/workflow regression tests
- desktop production build